### PR TITLE
KBS: fix session status

### DIFF
--- a/kbs/src/api/src/session.rs
+++ b/kbs/src/api/src/session.rs
@@ -38,6 +38,7 @@ pub(crate) enum SessionStatus {
 
     Attested {
         attestation_claims: String,
+        token: String,
         id: String,
         timeout: OffsetDateTime,
     },
@@ -105,11 +106,12 @@ impl SessionStatus {
         return *self.timeout() < OffsetDateTime::now_utc();
     }
 
-    pub fn attest(&mut self, attestation_claims: String) {
+    pub fn attest(&mut self, attestation_claims: String, token: String) {
         match self {
             SessionStatus::Authed { id, timeout, .. } => {
                 *self = SessionStatus::Attested {
                     attestation_claims,
+                    token,
                     id: id.clone(),
                     timeout: *timeout,
                 };


### PR DESCRIPTION
When an attested session sends a new attest request, the session should not do anything else but only return the old token if it is still valid. 

Close #374