### PR TITLE
Verifier: Add IBM Secure Execution driver framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
  "env_logger 0.10.2",
  "jsonwebtoken",
  "jwt-simple",
- "kbs-types",
+ "kbs-types 0.6.0",
  "lazy_static",
  "log",
  "mobc",
@@ -537,7 +537,7 @@ dependencies = [
  "env_logger 0.10.2",
  "futures",
  "hex",
- "kbs-types",
+ "kbs-types 0.6.0",
  "lazy_static",
  "log",
  "openssl",
@@ -578,7 +578,7 @@ dependencies = [
  "csv-rs",
  "hyper",
  "hyper-tls",
- "kbs-types",
+ "kbs-types 0.5.3",
  "log",
  "nix",
  "occlum_dcap",
@@ -1299,7 +1299,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "ctr",
- "kbs-types",
+ "kbs-types 0.5.3",
  "rand",
  "rsa 0.9.6",
  "serde",
@@ -1367,6 +1367,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "curl"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2161dd6eba090ff1594084e95fd67aeccf04382ffea77999ea94ed42ec67b6"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.72+curl-8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29cbdc8314c447d11e8fd156dcdd031d9e02a7a976163e396b548c03153bc9ea"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2493,6 +2523,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kbs-types"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "febd73b2b1df274ea454d81ddf76f596af9754410b7ed6f988f2e1782a175da3"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kbs_protocol"
 version = "0.1.0"
 source = "git+https://github.com/confidential-containers/guest-components.git?rev=5ae8d8ed136aef6303dc9802df04d19b86e1e70d#5ae8d8ed136aef6303dc9802df04d19b86e1e70d"
@@ -2503,7 +2543,7 @@ dependencies = [
  "base64 0.21.7",
  "crypto",
  "jwt-simple",
- "kbs-types",
+ "kbs-types 0.5.3",
  "log",
  "reqwest",
  "resource_uri",
@@ -4066,6 +4106,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
+name = "s390_pv"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f75b3a6c5bb5b3e8e4fdced5e8b406fcfaf909a96975c4010e839799bf25f48"
+dependencies = [
+ "byteorder",
+ "curl",
+ "foreign-types",
+ "log",
+ "openssl",
+ "openssl-sys",
+ "s390_pv_core",
+ "serde",
+ "thiserror",
+ "zerocopy",
+]
+
+[[package]]
+name = "s390_pv_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dacc93d1903ab065f327d8c71745a9a48f4e812dd6707cec62538d5a84654627"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "serde",
+ "thiserror",
+ "zerocopy",
+]
+
+[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5365,13 +5437,15 @@ dependencies = [
  "intel-tee-quote-verification-rs",
  "jsonwebkey",
  "jsonwebtoken",
- "kbs-types",
+ "kbs-types 0.6.0",
  "log",
  "openssl",
  "rstest",
+ "s390_pv",
  "scroll 0.11.0",
  "serde",
  "serde_json",
+ "serde_with",
  "serial_test",
  "sev",
  "shadow-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4387,6 +4387,7 @@ checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "base64 0.13.1",
  "chrono",
+ "hex",
  "serde",
  "serde_with_macros",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
  "env_logger 0.10.2",
  "jsonwebtoken",
  "jwt-simple",
- "kbs-types 0.6.0",
+ "kbs-types",
  "lazy_static",
  "log",
  "mobc",
@@ -537,7 +537,7 @@ dependencies = [
  "env_logger 0.10.2",
  "futures",
  "hex",
- "kbs-types 0.6.0",
+ "kbs-types",
  "lazy_static",
  "log",
  "openssl",
@@ -567,7 +567,7 @@ dependencies = [
 [[package]]
 name = "attester"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5ae8d8ed136aef6303dc9802df04d19b86e1e70d#5ae8d8ed136aef6303dc9802df04d19b86e1e70d"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=c543f208211aedd5fbecc5ddddf4c3200d0bbc00#c543f208211aedd5fbecc5ddddf4c3200d0bbc00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -578,13 +578,15 @@ dependencies = [
  "csv-rs",
  "hyper",
  "hyper-tls",
- "kbs-types 0.5.3",
+ "kbs-types",
  "log",
  "nix",
  "occlum_dcap",
+ "s390_pv",
  "scroll 0.12.0",
  "serde",
  "serde_json",
+ "serde_with",
  "sev",
  "sha2",
  "strum",
@@ -1293,13 +1295,13 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5ae8d8ed136aef6303dc9802df04d19b86e1e70d#5ae8d8ed136aef6303dc9802df04d19b86e1e70d"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=c543f208211aedd5fbecc5ddddf4c3200d0bbc00#c543f208211aedd5fbecc5ddddf4c3200d0bbc00"
 dependencies = [
  "aes-gcm",
  "anyhow",
  "base64 0.21.7",
  "ctr",
- "kbs-types 0.5.3",
+ "kbs-types",
  "rand",
  "rsa 0.9.6",
  "serde",
@@ -2514,16 +2516,6 @@ dependencies = [
 
 [[package]]
 name = "kbs-types"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f4b0642769e12f56cfc646d8be13668ed48d3caed0e99efb161c407f3ec532"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "kbs-types"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "febd73b2b1df274ea454d81ddf76f596af9754410b7ed6f988f2e1782a175da3"
@@ -2535,7 +2527,7 @@ dependencies = [
 [[package]]
 name = "kbs_protocol"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5ae8d8ed136aef6303dc9802df04d19b86e1e70d#5ae8d8ed136aef6303dc9802df04d19b86e1e70d"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=c543f208211aedd5fbecc5ddddf4c3200d0bbc00#c543f208211aedd5fbecc5ddddf4c3200d0bbc00"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2543,7 +2535,7 @@ dependencies = [
  "base64 0.21.7",
  "crypto",
  "jwt-simple",
- "kbs-types 0.5.3",
+ "kbs-types",
  "log",
  "reqwest",
  "resource_uri",
@@ -3836,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "resource_uri"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5ae8d8ed136aef6303dc9802df04d19b86e1e70d#5ae8d8ed136aef6303dc9802df04d19b86e1e70d"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=c543f208211aedd5fbecc5ddddf4c3200d0bbc00#c543f208211aedd5fbecc5ddddf4c3200d0bbc00"
 dependencies = [
  "anyhow",
  "serde",
@@ -5438,7 +5430,7 @@ dependencies = [
  "intel-tee-quote-verification-rs",
  "jsonwebkey",
  "jsonwebtoken",
- "kbs-types 0.6.0",
+ "kbs-types",
  "log",
  "openssl",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ regorus = { version = "0.1.5", default-features = false, features = ["regex", "b
 rstest = "0.18.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.89"
-serde_with = { version = "1.11.0", features = ["base64"] }
+serde_with = { version = "1.11.0", features = ["base64", "hex"] }
 serial_test = "0.9.0"
 sha2 = "0.10"
 shadow-rs = "0.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ clap = { version = "4", features = ["derive"] }
 config = "0.13.3"
 env_logger = "0.10.0"
 hex = "0.4.3"
-kbs-types = "0.5.3"
+kbs-types = "0.6.0"
 jsonwebtoken = { version = "9", default-features = false }
 log = "0.4.17"
 prost = "0.11.0"
@@ -38,6 +38,7 @@ regorus = { version = "0.1.5", default-features = false, features = ["regex", "b
 rstest = "0.18.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.89"
+serde_with = { version = "1.11.0", features = ["base64"] }
 serial_test = "0.9.0"
 sha2 = "0.10"
 shadow-rs = "0.19.0"

--- a/attestation-service/README.md
+++ b/attestation-service/README.md
@@ -13,6 +13,7 @@ Today, the AS can validate evidence from the following TEEs:
 - Hygon CSV
 - Intel TDX with vTPM on Azure
 - AMD SEV-SNP with vTPM on Azure
+- IBM Secure Execution (SE)
 
 # Overview
 ```
@@ -80,6 +81,7 @@ Please refer to the individual verifiers for the specific format of the evidence
 - Azure TDX vTPM: [Evidence](./verifier/src/az_tdx_vtpm/mod.rs)
 - Arm CCA: [CcaEvidence](./verifier/src/cca/mod.rs)
 - Hygon CSV: [CsvEvidence](./verifier/src/csv/mod.rs)
+- IBM Secure Execution (SE) [(SeEvidence)](./verifier/src/se/mod.rs)
 
 ## Output
 
@@ -132,6 +134,7 @@ Supported Verifier Drivers:
 - `azsnpvtpm`: Verifier Driver for Azure vTPM based on SNP (Azure SNP vTPM)
 - `cca`: Verifier Driver for Confidential Compute Architecture (Arm CCA).
 - `csv`: Verifier Driver for China Security Virtualization (Hygon CSV).
+- `se`: Verifier Driver for IBM Secure Execution (SE).
 
 ### Policy Engine
 

--- a/attestation-service/README.md
+++ b/attestation-service/README.md
@@ -81,7 +81,7 @@ Please refer to the individual verifiers for the specific format of the evidence
 - Azure TDX vTPM: [Evidence](./verifier/src/az_tdx_vtpm/mod.rs)
 - Arm CCA: [CcaEvidence](./verifier/src/cca/mod.rs)
 - Hygon CSV: [CsvEvidence](./verifier/src/csv/mod.rs)
-- IBM Secure Execution (SE) [(SeEvidence)](./verifier/src/se/mod.rs)
+- IBM Secure Execution (SE): [SeEvidence](./verifier/src/se/mod.rs)
 
 ## Output
 

--- a/attestation-service/attestation-service/Cargo.toml
+++ b/attestation-service/attestation-service/Cargo.toml
@@ -13,6 +13,7 @@ az-tdx-vtpm-verifier = [ "verifier/az-tdx-vtpm-verifier" ]
 snp-verifier = [ "verifier/snp-verifier" ]
 csv-verifier = [ "verifier/csv-verifier" ]
 cca-verifier = [ "verifier/cca-verifier" ]
+se-verifier  = [ "verifier/se-verifier" ]
 
 # Only for testing and CI
 rvps-builtin = [ "reference-value-provider-service" ]

--- a/attestation-service/attestation-service/src/bin/restful-as.rs
+++ b/attestation-service/attestation-service/src/bin/restful-as.rs
@@ -13,7 +13,7 @@ use strum::{AsRefStr, EnumString};
 use thiserror::Error;
 use tokio::sync::RwLock;
 
-use crate::restful::{attestation, get_policies, set_policy};
+use crate::restful::{attestation, get_challenge, get_policies, set_policy};
 
 mod restful;
 
@@ -48,6 +48,9 @@ enum WebApi {
 
     #[strum(serialize = "/policy")]
     Policy,
+
+    #[strum(serialize = "/challenge")]
+    Challenge,
 }
 
 #[derive(Error, Debug)]
@@ -100,6 +103,7 @@ async fn main() -> Result<(), RestfulError> {
                     .route(web::post().to(set_policy))
                     .route(web::get().to(get_policies)),
             )
+            .service(web::resource(WebApi::Challenge.as_ref()).route(web::post().to(get_challenge)))
             .app_data(web::Data::clone(&attestation_service))
     });
 

--- a/attestation-service/attestation-service/src/lib.rs
+++ b/attestation-service/attestation-service/src/lib.rs
@@ -274,6 +274,17 @@ impl AttestationService {
     pub async fn register_reference_value(&mut self, message: &str) -> Result<()> {
         self.rvps.verify_and_extract(message).await
     }
+
+    pub async fn generate_supplemental_challenge(
+        &self,
+        tee: Tee,
+        tee_parameters: String,
+    ) -> Result<String> {
+        let verifier = verifier::to_verifier(&tee)?;
+        verifier
+            .generate_supplemental_challenge(tee_parameters)
+            .await
+    }
 }
 
 /// Get the expected init/runtime data and potential claims due to the given input

--- a/attestation-service/docs/parsed_claims.md
+++ b/attestation-service/docs/parsed_claims.md
@@ -93,6 +93,14 @@ The claim inherit the fields from the SEV-SNP claim with and additional `tpm` hi
 
 Note: The TD Report and TD Quote are fetched during early boot in this TEE. Kernel, Initrd and rootfs are measured into the vTPM's registers.
 
+## IBM Secure Execution (SE)
+- `se.version`: The version this quote structure.
+- `se.cuid`: The config uid.
+- `se.hdr.tag`: SE header tag (seht)
+- `se.image.phkh`: SE image public host key hash
+- `se.attestation.phkh`: SE attestation public host key hash
+- `se.user_data`: Custom attestation key owner data.
+
 ## AMD SEV-SNP
 
 - `snp.measurement` Launch Digest covering initial guest memory

--- a/attestation-service/docs/parsed_claims.md
+++ b/attestation-service/docs/parsed_claims.md
@@ -95,11 +95,11 @@ Note: The TD Report and TD Quote are fetched during early boot in this TEE. Kern
 
 ## IBM Secure Execution (SE)
 - `se.version`: The version this quote structure.
-- `se.cuid`: The config uid.
-- `se.hdr.tag`: SE header tag (seht)
+- `se.cuid`: The unique ID of the attested guest (configuration uniqe ID).
+- `se.hdr.tag`: SE header tag.
 - `se.image.phkh`: SE image public host key hash
 - `se.attestation.phkh`: SE attestation public host key hash
-- `se.user_data`: Custom attestation key owner data.
+- `se.user_data`: Optional custom attestation owner data, could be key:value pairs collected on guest.
 
 ## AMD SEV-SNP
 

--- a/attestation-service/protos/attestation.proto
+++ b/attestation-service/protos/attestation.proto
@@ -77,8 +77,18 @@ message SetPolicyRequest {
 }
 message SetPolicyResponse {}
 
+message ChallengeRequest {
+    // ChallengeRequest uses HashMap to pass variables like:
+    // tee, tee_params etc
+    map<string, string> inner = 1;
+}
+message ChallengeResponse {
+    string attestation_challenge = 1;
+}
+
 service AttestationService {
     rpc AttestationEvaluate(AttestationRequest) returns (AttestationResponse) {};
     rpc SetAttestationPolicy(SetPolicyRequest) returns (SetPolicyResponse) {};
+    rpc GetAttestationChallenge(ChallengeRequest) returns (ChallengeResponse) {};
     // Get the GetPolicyRequest.user and GetPolicyRequest.tee specified Policy(.rego)
 }

--- a/attestation-service/verifier/Cargo.toml
+++ b/attestation-service/verifier/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [features]
 default = [ "all-verifier" ]
-all-verifier = [ "tdx-verifier", "sgx-verifier", "snp-verifier", "az-snp-vtpm-verifier", "az-tdx-vtpm-verifier", "csv-verifier", "cca-verifier" ]
+all-verifier = [ "tdx-verifier", "sgx-verifier", "snp-verifier", "az-snp-vtpm-verifier", "az-tdx-vtpm-verifier", "csv-verifier", "cca-verifier", "se-verifier" ]
 tdx-verifier = [ "eventlog-rs", "scroll", "intel-tee-quote-verification-rs" ]
 sgx-verifier = [ "scroll", "intel-tee-quote-verification-rs" ]
 az-snp-vtpm-verifier = [ "az-snp-vtpm", "sev", "snp-verifier" ]
@@ -13,6 +13,7 @@ az-tdx-vtpm-verifier = [ "az-tdx-vtpm", "openssl", "tdx-verifier" ]
 snp-verifier = [ "asn1-rs", "openssl", "sev", "x509-parser" ]
 csv-verifier = [ "openssl", "csv-rs", "codicon" ]
 cca-verifier = [ "ear", "jsonwebtoken", "veraison-apiclient" ]
+se-verifier = [ "openssl", "pv", "serde_with", "tokio/sync" ]
 
 [dependencies]
 anyhow.workspace = true
@@ -35,10 +36,13 @@ jsonwebtoken = { workspace = true, default-features = false, optional = true }
 kbs-types.workspace = true
 log.workspace = true
 openssl = { version = "0.10.55", optional = true }
+pv = { version = "0.10.0", package = "s390_pv", optional = true }
 scroll = { version = "0.11.0", default-features = false, features = ["derive"], optional = true }
 serde.workspace = true
 serde_json.workspace = true
+serde_with = { workspace = true, optional = true }
 sev = { version = "3.1.1", features = ["openssl", "snp"], optional = true }
+tokio = { workspace = true, optional = true, default-features = false }
 intel-tee-quote-verification-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", tag = "DCAP_1.21", optional = true }
 strum.workspace = true
 veraison-apiclient = { git = "https://github.com/chendave/rust-apiclient", branch = "token", optional = true }
@@ -54,3 +58,4 @@ assert-json-diff.workspace = true
 rstest.workspace = true
 serial_test.workspace = true
 tokio.workspace = true
+

--- a/attestation-service/verifier/Cargo.toml
+++ b/attestation-service/verifier/Cargo.toml
@@ -58,4 +58,3 @@ assert-json-diff.workspace = true
 rstest.workspace = true
 serial_test.workspace = true
 tokio.workspace = true
-

--- a/attestation-service/verifier/src/se/ibmse.rs
+++ b/attestation-service/verifier/src/se/ibmse.rs
@@ -18,7 +18,7 @@ use pv::misc::{open_file, read_certs};
 use pv::request::{BootHdrTags, CertVerifier, HkdVerifier, ReqEncrCtx, Request, SymKeyType};
 use pv::uv::ConfigUid;
 use serde::{Deserialize, Serialize};
-use serde_with::{base64::Base64, serde_as};
+use serde_with::{base64::Base64, hex::Hex, serde_as};
 use std::{env, fs};
 
 const DEFAULT_SE_HOST_KEY_DOCUMENTS_ROOT: &str = "/run/confidential-containers/ibmse/hkds";
@@ -87,16 +87,16 @@ pub struct SeAttestationResponse {
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SeAttestationClaims {
-    #[serde_as(as = "Base64")]
+    #[serde_as(as = "Hex")]
     cuid: ConfigUid,
-    #[serde_as(as = "Base64")]
+    #[serde_as(as = "Hex")]
     user_data: Vec<u8>,
     version: u32,
-    #[serde_as(as = "Base64")]
+    #[serde_as(as = "Hex")]
     image_phkh: Vec<u8>,
-    #[serde_as(as = "Base64")]
+    #[serde_as(as = "Hex")]
     attestation_phkh: Vec<u8>,
-    #[serde_as(as = "Base64")]
+    #[serde_as(as = "Hex")]
     tag: [u8; 16],
 }
 

--- a/attestation-service/verifier/src/se/ibmse.rs
+++ b/attestation-service/verifier/src/se/ibmse.rs
@@ -1,0 +1,311 @@
+// Copyright (C) Copyright IBM Corp. 2024
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::TeeEvidenceParsedClaim;
+use anyhow::{anyhow, bail, Context, Result};
+use core::result::Result::Ok;
+use log::{debug, info, warn};
+use openssl::encrypt::{Decrypter, Encrypter};
+use openssl::pkey::{PKey, Private, Public};
+use openssl::rsa::{Padding, Rsa};
+use pv::attest::{
+    AdditionalData, AttestationFlags, AttestationItems, AttestationMeasAlg, AttestationMeasurement,
+    AttestationRequest, AttestationVersion,
+};
+use pv::misc::{open_file, read_certs};
+use pv::request::{BootHdrTags, CertVerifier, HkdVerifier, ReqEncrCtx, Request, SymKeyType};
+use pv::uv::ConfigUid;
+use serde::{Deserialize, Serialize};
+use serde_with::{base64::Base64, serde_as};
+use std::{env, fs};
+
+const DEFAULT_SE_HOST_KEY_DOCUMENTS_ROOT: &str = "/run/confidential-containers/ibmse/hkds";
+
+const DEFAULT_SE_CERTIFICATES_ROOT: &str = "/run/confidential-containers/ibmse/certs";
+
+const DEFAULT_SE_CERTIFICATE_ROOT_CA: &str = "/run/confidential-containers/ibmse/certs/ca";
+
+const DEFAULT_SE_CERTIFICATE_REVOCATION_LISTS_ROOT: &str =
+    "/run/confidential-containers/ibmse/crls";
+
+const DEFAULT_SE_IMAGE_HEADER_FILE: &str = "/run/confidential-containers/ibmse/hdr/hdr.bin";
+
+const DEFAULT_SE_MEASUREMENT_ENCR_KEY_PRIVATE: &str =
+    "/run/confidential-containers/ibmse/rsa/encrypt_key.pem";
+
+const DEFAULT_SE_MEASUREMENT_ENCR_KEY_PUBLIC: &str =
+    "/run/confidential-containers/ibmse/rsa/encrypt_key.pub";
+
+macro_rules! env_or_default {
+    ($env:literal, $default:ident) => {
+        match env::var($env) {
+            Ok(env_path) => env_path,
+            Err(_) => $default.into(),
+        }
+    };
+}
+
+fn list_files_in_folder(dir: &str) -> Result<Vec<String>> {
+    let mut file_paths = Vec::new();
+
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.is_file() {
+            if let Some(path_str) = path.to_str() {
+                file_paths.push(path_str.to_string());
+            }
+        }
+    }
+
+    Ok(file_paths)
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SeAttestationResponse {
+    #[serde_as(as = "Base64")]
+    measurement: Vec<u8>,
+    #[serde_as(as = "Base64")]
+    additional_data: Vec<u8>,
+    #[serde_as(as = "Base64")]
+    user_data: Vec<u8>,
+    #[serde_as(as = "Base64")]
+    cuid: ConfigUid,
+    #[serde_as(as = "Base64")]
+    encr_measurement_key: Vec<u8>,
+    #[serde_as(as = "Base64")]
+    encr_request_nonce: Vec<u8>,
+    #[serde_as(as = "Base64")]
+    image_hdr_tags: BootHdrTags,
+}
+
+#[repr(C)]
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SeAttestationClaims {
+    #[serde_as(as = "Base64")]
+    cuid: ConfigUid,
+    #[serde_as(as = "Base64")]
+    user_data: Vec<u8>,
+    version: u32,
+    #[serde_as(as = "Base64")]
+    image_phkh: Vec<u8>,
+    #[serde_as(as = "Base64")]
+    attestation_phkh: Vec<u8>,
+    #[serde_as(as = "Base64")]
+    tag: [u8; 16],
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SeAttestationRequest {
+    #[serde_as(as = "Base64")]
+    request_blob: Vec<u8>,
+    measurement_size: u32,
+    additional_size: u32,
+    #[serde_as(as = "Base64")]
+    encr_measurement_key: Vec<u8>,
+    #[serde_as(as = "Base64")]
+    encr_request_nonce: Vec<u8>,
+    #[serde_as(as = "Base64")]
+    image_hdr_tags: BootHdrTags,
+}
+
+#[derive(Debug)]
+pub struct RealSeVerifier {
+    rsa_private_key: PKey<Private>,
+    rsa_public_key: PKey<Public>,
+}
+
+impl RealSeVerifier {
+    pub fn new() -> Result<Self> {
+        let pri_key_file = env_or_default!(
+            "SE_MEASUREMENT_ENCR_KEY_PRIVATE",
+            DEFAULT_SE_MEASUREMENT_ENCR_KEY_PRIVATE
+        );
+        let priv_contents = fs::read(pri_key_file)?;
+        let rsa_private_key = Rsa::private_key_from_pem(&priv_contents)?;
+        let rsa_private_key = PKey::from_rsa(rsa_private_key)?;
+
+        let pub_key_file = env_or_default!(
+            "SE_MEASUREMENT_ENCR_KEY_PUBLIC",
+            DEFAULT_SE_MEASUREMENT_ENCR_KEY_PUBLIC
+        );
+        let pub_contents = fs::read(pub_key_file)?;
+        let rsa = Rsa::public_key_from_pem(&pub_contents)?;
+        let rsa_public_key = PKey::from_rsa(rsa)?;
+
+        Ok(Self {
+            rsa_private_key,
+            rsa_public_key,
+        })
+    }
+
+    fn decrypt(&self, ciphertext: &[u8]) -> Result<Vec<u8>> {
+        let mut decrypter = Decrypter::new(&self.rsa_private_key)?;
+        decrypter.set_rsa_padding(Padding::PKCS1)?;
+
+        let buffer_len = decrypter.decrypt_len(ciphertext)?;
+        let mut decrypted_hmac_key = vec![0; buffer_len];
+        let decrypted_len = decrypter.decrypt(ciphertext, &mut decrypted_hmac_key)?;
+        decrypted_hmac_key.truncate(decrypted_len);
+
+        Ok(decrypted_hmac_key)
+    }
+
+    fn encrypt(&self, text: &[u8]) -> Result<Vec<u8>> {
+        let mut encrypter = Encrypter::new(&self.rsa_public_key)?;
+        encrypter.set_rsa_padding(Padding::PKCS1)?;
+    
+        let buffer_len = encrypter.encrypt_len(text)?;
+        let mut encrypted_hmac_key = vec![0; buffer_len];
+        let len = encrypter.encrypt(text, &mut encrypted_hmac_key)?;
+        encrypted_hmac_key.truncate(len);
+    
+        Ok(encrypted_hmac_key)
+    }
+
+    pub fn evaluate(&self, evidence: &[u8]) -> Result<TeeEvidenceParsedClaim> {
+        info!("IBM SE verify API called.");
+
+        // evidence is serialized SeAttestationResponse String bytes
+        let se_response: SeAttestationResponse = serde_json::from_slice(evidence)?;
+
+        let meas_key = self
+            .decrypt(&se_response.encr_measurement_key)
+            .context("decrypt Measurement Key")?;
+        let nonce = self
+            .decrypt(&se_response.encr_request_nonce)
+            .context("decrypt Request Nonce")?;
+
+        if nonce.len() != 16 {
+            bail!("The nonce vector must have exactly 16 elements.");
+        }
+
+        let nonce_array: [u8; 16] = nonce
+            .try_into()
+            .map_err(|_| anyhow!("Failed to convert nonce from Vec<u8> to [u8; 16]."))?;
+
+        let meas_key = PKey::hmac(&meas_key)?;
+        let items = AttestationItems::new(
+            &se_response.image_hdr_tags,
+            &se_response.cuid,
+            Some(&se_response.user_data),
+            Some(&nonce_array),
+            Some(&se_response.additional_data),
+        );
+
+        let measurement =
+            AttestationMeasurement::calculate(items, AttestationMeasAlg::HmacSha512, &meas_key)?;
+
+        if !measurement.eq_secure(&se_response.measurement) {
+            debug!("Recieved: {:?}", se_response.measurement);
+            debug!("Calculated: {:?}", measurement.as_ref());
+            warn!("Attestation measurement verification failed. Calculated and received attestation measurement are not equal.");
+            bail!("Failed to verify the measurement!");
+        }
+
+        // TODO check self.user_data.image_btph with previous saved value
+
+        let mut att_flags = AttestationFlags::default();
+        att_flags.set_image_phkh();
+        att_flags.set_attest_phkh();
+        let add_data = AdditionalData::from_slice(&se_response.additional_data, &att_flags)?;
+        debug!("additional_data: {:?}", add_data);
+        let image_phkh = add_data
+            .image_public_host_key_hash()
+            .ok_or(anyhow!("Failed to get image_public_host_key_hash."))?;
+        let attestation_phkh = add_data
+            .attestation_public_host_key_hash()
+            .ok_or(anyhow!("Failed to get attestation_public_host_key_hash."))?;
+
+        // TODO image_phkh and attestation_phkh with previous saved value
+
+        let claims = SeAttestationClaims {
+            cuid: se_response.cuid,
+            user_data: se_response.user_data.clone(),
+            version: AttestationVersion::One as u32,
+            image_phkh: image_phkh.to_vec(),
+            attestation_phkh: attestation_phkh.to_vec(),
+            tag: *se_response.image_hdr_tags.tag(),
+        };
+
+        serde_json::to_value(claims).context("build json value from the se claims")
+    }
+
+    pub async fn generate_supplemental_challenge(&self, _tee_parameters: String) -> Result<String> {
+        let se_certificate_root =
+            env_or_default!("SE_CERTIFICATES_ROOT", DEFAULT_SE_CERTIFICATES_ROOT);
+        let certs = list_files_in_folder(&se_certificate_root)?;
+
+        let crl_root = env_or_default!(
+            "SE_CERTIFICATE_REVOCATION_LISTS_ROOT",
+            DEFAULT_SE_CERTIFICATE_REVOCATION_LISTS_ROOT
+        );
+        let crls = list_files_in_folder(&crl_root)?;
+
+        let root_ca_path =
+            env_or_default!("SE_CERTIFICATE_ROOT_CA", DEFAULT_SE_CERTIFICATE_ROOT_CA);
+        let verifier =
+            CertVerifier::new(certs.as_slice(), crls.as_slice(), Some(root_ca_path), false)?;
+
+        let mut arcb = AttestationRequest::new(
+            AttestationVersion::One,
+            AttestationMeasAlg::HmacSha512,
+            AttestationFlags::default(),
+        )?;
+
+        let hkds_root = env_or_default!(
+            "DEFAULT_SE_HOST_KEY_DOCUMENTS_ROOT",
+            DEFAULT_SE_HOST_KEY_DOCUMENTS_ROOT
+        );
+        let hkds = list_files_in_folder(&hkds_root)?;
+        for hkd in &hkds {
+            let hk = std::fs::read(hkd).context("read host-key document")?;
+            let certs = read_certs(&hk)?;
+            if certs.is_empty() {
+                warn!("The host key document in '{hkd}' contains empty certificate!");
+            }
+            if certs.len() != 1 {
+                warn!("The host key document in '{hkd}' contains more than one certificate!")
+            }
+            let c = certs
+                .first()
+                .ok_or(anyhow!("File does not contain a X509 certificate"))?;
+            verifier.verify(c)?;
+            arcb.add_hostkey(c.public_key()?);
+        }
+
+        let encr_ctx = ReqEncrCtx::random(SymKeyType::Aes256)?;
+        let request_blob = arcb.encrypt(&encr_ctx)?;
+        let conf_data = arcb.confidential_data();
+        let encr_measurement_key =
+            self.encrypt(conf_data.measurement_key())?;
+        let nonce = conf_data
+            .nonce()
+            .as_ref()
+            .ok_or(anyhow!("Failed to get nonce binding"))?
+            .value();
+        let encr_request_nonce = self.encrypt(nonce)?;
+
+        let se_img_hdr = env_or_default!("SE_IMAGE_HEADER_FILE", DEFAULT_SE_IMAGE_HEADER_FILE);
+        let mut hdr_file = open_file(se_img_hdr)?;
+        let image_hdr_tags = BootHdrTags::from_se_image(&mut hdr_file)?;
+
+        let se_attestation_request = SeAttestationRequest {
+            request_blob,
+            measurement_size: AttestationMeasAlg::HmacSha512.exp_size(),
+            additional_size: arcb.flags().expected_additional_size(),
+            encr_measurement_key,
+            encr_request_nonce,
+            image_hdr_tags,
+        };
+
+        let challenge = serde_json::to_string(&se_attestation_request)?;
+        Ok(challenge)
+    }
+}

--- a/attestation-service/verifier/src/se/mod.rs
+++ b/attestation-service/verifier/src/se/mod.rs
@@ -1,0 +1,45 @@
+// Copyright (C) Copyright IBM Corp. 2024
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::Result;
+use async_trait::async_trait;
+use ibmse::RealSeVerifier;
+use log::warn;
+use tokio::sync::OnceCell;
+
+use crate::{InitDataHash, ReportData, TeeEvidenceParsedClaim, Verifier};
+
+pub mod ibmse;
+
+static ONCE: OnceCell<RealSeVerifier> = OnceCell::const_new();
+
+#[derive(Debug, Default)]
+pub struct SeVerifier;
+
+#[async_trait]
+impl Verifier for SeVerifier {
+    async fn evaluate(
+        &self,
+        evidence: &[u8],
+        _expected_report_data: &ReportData,
+        _expected_init_data_hash: &InitDataHash,
+    ) -> Result<TeeEvidenceParsedClaim> {
+        let se_verifier = ONCE
+            .get_or_try_init(|| async { RealSeVerifier::new() })
+            .await?;
+        warn!("IBM SE does not support initdata.");
+        se_verifier.evaluate(evidence)
+    }
+
+    async fn generate_supplemental_challenge(
+        &self,
+        _tee_parameters: String,
+    ) -> Result<String> {
+        let se_verifier = ONCE
+            .get_or_try_init(|| async { RealSeVerifier::new() })
+            .await?;
+        se_verifier.generate_supplemental_challenge(_tee_parameters).await
+    }
+}

--- a/kbs/src/api/src/attestation/coco/grpc.rs
+++ b/kbs/src/api/src/attestation/coco/grpc.rs
@@ -127,13 +127,8 @@ impl Attest for GrpcClientPool {
     async fn generate_challenge(&self, tee: Tee, tee_parameters: String) -> Result<Challenge> {
         let nonce = match tee {
             Tee::Se => {
-                let tee = serde_json::to_string(&tee)
-                    .context("CoCo AS client: serialize tee type failed.")?
-                    .trim_end_matches('"')
-                    .trim_start_matches('"')
-                    .to_string();
                 let mut inner = HashMap::new();
-                inner.insert(String::from("tee"), tee);
+                inner.insert(String::from("tee"), String::from("se"));
                 inner.insert(String::from("tee_params"), tee_parameters);
                 let req = tonic::Request::new(ChallengeRequest { inner });
 

--- a/kbs/src/api/src/session.rs
+++ b/kbs/src/api/src/session.rs
@@ -7,25 +7,12 @@ use actix_web::cookie::{
     Cookie,
 };
 use anyhow::{bail, Result};
-use base64::engine::general_purpose::STANDARD;
-use base64::Engine;
 use kbs_types::{Challenge, Request};
 use log::warn;
-use rand::{thread_rng, Rng};
 use semver::Version;
 use uuid::Uuid;
 
 pub(crate) static KBS_SESSION_ID: &str = "kbs-session-id";
-
-fn nonce() -> Result<String> {
-    let mut nonce: Vec<u8> = vec![0; 32];
-
-    thread_rng()
-        .try_fill(&mut nonce[..])
-        .map_err(anyhow::Error::from)?;
-
-    Ok(STANDARD.encode(&nonce))
-}
 
 /// Finite State Machine model for RCAR handshake
 pub(crate) enum SessionStatus {
@@ -64,7 +51,7 @@ macro_rules! impl_member {
 }
 
 impl SessionStatus {
-    pub fn auth(request: Request, timeout: i64) -> Result<Self> {
+    pub fn auth(request: Request, timeout: i64, challenge: Challenge) -> Result<Self> {
         let version = Version::parse(&request.version).map_err(anyhow::Error::from)?;
         if !crate::VERSION_REQ.matches(&version) {
             bail!("Invalid Request version {}", request.version);
@@ -75,10 +62,7 @@ impl SessionStatus {
 
         Ok(Self::Authed {
             request,
-            challenge: Challenge {
-                nonce: nonce()?,
-                extra_params: String::new(),
-            },
+            challenge,
             id,
             timeout,
         })

--- a/kbs/tools/client/Cargo.toml
+++ b/kbs/tools/client/Cargo.toml
@@ -18,7 +18,7 @@ base64.workspace = true
 clap = { version = "4.0.29", features = ["derive"] }
 env_logger.workspace = true
 jwt-simple = "0.11.4"
-kbs_protocol = { git = "https://github.com/confidential-containers/guest-components.git", rev="5ae8d8ed136aef6303dc9802df04d19b86e1e70d", default-features = false }
+kbs_protocol = { git = "https://github.com/confidential-containers/guest-components.git", rev="c543f208211aedd5fbecc5ddddf4c3200d0bbc00", default-features = false }
 log.workspace = true
 reqwest = { version = "0.11.18", default-features = false, features = ["cookies", "json"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Fixes: #342 
This is kbs side code and related with PR: https://github.com/confidential-containers/guest-components/pull/492/
Depends on: 
 - [x] https://github.com/virtee/kbs-types/issues/26

# The IBM SE Remote Attestation flow:
<img width="1438" alt="image" src="https://github.com/confidential-containers/trustee/assets/15607193/8cd52762-2dbf-443a-b518-79ea4d57e7cd">

- The verifier generate the encrypted attestation-request based on hkd, CA, signing_key, a measurement key  and a nonce, the encrypted data is protected by a symmetric attestation request protection key,  which is encrypted using the Host-key document
- Verifier sends the request to attester
- Firmware on the Attester's system decrypts the request via private host-key and calculates the evidence based on the encrpted part of the request (Measurement key + nonce)
- Attester send the evidence to verifier
- Verifier recalculates the evidence based on the Configuration UID, Additional data, user-data, guest image hashes, and nonce. (its a HMAC-SHA512 with the measurement key as secret)
- if both HMACs, the one from the Firmware and the calculated one from the verifier match -> attestation success

