### PR TITLE
Add write-packages permission for kbs-client-build-and-push workflow

### DIFF
--- a/.github/workflows/kbs-client-build-and-push.yaml
+++ b/.github/workflows/kbs-client-build-and-push.yaml
@@ -10,6 +10,9 @@ jobs:
     env:
       RUSTC_VERSION: 1.76.0
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
 
     steps:
     - name: Check out code


### PR DESCRIPTION
This is an attempt to fix the permission error seen here:
https://github.com/confidential-containers/trustee/actions/runs/8502445853/job/23286620681#step:6:13

Related issue:
Issue https://github.com/confidential-containers/trustee/issues/333

Original/merged PR (successfully created staged-images/kbs-client package and sha-based tag but failed to add latest tag):
PR https://github.com/confidential-containers/trustee/pull/349

Related [github docs](https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#about-scopes-and-permissions-for-package-registries) suggest to me that the package should have never been uploaded in the first place without this write permission, so I'm not 100% confident in this PR. An alternative might be to have a trustee admin inspect the package settings on the github website (e.g. [maybe like this](https://stackoverflow.com/a/72585915)).