### PR TITLE
Fix build warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "attestation-service/verifier",
     "attestation-service/rvps",
 ]
+resolver = "2"
 
 [workspace.package]
 version = "0.1.0"
@@ -30,7 +31,7 @@ config = "0.13.3"
 env_logger = "0.10.0"
 hex = "0.4.3"
 kbs-types = "0.5.3"
-jsonwebtoken = "9"
+jsonwebtoken = { version = "9", default-features = false }
 log = "0.4.17"
 prost = "0.11.0"
 rstest = "0.18.1"


### PR DESCRIPTION
Fix two of the build warnings that we typically get.

1) Force all the workspace members to use the resolver 2
2) Set default-features to false for jsonwebtoken in the root Cargo file so that package members can use it with default-features set to false as well. 