### PR TITLE
Use the Trustee name in a few more places

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fconfidential-containers%2Fkbs.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fconfidential-containers%2Fkbs?ref=badge_shield)
 
 This repository contains tools and components for attesting confidential guests and providing secrets to them.
-These components typically operate on behalf of the guest owner and interact remotely with
+Collectively, these components are known as Trustee.
+Trustee typically operates on behalf of the guest owner and interact remotely with
 [guest components](https://github.com/confidential-containers/guest-components).
 
-These components were developed for the Confidential Containers project, but can be used with a wide variety
+Trustee was developed for the Confidential Containers project, but can be used with a wide variety
 of applications and hardware platforms.
 
 ## Components
@@ -32,7 +33,7 @@ For further information, see documentation of individual components.
 
 ## Architecture
 
-These components are flexible and can be deployed in several different configurations.
+Trustee is flexible and can be deployed in several different configurations.
 This figure shows one common way to deploy these components in conjunction with certain guest components.
 
 ```mermaid
@@ -42,7 +43,7 @@ flowchart LR
     subgraph Guest
         CDH <.-> AA
     end
-    subgraph KBS Cluster
+    subgraph Trustee
         AS -- verifies evidence --> KBS
         RVPS -- provides reference values--> AS
     end
@@ -50,11 +51,11 @@ flowchart LR
 ```
 ## Deployment
 
-There are two main ways to deploy the KBS and supporting components.
+There are two main ways to deploy Trustee.
 
 ### Docker Compose
 
-One simple way to get started with these components is with Docker compose, which can be used
+One simple way to get started with Trustee is with Docker compose, which can be used
 to quickly setup a cluster matching the diagram above.
 
 Please refer to the [cluster setup guide](kbs/docs/cluster.md).
@@ -63,7 +64,7 @@ This cluster could be run inside a VM or as part of a managed service.
 
 ### Kubernetes
 
-There are two supported ways of deploying KBS on Kubernetes.
+There are two supported ways of deploying Trustee on Kubernetes.
 One is via the [KBS Operator](https://github.com/confidential-containers/kbs-operator),
 which deploys the KBS components. The second option is to use the KBS'
 provided Kubernetes tooling [here](kbs/config/kubernetes).

--- a/kbs/README.md
+++ b/kbs/README.md
@@ -33,7 +33,7 @@ flowchart LR
     subgraph Guest
         AA <.-> CDH
     end
-    subgraph KBS Cluster
+    subgraph Trustee
         AS -- validates evidence--> KBS
     end
 ```
@@ -65,10 +65,10 @@ flowchart LR
     subgraph Guest
         CDH <.-> AA
     end
-    subgraph KBS Cluster 1
+    subgraph Trustee 1
         AS -- validates evidence--> KBS1
     end
-    subgraph KBS Cluster 2
+    subgraph Trustee 2
         KBS2
     end
 ```


### PR DESCRIPTION
Fixup a few places where we refer to the "KBS Cluster." Now we call that Trustee.