### PR TITLE
kbs: switch to Regorus for resource policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,9 @@ name = "anyhow"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "api-server"
@@ -419,6 +422,7 @@ dependencies = [
  "openssl",
  "prost",
  "rand",
+ "regorus",
  "reqwest",
  "rsa 0.9.6",
  "rstest",
@@ -963,6 +967,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,6 +1137,12 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "compact-rc"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf2bdc97c915ed231cf450d1dc4f7293b6135a46834f886f23cfdf8ac2ba4a23"
 
 [[package]]
 name = "config"
@@ -1613,6 +1645,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,6 +1691,19 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c012a26a7f605efc424dd53697843a72be7dc86ad2d01f7814337794a12231d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -2292,6 +2347,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2769,6 +2833,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,6 +2872,15 @@ dependencies = [
  "rand",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2829,6 +2916,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3066,6 +3165,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,6 +3305,16 @@ dependencies = [
  "phf_macros",
  "phf_shared",
  "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3458,7 +3576,7 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -3479,7 +3597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3637,6 +3755,29 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "regorus"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f01b11bdcd295d4c24d17d8248bb77e7664e3f288481a72e9013ec8d27f9064"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "chrono-tz",
+ "compact-rc",
+ "data-encoding",
+ "env_logger 0.11.2",
+ "itertools 0.12.1",
+ "lazy_static",
+ "log",
+ "num",
+ "rand",
+ "regex",
+ "scientific",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "relative-path"
@@ -4002,6 +4143,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "scientific"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc53198b8e237c451c68dba8411a1f8bd92787657689f24d67ae3d6b98c39f59"
+dependencies = [
+ "scientific-macro",
+]
+
+[[package]]
+name = "scientific-macro"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ee4885492bb655bfa05d039cd9163eb8fe9f79ddebf00ca23a1637510c2fd2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ kbs-types = "0.5.3"
 jsonwebtoken = { version = "9", default-features = false }
 log = "0.4.17"
 prost = "0.11.0"
+regorus = { version = "0.1.2", default-features = false, features = ["regex", "base64", "time"] }
 rstest = "0.18.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.89"

--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     curl \
     gpg \
-    gnupg-agent
+    gnupg-agent \
+    git
 
 RUN curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
     gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \

--- a/kbs/docker/Dockerfile.coco-as-grpc
+++ b/kbs/docker/Dockerfile.coco-as-grpc
@@ -3,7 +3,7 @@ FROM rust:latest as builder
 WORKDIR /usr/src/kbs
 COPY . .
 
-RUN apt-get update && apt install -y protobuf-compiler wget
+RUN apt-get update && apt install -y protobuf-compiler wget git
 
 RUN wget https://go.dev/dl/go1.20.1.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.20.1.linux-amd64.tar.gz

--- a/kbs/docker/Dockerfile.intel-trust-authority
+++ b/kbs/docker/Dockerfile.intel-trust-authority
@@ -3,7 +3,7 @@ FROM rust:latest as builder
 WORKDIR /usr/src/kbs
 COPY . .
 
-RUN apt-get update && apt install -y wget
+RUN apt-get update && apt install -y wget git
 
 RUN wget https://go.dev/dl/go1.20.1.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.20.1.linux-amd64.tar.gz

--- a/kbs/sample_policies/README.md
+++ b/kbs/sample_policies/README.md
@@ -1,6 +1,8 @@
 This directory contains sample policy files to configure the policy engine
 of the KBS. You can use these files to write your own policies.
 
+There are also several example policies used [for testing](../test/data). 
+
 | File | Description |
 | ---  | ---         |
 |[allow_all.rego](./allow_all.rego)|Equivalent to turning off the policy engine. Release resources unconditionally|

--- a/kbs/src/api/Cargo.toml
+++ b/kbs/src/api/Cargo.toml
@@ -40,6 +40,7 @@ log.workspace = true
 mobc = { version = "0.8.3", optional = true }
 prost = { version = "0.11", optional = true }
 rand = "0.8.5"
+regorus.workspace = true
 reqwest = { version = "0.11", features = ["json"], optional = true }
 rsa = { version = "0.9.2", optional = true, features = ["sha2"] }
 rustls = { version = "0.20.8", optional = true }

--- a/kbs/src/api/src/http/resource.rs
+++ b/kbs/src/api/src/http/resource.rs
@@ -108,7 +108,7 @@ pub(crate) async fn get_resource(
             resource_description.resource_type,
             resource_description.resource_tag
         );
-        let (resource_allowed, _extra_policy_output) = policy_engine
+        let resource_allowed = policy_engine
             .0
             .lock()
             .await

--- a/kbs/src/api/src/policy_engine/mod.rs
+++ b/kbs/src/api/src/policy_engine/mod.rs
@@ -7,12 +7,37 @@ use async_trait::async_trait;
 use serde::Deserialize;
 use std::path::PathBuf;
 use std::sync::Arc;
+use thiserror::Error;
 use tokio::sync::Mutex;
 
 #[cfg(feature = "opa")]
 mod opa;
 
 const DEFAULT_POLICY_PATH: &str = "/opa/confidential-containers/kbs/policy.rego";
+
+#[derive(Error, Debug)]
+pub enum ResourcePolicyError {
+    #[error("Failed to evaluate resource policy {0}")]
+    EvaluationError(#[from] anyhow::Error),
+
+    #[error("Failed to load data for resource policy")]
+    DataLoadError,
+
+    #[error("Invalid resource path format")]
+    ResourcePathError,
+
+    #[error("Resource Policy IO Error: {0}")]
+    IOError(#[from] std::io::Error),
+
+    #[error("Decoding (base64) resource policy failed: {0}")]
+    DecodeError(#[from] base64::DecodeError),
+
+    #[error("Failed to load input for resource policy")]
+    InputError,
+
+    #[error("Failed to load resource policy")]
+    PolicyLoadError,
+}
 
 /// Resource policy engine interface
 #[async_trait]
@@ -26,11 +51,14 @@ pub(crate) trait PolicyEngineInterface: Send + Sync {
     /// ([decide_result, extra_output])
     /// decide_result: Boolean value to present whether the evaluate is passed or not.
     /// extra_output: original ouput from policy engine.
-    async fn evaluate(&self, resource_path: String, input_claims: String)
-        -> Result<(bool, String)>;
+    async fn evaluate(
+        &self,
+        resource_path: String,
+        input_claims: String,
+    ) -> Result<bool, ResourcePolicyError>;
 
     /// Set policy (Base64 encode)
-    async fn set_policy(&mut self, policy: String) -> Result<()>;
+    async fn set_policy(&mut self, policy: String) -> Result<(), ResourcePolicyError>;
 }
 
 /// Policy engine configuration.
@@ -55,7 +83,7 @@ pub(crate) struct PolicyEngine(pub Arc<Mutex<dyn PolicyEngineInterface>>);
 
 impl PolicyEngine {
     /// Create and initialize PolicyEngine
-    pub async fn new(config: &PolicyEngineConfig) -> Result<Self> {
+    pub async fn new(config: &PolicyEngineConfig) -> Result<Self, ResourcePolicyError> {
         let policy_engine: Arc<Mutex<dyn PolicyEngineInterface>> = {
             cfg_if::cfg_if! {
                 if #[cfg(feature = "opa")] {

--- a/kbs/test/data/policy_3.rego
+++ b/kbs/test/data/policy_3.rego
@@ -1,0 +1,5 @@
+
+package policy
+
+default allow = false
+

--- a/kbs/test/data/policy_4.rego
+++ b/kbs/test/data/policy_4.rego
@@ -1,0 +1,31 @@
+# Test policy to make sure that extra lines do not break the KBS
+
+
+
+
+
+
+package policy
+
+default allow = false
+
+path := split(data["resource-path"], "/")
+input_tcb := input["tcb-status"]
+
+allow {
+    count(path) == 3
+
+
+
+
+
+
+    input_tcb.productId == path[1]
+}
+
+
+
+
+
+
+

--- a/kbs/test/data/policy_5.rego
+++ b/kbs/test/data/policy_5.rego
@@ -1,0 +1,33 @@
+package policy
+
+# Opt-in to the breaking changes coming in rego v1
+import rego.v1
+
+default allow := false
+
+# path should be of form `repository_name/resource_type/resource_name`
+path := split(data["resource-path"], "/")
+
+# these are the claims that the verifier extracted from the evidence
+input_tcb := input["tcb-status"]
+
+platform := input.tee
+
+# mapping of resource ids to minimum SVNs
+resources := {"secret1": 2, "secret2": 3}
+
+allow if {
+    # check that evidence comes from expected platform
+    platform == "sample"
+
+    # check tht resource path is valid
+    count(path) == 3
+
+    # check repository_name and resource_type
+    path[0] == "myrepo"
+    path[1] == "secret"
+
+    # check that the secret name exists and tht the minimum svn is met
+    resources[path[2]] <= input_tcb.svn 
+    
+}

--- a/kbs/test/data/policy_invalid_1.rego
+++ b/kbs/test/data/policy_invalid_1.rego
@@ -1,2 +1,2 @@
-package policy
 default allow = true
+

--- a/kbs/test/data/policy_invalid_2.rego
+++ b/kbs/test/data/policy_invalid_2.rego
@@ -1,0 +1,11 @@
+package policy
+
+default allowed = false
+
+path := split(data["resource-path"], "/")
+input_tcb := input["tcb-status"]
+
+allowed {
+    count(path) == 3
+    input_tcb.productId == path[1]
+}


### PR DESCRIPTION
1) Switch from Go-based policy engine to rust-based Regorus 
2) Switch from Anyhow to thiserror for resource policy 
3) Add several unit tests and test policies

This does not touch the AS policy. I will do that later although the plan may change based on whether/how we use EAR tokens.