### PR TITLE
k8s-config: Add support for NodePort service type

### DIFF
--- a/kbs/config/kubernetes/README.md
+++ b/kbs/config/kubernetes/README.md
@@ -44,6 +44,20 @@ kustomize edit add resource ingress.yaml
 popd
 ```
 
+## Optional: Expose KBS using Nodeport
+
+If you would like to expose KBS service using Nodeport then export the following environment variable:
+
+```bash
+export DEPLOYMENT_DIR=nodeport
+```
+
+Once you deploy the KBS, you can use the services' nodeport and the Kubernetes node's IP to reach out to the KBS. You can generate the KBS URL by running the following command:
+
+```bash
+echo $(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}'):$(kubectl get svc kbs -n coco-tenant -o jsonpath='{.spec.ports[0].nodePort}')
+```
+
 ## Deploy KBS
 
 Deploy KBS by running the following command:

--- a/kbs/config/kubernetes/deploy-kbs.sh
+++ b/kbs/config/kubernetes/deploy-kbs.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Environment variable that defines which directory to use the kustomization file for deployment.
+DEPLOYMENT_DIR="${DEPLOYMENT_DIR:-overlays}"
+
 k8s_cnf_dir="$(dirname ${BASH_SOURCE[0]})"
 
 # Fail the script if the key.bin file does not exist.
@@ -18,4 +21,4 @@ kbs_cert="${k8s_cnf_dir}/base/kbs.pem"
     openssl pkey -in "${k8s_cnf_dir}/base/kbs.key" -pubout -out "${kbs_cert}"
 }
 
-kubectl apply -k "./${k8s_cnf_dir}/overlays"
+kubectl apply -k "./${k8s_cnf_dir}/${DEPLOYMENT_DIR}"

--- a/kbs/config/kubernetes/nodeport/kustomization.yaml
+++ b/kbs/config/kubernetes/nodeport/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: coco-tenant
+
+resources:
+- ../overlays
+
+patches:
+- path: patch.yaml
+  target:
+    group: ""
+    kind: Service
+    name: kbs

--- a/kbs/config/kubernetes/nodeport/patch.yaml
+++ b/kbs/config/kubernetes/nodeport/patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/type
+  value: NodePort


### PR DESCRIPTION
Right now the KBS service is only exposed as the
ClusterIP service type. And to be able to really
use the KBS service you need to expose it using an Ingress, but this is not always feasible. So this
commit adds a way for the KBS service to be
exposed as a NodePort service type.