### PR TITLE
docker: Use Ubuntu 22.04 as kbs base image

### DIFF
--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -40,7 +40,7 @@ COPY . .
 ARG KBS_FEATURES=coco-as-builtin,rustls,resource,opa
 RUN cargo install --locked --path kbs/src/kbs --no-default-features --features ${KBS_FEATURES}
 
-FROM debian:stable-slim
+FROM ubuntu:22.04
 
 RUN apt-get update && \
     apt-get install -y \
@@ -51,12 +51,11 @@ RUN apt-get update && \
 # Install TDX Runtime Dependencies
 RUN curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
     gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
-RUN echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | tee /etc/apt/sources.list.d/intel-sgx.list
+RUN echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
     libsgx-dcap-default-qpl \
     libsgx-dcap-quote-verify \
-    libtdx-attest \
     tpm2-tools
 
 # Intel PCCS URL Configurations


### PR DESCRIPTION
related to: #153

When using debian:stable-slim as a base image the sgx verification libraries will crash when attempting to fetch an sgx collateral during td quote validation.

Using Ubuntu 22.04 as a base image fixes the crash, and is consistent with AS which uses the same base image.

(discussion [here](https://cloud-native.slack.com/archives/C039JSH0807/p1713270650840409?thread_ts=1713264500.545019&cid=C039JSH0807))

Also removed the tdx attest lib which is not required for verification and pointed the sgx repo to the correct ubuntu version.