### PR TITLE
k8s: docs: DCAP kustomization + non-release images

### DIFF
--- a/kbs/config/kubernetes/README.md
+++ b/kbs/config/kubernetes/README.md
@@ -58,6 +58,16 @@ Once you deploy the KBS, you can use the services' nodeport and the Kubernetes n
 echo $(kubectl get nodes -o jsonpath='{.items[0].status.addresses[0].address}'):$(kubectl get svc kbs -n coco-tenant -o jsonpath='{.spec.ports[0].nodePort}')
 ```
 
+## Optional: Use custom Intel DCAP configuration
+
+If you would like to override the default `sgx_default_qcnl.conf` in the KBS/AS images, copy/configure one into `custom_pccs/` directory and deploy using:
+
+```bash
+export DEPLOYMENT_DIR=custom_pccs
+```
+
+NB: this currently builds on `nodeport` kustomization.
+
 ## Deploy KBS
 
 Deploy KBS by running the following command:

--- a/kbs/config/kubernetes/README.md
+++ b/kbs/config/kubernetes/README.md
@@ -44,6 +44,19 @@ kustomize edit add resource ingress.yaml
 popd
 ```
 
+## Optional: Use non-release images
+
+Sometimes it may be desirable to deploy KBS with an image that is not what is set in the repo (typically
+the latest release image). To change the deployment to use a staging build, set the image using `kustomize`:
+
+```bash
+pushd base
+kustomize edit set image kbs-container-image=ghcr.io/confidential-containers/staged-images/kbs:65ee7e1acccd13dcb515058e71c5f8bfb4281e35
+popd
+```
+
+The available image tags can be found in the [CoCo packages listing](https://github.com/orgs/confidential-containers/packages?repo_name=trustee).
+
 ## Optional: Expose KBS using Nodeport
 
 If you would like to expose KBS service using Nodeport then export the following environment variable:

--- a/kbs/config/kubernetes/custom_pccs/kustomization.yaml
+++ b/kbs/config/kubernetes/custom_pccs/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: coco-tenant
+
+resources:
+- ../nodeport
+
+patches:
+- path: set_custom_pccs.yaml
+  target:
+    kind: Deployment
+    name: kbs
+
+configMapGenerator:
+- files:
+  - sgx_default_qcnl.conf
+  name: dcap-attestation-conf

--- a/kbs/config/kubernetes/custom_pccs/set_custom_pccs.yaml
+++ b/kbs/config/kubernetes/custom_pccs/set_custom_pccs.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kbs
+spec:
+  template:
+    spec:
+      containers:
+      - name: kbs
+        volumeMounts:
+        - name: qplconf
+          mountPath: /etc/sgx_default_qcnl.conf
+          subPath: sgx_default_qcnl.conf
+      volumes:
+      - name: qplconf
+        configMap:
+          name: dcap-attestation-conf
+          items:
+          - key: sgx_default_qcnl.conf
+            path: sgx_default_qcnl.conf

--- a/kbs/config/kubernetes/custom_pccs/sgx_default_qcnl.conf
+++ b/kbs/config/kubernetes/custom_pccs/sgx_default_qcnl.conf
@@ -1,0 +1,1 @@
+{"collateral_service": "https://api.trustedservices.intel.com/sgx/certification/v4/"}


### PR DESCRIPTION
The KBS crash problem (ee1a8cebb6) was difficult to debug with the "built-in-as" image since all the logs from AS were lost.

Make the k8s sample deployment to use AS separately. This also makes it aligned with what docker-compose offers by default.