### PR TITLE
AS & KBS | Optimize log

### DIFF
--- a/attestation-service/attestation-service/src/bin/grpc/mod.rs
+++ b/attestation-service/attestation-service/src/bin/grpc/mod.rs
@@ -68,6 +68,7 @@ impl AttestationService for Arc<RwLock<AttestationServer>> {
     ) -> Result<Response<SetPolicyResponse>, Status> {
         let request: SetPolicyRequest = request.into_inner();
 
+        info!("SetPolicy API called.");
         debug!("SetPolicyInput: {}", &request.input);
 
         let set_policy_input: SetPolicyInput = serde_json::from_str(&request.input)
@@ -89,6 +90,7 @@ impl AttestationService for Arc<RwLock<AttestationServer>> {
     ) -> Result<Response<AttestationResponse>, Status> {
         let request: AttestationRequest = request.into_inner();
 
+        info!("AttestationEvaluate API called.");
         debug!("Evidence: {}", &request.evidence);
 
         let tee = to_kbs_tee(
@@ -206,7 +208,8 @@ impl ReferenceValueProviderService for Arc<RwLock<AttestationServer>> {
     ) -> Result<Response<ReferenceValueRegisterResponse>, Status> {
         let request = request.into_inner();
 
-        info!("registry reference value: {}", request.message);
+        info!("RegisterReferenceValue API called.");
+        debug!("registry reference value: {}", request.message);
 
         let message = serde_json::from_str(&request.message)
             .map_err(|e| Status::aborted(format!("Parse message: {e}")))?;

--- a/attestation-service/attestation-service/src/bin/restful/mod.rs
+++ b/attestation-service/attestation-service/src/bin/restful/mod.rs
@@ -87,7 +87,7 @@ pub async fn attestation(
     request: web::Json<AttestationRequest>,
     cocoas: web::Data<Arc<RwLock<AttestationService>>>,
 ) -> Result<HttpResponse> {
-    info!("new attestation request.");
+    info!("Attestation API called.");
 
     let request = request.into_inner();
     debug!("attestation: {request:#?}");
@@ -159,7 +159,7 @@ pub async fn set_policy(
     input: web::Json<SetPolicyInput>,
     cocoas: web::Data<Arc<RwLock<AttestationService>>>,
 ) -> Result<HttpResponse> {
-    info!("set policy.");
+    info!("Set Policy API called.");
     let input = input.into_inner();
 
     debug!("set policy: {input:#?}");

--- a/attestation-service/attestation-service/src/policy_engine/opa/mod.rs
+++ b/attestation-service/attestation-service/src/policy_engine/opa/mod.rs
@@ -109,7 +109,7 @@ impl PolicyEngine for OPA {
                 unsafe { evaluateGo(policy_go, reference_go, input_go) };
             let decision_str: &CStr = unsafe { CStr::from_ptr(decision_buf) };
             let policy_res = decision_str.to_str()?.to_string();
-            debug!("Evaluated: {}", policy_res);
+            debug!("OPA Evaluated: {}", policy_res);
             if policy_res.starts_with("Error::") {
                 bail!("OPA verification failed: {policy_res}");
             }

--- a/attestation-service/attestation-service/src/token/mod.rs
+++ b/attestation-service/attestation-service/src/token/mod.rs
@@ -7,7 +7,7 @@ use anyhow::*;
 use serde::Deserialize;
 use serde_json::Value;
 use simple::COCO_AS_ISSUER_NAME;
-use strum::EnumString;
+use strum::{Display, EnumString};
 
 mod simple;
 
@@ -23,7 +23,7 @@ pub trait AttestationTokenBroker {
     fn pubkey_jwks(&self) -> Result<String>;
 }
 
-#[derive(Deserialize, Debug, Clone, EnumString)]
+#[derive(Deserialize, Debug, Clone, EnumString, Display)]
 pub enum AttestationTokenBrokerType {
     Simple,
 }

--- a/attestation-service/verifier/src/lib.rs
+++ b/attestation-service/verifier/src/lib.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use anyhow::*;
 use async_trait::async_trait;
 use kbs_types::Tee;
-use log::warn;
+use log::debug;
 
 pub mod sample;
 
@@ -159,14 +159,14 @@ fn regularize_data(data: &[u8], len: usize, data_name: &str, arch: &str) -> Vec<
     let data_len = data.len();
     match data_len.cmp(&len) {
         Ordering::Less => {
-            warn!("The input {data_name} of {arch} is shorter than {len} bytes, will be padded with '\\0'.");
+            debug!("The input {data_name} of {arch} is shorter than {len} bytes, will be padded with '\\0'.");
             let mut data = data.to_vec();
             data.resize(len, b'\0');
             data
         }
         Ordering::Equal => data.to_vec(),
         Ordering::Greater => {
-            warn!("The input {data_name} of {arch} is longer than {len} bytes, will be truncated to {len} bytes.");
+            debug!("The input {data_name} of {arch} is longer than {len} bytes, will be truncated to {len} bytes.");
             data[..len].to_vec()
         }
     }

--- a/attestation-service/verifier/src/tdx/claims.rs
+++ b/attestation-service/verifier/src/tdx/claims.rs
@@ -169,8 +169,6 @@ pub fn generate_parsed_claim(
     let mut ccel_map = Map::new();
     if let Some(ccel) = cc_eventlog {
         parse_ccel(ccel, &mut ccel_map)?;
-    } else {
-        warn!("parse CC EventLog: CCEL is null");
     }
 
     let mut claims = Map::new();
@@ -180,7 +178,8 @@ pub fn generate_parsed_claim(
     parse_claim!(claims, "report_data", quote.report_data());
     parse_claim!(claims, "init_data", quote.mr_config_id());
 
-    log::info!("\nParsed Evidence claims map: \n{:?}\n", &claims);
+    let claims_str = serde_json::to_string_pretty(&claims)?;
+    debug!("Parsed Evidence claims map: \n{claims_str}\n");
 
     Ok(Value::Object(claims) as TeeEvidenceParsedClaim)
 }

--- a/attestation-service/verifier/src/tdx/mod.rs
+++ b/attestation-service/verifier/src/tdx/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use log::{debug, warn};
+use log::{debug, error, info, warn};
 
 use crate::tdx::claims::generate_parsed_claim;
 
@@ -52,10 +52,12 @@ async fn verify_evidence(
     let quote_bin = base64::engine::general_purpose::STANDARD.decode(evidence.quote)?;
     ecdsa_quote_verification(quote_bin.as_slice()).await?;
 
+    info!("Quote DCAP check succeeded.");
+
     // Parse quote and Compare report data
     let quote = parse_tdx_quote(&quote_bin)?;
 
-    log::info!("{}\n", &quote);
+    debug!("{quote}");
 
     if let ReportData::Value(expected_report_data) = expected_report_data {
         debug!("Check the binding of REPORT_DATA.");
@@ -70,9 +72,12 @@ async fn verify_evidence(
         let expected_init_data_hash =
             regularize_data(expected_init_data_hash, 48, "MRCONFIGID", "TDX");
         if expected_init_data_hash != quote.mr_config_id() {
+            error!("MRCONFIGID (Initdata) verification failed.");
             bail!("MRCONFIGID is different from that in TDX Quote");
         }
     }
+
+    info!("MRCONFIGID check succeeded.");
 
     // Verify Integrity of CC Eventlog
     let mut ccel_option = Option::default();
@@ -93,9 +98,10 @@ async fn verify_evidence(
             };
 
             ccel.integrity_check(rtmr_from_quote)?;
+            info!("CCEL integrity check succeeded.");
         }
         None => {
-            warn!("There is no CC EventLog in Evidence!!!");
+            warn!("No CC Eventlog included inside the TDX evidence.");
         }
     }
 

--- a/kbs/src/api/src/http/attest.rs
+++ b/kbs/src/api/src/http/attest.rs
@@ -9,7 +9,7 @@ use super::*;
 use anyhow::anyhow;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
-use log::{error, info};
+use log::{debug, error, info};
 use serde_json::json;
 
 /// POST /auth
@@ -18,7 +18,8 @@ pub(crate) async fn auth(
     map: web::Data<SessionMap>,
     timeout: web::Data<i64>,
 ) -> Result<HttpResponse> {
-    info!("request: {:?}", &request);
+    info!("Auth API called.");
+    debug!("Auth Request: {:?}", &request);
 
     let session = SessionStatus::auth(request.0, **timeout)
         .map_err(|e| Error::FailedAuthentication(format!("Session: {e}")))?;
@@ -39,6 +40,7 @@ pub(crate) async fn attest(
     map: web::Data<SessionMap>,
     attestation_service: web::Data<Arc<AttestationService>>,
 ) -> Result<HttpResponse> {
+    info!("Attest API called.");
     let cookie = request.cookie(KBS_SESSION_ID).ok_or(Error::MissingCookie)?;
 
     let (tee, nonce) = {
@@ -49,7 +51,10 @@ pub(crate) async fn attest(
             .ok_or(Error::InvalidCookie)?;
         let session = session.get();
 
-        info!("Cookie {} attestation {:?}", session.id(), attestation);
+        debug!("Session ID {}", session.id());
+        let attestation_str = serde_json::to_string_pretty(&attestation.0)
+            .map_err(|_| Error::AttestationFailed("Failed to serialize Attestation".into()))?;
+        debug!("Attestation: {attestation_str}");
 
         if session.is_expired() {
             raise_error!(Error::ExpiredCookie);

--- a/kbs/src/api/src/http/error.rs
+++ b/kbs/src/api/src/http/error.rs
@@ -13,6 +13,7 @@ use actix_web::{
     HttpResponse, Responder, ResponseError,
 };
 use kbs_types::ErrorInformation;
+use log::error;
 use serde::Serialize;
 use strum_macros::AsRefStr;
 use thiserror::Error;
@@ -115,6 +116,8 @@ impl ResponseError for Error {
             Error::ReadSecretFailed(_) => HttpResponse::NotFound(),
             _ => HttpResponse::Unauthorized(),
         };
+
+        error!("{self}");
 
         res.body(BoxBody::new(body))
     }

--- a/kbs/src/api/src/policy_engine/opa/mod.rs
+++ b/kbs/src/api/src/policy_engine/opa/mod.rs
@@ -82,7 +82,7 @@ impl PolicyEngineInterface for Opa {
             unsafe { evaluateGo(policy_go, resource_path_go, input_go) };
         let decision_str: &CStr = unsafe { CStr::from_ptr(decision_buf) };
         let res = decision_str.to_str()?.to_string();
-        log::debug!("Evaluated: {}", res);
+        log::debug!("OPA Evaluated: {}", res);
         if res.starts_with("Error::") {
             return Err(anyhow!(res));
         }


### PR DESCRIPTION
This PR mainly optimize the logs of both AS and KBS. including:
- make logs more readable
- make detailed and long logs as "debug" level, and brief logs as "info" level.

Examples.

Before this PR
```log
[2024-04-07T06:15:35Z INFO  api_server::http::attest] Cookie 9c47605b5f7d42bca784b5024e071d65 attestation Json(Attestation { tee_pubkey: TeePubKey { kty: "RSA", alg: "RSA1_5", k_mod: "rWKEKFCeBQrTwQgy6QR3lhzKFxqZiZuwhoetIRkuSPNgQJC8UmP5k6uwFGbF81xyNX3FDbbYhq0zsAqDyoDBPhhpl5nTg0D2_5JX7G20ky_eT6hFuNcoHNflmmJxPJmF1A1uqNX-xwAq2XCeWF0bZ10p6o9cNJ_PG0NIlrvHjQavf1tyfn59jfc_PrrtP1q6Kkq-155IJ3p7yFHyhnyT05R_soJ7hDknYgVDX-KeqCheSD_67hZAMFn7gIF-DAu47fW3KzssC1J7P5VgBaB8d3o2qeKTAwbOkHjgw3VmcXBYt4-d2DoXr489w8ZLNBstx0XRsUz2hi9QA_8xlHSyNw", k_exp: "AQAB" }, tee_evidence: "{\"cc_eventlog\":null,\"quote\":\"BQACAIEAAAAAAAAAk5pyM/ecTKmUCg2zlX8GB9osfjJsVpaImmpqtPimSxcAAAAAAwCIAgAABQECAAAAAAAAAAAAAAAAABzGoXq3memmk/rHU2vmHBLuHg+rragtDJmeCMzuKqht53sIcPVYxXDn/+VdbUf6BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAADnQgYAAAAAAN+6IhtIoir4URVC7nlmA/NzgoAIQNzZeHA5Cb+OZNTIoenehufJY4v8ukIvOIZACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJtSnzaJ4ujruJnpq7vD2rOU1lRejNsooqu5zC83e4OmXAG6VrgkzT7ohd8gBR9RKB24qnPEc3sKO6NCR5hkTQVb6nq9T/zV5GfkqzRPaojGr3tNQK+CnAPpnBfpa2M6HwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2CBfOx6fXvMhXu6KgECBrIHKtNoZA1HvFZhtgmNxG3vvFJXXcMueS9GhigW69hOwAAAAAAAAAAAAAAAAAAAAAFAQIAAAAAAAAAAAAAAAAAODyH07uwR7LRcerKlTEu3pnyWAiNx4j2rizPi23YSP6NR2KeCLP2y9SgDdR6WgM9zBAAALJhWTviMLFRQrTJH0rZX4NLCCetjdV52vemGh2jnL0ZDLQAhN4KwxPR/DDRCM7JBlxC6dDCoJMnu2KMSdTBHD7dkYh6RhFwsM8f5hEgwoSQG7DDvQNY5D4dnQ9XonMfm9ey5rsXo5lbjLb4DR9HCJaR/IsfrNXhXVE50MZEpAbQBgBGEAAAAgIYGgP/AAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAAAAAAADnAAAAAAAAAOWjp7XYMMKVO5hTTGxZo6NP3DTpM/f1iY8Khc8IhGvKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADcnip8b5SPF0dONKf8Q+0DD3wVY/G6vd9jQMguDlSoxQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABL2UGrT+loMaDjo7e7oMLmikl/wwWR66S0dUQQFc0CgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0eN7DaC2STro34OFM9/cFxu3htS8047yQ+WgorK7GL4COVgGWWHhUuJYC6o4wM8snfIUzAIT8sJyQ6TA9hUpAiAAAAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8FAF4OAAAtLS0tLUJFR0lOIENFUlRJRklDQVRFLS0tLS0KTUlJRThEQ0NCSmVnQXdJQkFnSVZBSzBLbkJqY0FPUU10dFArZlRuRlU5MC9vbEdMTUFvR0NDcUdTTTQ5QkFNQwpNSEF4SWpBZ0JnTlZCQU1NR1VsdWRHVnNJRk5IV0NCUVEwc2dVR3hoZEdadmNtMGdRMEV4R2pBWUJnTlZCQW9NCkVVbHVkR1ZzSUVOdmNuQnZjbUYwYVc5dU1SUXdFZ1lEVlFRSERBdFRZVzUwWVNCRGJHRnlZVEVMTUFrR0ExVUUKQ0F3Q1EwRXhDekFKQmdOVkJBWVRBbFZUTUI0WERUSTBNRE14T0RBNE5ETTFNVm9YRFRNeE1ETXhPREE0TkRNMQpNVm93Y0RFaU1DQUdBMVVFQXd3WlNXNTBaV3dnVTBkWUlGQkRTeUJEWlhKMGFXWnBZMkYwWlRFYU1CZ0dBMVVFCkNnd1JTVzUwWld3Z1EyOXljRzl5WVhScGIyNHhGREFTQmdOVkJBY01DMU5oYm5SaElFTnNZWEpoTVFzd0NRWUQKVlFRSURBSkRRVEVMTUFrR0ExVUVCaE1DVlZNd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFRVQorUlNPT1dlQndCbFJNYnRLeXVrWXRPdE95VDhRdGpweUt5OXpSa09lYmZ1WWtxMkRUelhsallMUzV3OTRraVVFClpINXdNRHhHaDYwcVhLcTZoVTZIbzRJREREQ0NBd2d3SHdZRFZSMGpCQmd3Rm9BVWxXOWR6YjBiNGVsQVNjblUKOURQT0FWY0wzbFF3YXdZRFZSMGZCR1F3WWpCZ29GNmdYSVphYUhSMGNITTZMeTloY0drdWRISjFjM1JsWkhObApjblpwWTJWekxtbHVkR1ZzTG1OdmJTOXpaM2d2WTJWeWRHbG1hV05oZEdsdmJpOTJNeTl3WTJ0amNtdy9ZMkU5CmNHeGhkR1p2Y20wbVpXNWpiMlJwYm1jOVpHVnlNQjBHQTFVZERnUVdCQlFjU3BjYitJRHR6bHhrUTZESm9ObWIKL2VZamV6QU9CZ05WSFE4QkFmOEVCQU1DQnNBd0RBWURWUjBUQVFIL0JBSXdBRENDQWprR0NTcUdTSWI0VFFFTgpBUVNDQWlvd2dnSW1NQjRHQ2lxR1NJYjRUUUVOQVFFRUVQQnBoTWpaTkRSU3VaZkVpemJXNW5nd2dnRmpCZ29xCmhraUcrRTBCRFFFQ01JSUJVekFRQmdzcWhraUcrRTBCRFFFQ0FRSUJBVEFRQmdzcWhraUcrRTBCRFFFQ0FnSUIKQVRBUUJnc3Foa2lHK0UwQkRRRUNBd0lCQWpBUUJnc3Foa2lHK0UwQkRRRUNCQUlCQWpBUUJnc3Foa2lHK0UwQgpEUUVDQlFJQkF6QVFCZ3NxaGtpRytFMEJEUUVDQmdJQkFUQVFCZ3NxaGtpRytFMEJEUUVDQndJQkFEQVFCZ3NxCmhraUcrRTBCRFFFQ0NBSUJBekFRQmdzcWhraUcrRTBCRFFFQ0NRSUJBREFRQmdzcWhraUcrRTBCRFFFQ0NnSUIKQURBUUJnc3Foa2lHK0UwQkRRRUNDd0lCQURBUUJnc3Foa2lHK0UwQkRRRUNEQUlCQURBUUJnc3Foa2lHK0UwQgpEUUVDRFFJQkFEQVFCZ3NxaGtpRytFMEJEUUVDRGdJQkFEQVFCZ3NxaGtpRytFMEJEUUVDRHdJQkFEQVFCZ3NxCmhraUcrRTBCRFFFQ0VBSUJBREFRQmdzcWhraUcrRTBCRFFFQ0VRSUJEVEFmQmdzcWhraUcrRTBCRFFFQ0VnUVEKQVFFQ0FnTUJBQU1BQUFBQUFBQUFBREFRQmdvcWhraUcrRTBCRFFFREJBSUFBREFVQmdvcWhraUcrRTBCRFFFRQpCQWFRd0c4QUFBQXdEd1lLS29aSWh2aE5BUTBCQlFvQkFUQWVCZ29xaGtpRytFMEJEUUVHQkJCcW5xTzQyZWMwClNWM0VDM0QxbGZsaE1FUUdDaXFHU0liNFRRRU5BUWN3TmpBUUJnc3Foa2lHK0UwQkRRRUhBUUVCL3pBUUJnc3EKaGtpRytFMEJEUUVIQWdFQi96QVFCZ3NxaGtpRytFMEJEUUVIQXdFQi96QUtCZ2dxaGtqT1BRUURBZ05IQURCRQpBaUJIeTI4WGxWZU1FODROTjZaVkNVZFFjdWhZUnJQcXV6UTIvL3JIMGJzQjhRSWdOZ0tERFQ0ZEI5WUlNWU9sCkdQamFlbjZocUR0d0JKazgwdkhQZmpFZU5xdz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQotLS0tLUJFR0lOIENFUlRJRklDQVRFLS0tLS0KTUlJQ2xqQ0NBajJnQXdJQkFnSVZBSlZ2WGMyOUcrSHBRRW5KMVBRenpnRlhDOTVVTUFvR0NDcUdTTTQ5QkFNQwpNR2d4R2pBWUJnTlZCQU1NRVVsdWRHVnNJRk5IV0NCU2IyOTBJRU5CTVJvd0dBWURWUVFLREJGSmJuUmxiQ0JECmIzSndiM0poZEdsdmJqRVVNQklHQTFVRUJ3d0xVMkZ1ZEdFZ1EyeGhjbUV4Q3pBSkJnTlZCQWdNQWtOQk1Rc3cKQ1FZRFZRUUdFd0pWVXpBZUZ3MHhPREExTWpFeE1EVXdNVEJhRncwek16QTFNakV4TURVd01UQmFNSEF4SWpBZwpCZ05WQkFNTUdVbHVkR1ZzSUZOSFdDQlFRMHNnVUd4aGRHWnZjbTBnUTBFeEdqQVlCZ05WQkFvTUVVbHVkR1ZzCklFTnZjbkJ2Y21GMGFXOXVNUlF3RWdZRFZRUUhEQXRUWVc1MFlTQkRiR0Z5WVRFTE1Ba0dBMVVFQ0F3Q1EwRXgKQ3pBSkJnTlZCQVlUQWxWVE1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRU5TQi83dDIxbFhTTwoyQ3V6cHh3NzRlSkI3MkV5REdnVzVyWEN0eDJ0VlRMcTZoS2s2eitVaVJaQ25xUjdwc092Z3FGZVN4bG1UbEpsCmVUbWkyV1l6M3FPQnV6Q0J1REFmQmdOVkhTTUVHREFXZ0JRaVpReldXcDAwaWZPRHRKVlN2MUFiT1NjR3JEQlMKQmdOVkhSOEVTekJKTUVlZ1JhQkRoa0ZvZEhSd2N6b3ZMMk5sY25ScFptbGpZWFJsY3k1MGNuVnpkR1ZrYzJWeQpkbWxqWlhNdWFXNTBaV3d1WTI5dEwwbHVkR1ZzVTBkWVVtOXZkRU5CTG1SbGNqQWRCZ05WSFE0RUZnUVVsVzlkCnpiMGI0ZWxBU2NuVTlEUE9BVmNMM2xRd0RnWURWUjBQQVFIL0JBUURBZ0VHTUJJR0ExVWRFd0VCL3dRSU1BWUIKQWY4Q0FRQXdDZ1lJS29aSXpqMEVBd0lEUndBd1JBSWdYc1ZraTB3K2k2VllHVzNVRi8yMnVhWGUwWUpEajFVZQpuQStUakQxYWk1Y0NJQ1liMVNBbUQ1eGtmVFZwdm80VW95aVNZeHJEV0xtVVI0Q0k5Tkt5ZlBOKwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLQpNSUlDanpDQ0FqU2dBd0lCQWdJVUltVU0xbHFkTkluemc3U1ZVcjlRR3prbkJxd3dDZ1lJS29aSXpqMEVBd0l3CmFERWFNQmdHQTFVRUF3d1JTVzUwWld3Z1UwZFlJRkp2YjNRZ1EwRXhHakFZQmdOVkJBb01FVWx1ZEdWc0lFTnYKY25CdmNtRjBhVzl1TVJRd0VnWURWUVFIREF0VFlXNTBZU0JEYkdGeVlURUxNQWtHQTFVRUNBd0NRMEV4Q3pBSgpCZ05WQkFZVEFsVlRNQjRYRFRFNE1EVXlNVEV3TkRVeE1Gb1hEVFE1TVRJek1USXpOVGsxT1Zvd2FERWFNQmdHCkExVUVBd3dSU1c1MFpXd2dVMGRZSUZKdmIzUWdRMEV4R2pBWUJnTlZCQW9NRVVsdWRHVnNJRU52Y25CdmNtRjAKYVc5dU1SUXdFZ1lEVlFRSERBdFRZVzUwWVNCRGJHRnlZVEVMTUFrR0ExVUVDQXdDUTBFeEN6QUpCZ05WQkFZVApBbFZUTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFQzZuRXdNRElZWk9qL2lQV3NDemFFS2k3CjFPaU9TTFJGaFdHamJuQlZKZlZua1k0dTNJamtEWVlMME14TzRtcXN5WWpsQmFsVFZZeEZQMnNKQks1emxLT0IKdXpDQnVEQWZCZ05WSFNNRUdEQVdnQlFpWlF6V1dwMDBpZk9EdEpWU3YxQWJPU2NHckRCU0JnTlZIUjhFU3pCSgpNRWVnUmFCRGhrRm9kSFJ3Y3pvdkwyTmxjblJwWm1sallYUmxjeTUwY25WemRHVmtjMlZ5ZG1salpYTXVhVzUwClpXd3VZMjl0TDBsdWRHVnNVMGRZVW05dmRFTkJMbVJsY2pBZEJnTlZIUTRFRmdRVUltVU0xbHFkTkluemc3U1YKVXI5UUd6a25CcXd3RGdZRFZSMFBBUUgvQkFRREFnRUdNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUV3Q2dZSQpLb1pJemowRUF3SURTUUF3UmdJaEFPVy81UWtSK1M5Q2lTRGNOb293THVQUkxzV0dmL1lpN0dTWDk0Qmd3VHdnCkFpRUE0SjBsckhvTXMrWG81by9zWDZPOVFXeEhSQXZaVUdPZFJRN2N2cVJYYXFJPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCgA=\"}" })
[2024-04-07T06:15:35Z INFO  actix_web::middleware::logger] 8.147.116.39 "POST /kbs/v0/attest HTTP/1.1" 200 4943 "-" "attestation-agent-kbs-client/0.1.0" 0.028964
[2024-04-07T06:15:35Z INFO  api_server::http::resource] Get pkey from auth header
[2024-04-07T06:15:35Z WARN  api_server::token::coco] No Trusted Certificate in Config, skip verification of JWK cert of Attestation Token
[2024-04-07T06:15:35Z INFO  api_server::http::resource] Resource description: ResourceDesc { repository_name: "default", resource_type: "aliyun", resource_tag: "ecs_ram_role" }
[2024-04-07T06:15:35Z DEBUG api_server::policy_engine::opa] Evaluated: {"allow":true}
[2024-04-07T06:15:35Z INFO  actix_web::middleware::logger] 8.147.116.39 "GET /kbs/v0/resource/default/aliyun/ecs_ram_role HTTP/1.1" 200 585 "-" "attestation-agent-kbs-client/0.1.0" 0.005432
```

After this PR
```log
[2024-04-08T08:57:17Z INFO  actix_web::middleware::logger] 59.82.45.9 "POST /kbs/v0/auth HTTP/1.1" 200 74 "-" "attestation-agent-kbs-client/0.1.0" 0.000079
[2024-04-08T08:57:17Z INFO  api_server::http::attest] Attest API called.
[2024-04-08T08:57:17Z DEBUG api_server::http::attest] Session ID f871be1200ca4bd8aa5b64deec2086c2
[2024-04-08T08:57:17Z DEBUG api_server::http::attest] Attestation: {
      "tee-pubkey": {
        "kty": "RSA",
        "alg": "RSA1_5",
        "n": "wItTt8dSiq6KkQp0bAvdEpTcHZlIyNVfCjBXPyjOvP-aJpLK4nxYBBdvrvGkmSU4Uj1WClrNl4GeTlju05JKgpRhm1-jDQSr-xRTn1PEmT9ywNdruGhaOu9rjVlYKA2JR5Wlt3oc25dn88rxDWteQfyuSjdQvpCcwQsg9fCGxZwng86MZ8JGcMYaBBylyghkrruucYXMMU1ktAQbrEvIeTTuJnwAYczC5mbZJYbqvQcgIYuZ61-U-lbUNM4KuVTUWR7MN57u-4ftcYKWq2RlEmRrmaSPASlHJrdBXihbusJ2uabJOSJZZxAiy4k2I322rfYl2Z_RjckP0ocR-JCAow",
        "e": "AQAB"
      },
      "tee-evidence": "{\"svn\":\"1\",\"report_data\":\"O56zADB1kqZcKkYUQSYecoC6uMQjQuP/+6LxwCeFN2jSAU3fw6XI3580ihdB2pZN\"}"
    }
[2024-04-08T08:57:17Z INFO  actix_web::middleware::logger] 59.82.45.9 "POST /kbs/v0/attest HTTP/1.1" 200 2218 "-" "attestation-agent-kbs-client/0.1.0" 0.003992
[2024-04-08T08:57:18Z DEBUG api_server::http::resource] Get pkey from auth header
[2024-04-08T08:57:18Z WARN  api_server::token::coco] No Trusted Certificate in Config, skip verification of JWK cert of Attestation Token
[2024-04-08T08:57:18Z INFO  api_server::http::resource] Get resource from kbs:///default/key/ssh-demo
[2024-04-08T08:57:18Z DEBUG api_server::policy_engine::opa] OPA Evaluated: {"allow":true}
[2024-04-08T08:57:18Z INFO  api_server::http::resource] Resource access request passes policy check.
[2024-04-08T08:57:18Z INFO  actix_web::middleware::logger] 59.82.45.9 "GET /kbs/v0/resource/default/key/ssh-demo HTTP/1.1" 200 530 "-" "attestation-agent-kbs-client/0.1.0" 0.001344
```

