### PR TITLE
Enable artifacts for s390x

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels:
+    - s390x

--- a/.github/workflows/as-build-and-push.yaml
+++ b/.github/workflows/as-build-and-push.yaml
@@ -7,10 +7,18 @@ on:
 
 jobs:
   build_and_push:
-    runs-on: ubuntu-latest
+    permissions:
+      packages: write
     strategy:
       fail-fast: false
       matrix:
+        instance:
+          - ubuntu-latest
+          - s390x
+        tag:
+          - coco-as-grpc
+          - coco-as-restful
+          - rvps
         include:
           - docker_file: attestation-service/Dockerfile.as-grpc
             tag: coco-as-grpc
@@ -21,8 +29,17 @@ jobs:
           - docker_file: attestation-service/rvps/Dockerfile
             tag: rvps
             name: RVPS
+    runs-on: ${{ matrix.instance }}
 
     steps:
+    - name: Take a pre-action for self-hosted runner
+      run: |
+        # NOTE: Use file checking instead triggering a step based on a runner type
+        # to avoid updating the step for each new self-hosted runner.
+        if [ -f "${HOME}/script/pre_action.sh" ]; then
+          "${HOME}/script/pre_action.sh" cc-trustee
+        fi
+
     - name: Checkout code
       uses: actions/checkout@v4
 
@@ -39,4 +56,57 @@ jobs:
     - name: Build ${{ matrix.name }} Container Image
       run: |
         commit_sha=${{ github.sha }}
-        DOCKER_BUILDKIT=1 docker build -t ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha} -t ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest . -f ${{ matrix.docker_file }} --push
+        arch=$(uname -m)
+        DOCKER_BUILDKIT=1 docker build -f ${{ matrix.docker_file }} --push --build-arg ARCH=${arch} \
+          -t ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch} \
+          -t ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch} .
+
+    - name: Take a post-action for self-hosted runner
+      if: always()
+      run: |
+        # Please check out the note in the pre-action step for the reason of using file checking
+        if [ -f "${HOME}/script/post_action.sh" ]; then
+          "${HOME}/script/post_action.sh" cc-trustee
+        fi
+
+  publish_multi_arch_image:
+    needs: build_and_push
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - coco-as-grpc
+          - coco-as-restful
+          - rvps
+        include:
+          - tag: coco-as-grpc
+            name: gRPC CoCo-AS
+          - tag: coco-as-restful
+            name: RESTful CoCo-AS
+          - tag: rvps
+            name: RVPS
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GHCR Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Publish Multi-arch Image for ${{ matrix.name }}
+      run: |
+        commit_sha=${{ github.sha }}
+        docker manifest create ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha} \
+          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-s390x \
+          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-x86_64
+        docker manifest push ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}
+        docker manifest create ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest \
+          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-s390x \
+          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-x86_64
+        docker manifest push ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest

--- a/.github/workflows/kbs-build-and-push.yaml
+++ b/.github/workflows/kbs-build-and-push.yaml
@@ -7,9 +7,37 @@ on:
 
 jobs:
   build_and_push:
-    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        instance:
+          - ubuntu-latest
+          - s390x
+        tag:
+          - kbs
+          - kbs-grpc-as
+        include:
+          - tag: kbs
+            docker_file: kbs/docker/Dockerfile
+            https_crypto: openssl
+            name: build-in AS
+          - tag: kbs-grpc-as
+            docker_file: kbs/docker/Dockerfile.coco-as-grpc
+            https_crypto: rustls
+            name: gRPC AS
+    runs-on: ${{ matrix.instance }}
 
     steps:
+    - name: Take a pre-action for self-hosted runner
+      run: |
+        # NOTE: Use file checking instead triggering a step based on a runner type
+        # to avoid updating the step for each new self-hosted runner.
+        if [ -f "${HOME}/script/pre_action.sh" ]; then
+          "${HOME}/script/pre_action.sh" cc-trustee
+        fi
+
     - name: Checkout code
       uses: actions/checkout@v4
 
@@ -23,12 +51,53 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build Container Image KBS (built-in AS)
+    - name: Build Container Image KBS (${{ matrix.name }})
       run: |
         commit_sha=${{ github.sha }}
-        DOCKER_BUILDKIT=1 docker build -t ghcr.io/confidential-containers/staged-images/kbs:${commit_sha} -t ghcr.io/confidential-containers/staged-images/kbs:latest --build-arg KBS_FEATURES=coco-as-builtin,openssl,resource,opa . -f kbs/docker/Dockerfile --push
+        arch=$(uname -m)
+        https_crypto=${{ matrix.https_crypto }}
+        [ "${arch}" = "s390x" ] && https_crypto=openssl
+        DOCKER_BUILDKIT=1 docker build -f ${{ matrix.docker_file }} --push \
+          -t ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch} \
+          -t ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch} \
+          --build-arg ARCH=${arch} --build-arg HTTPS_CRYPTO=${https_crypto} .
 
-    - name: Build Container Image KBS (gRPC AS)
+    - name: Take a post-action for self-hosted runner
+      if: always()
+      run: |
+        # Please check out the note in the pre-action step for the reason of using file checking
+        if [ -f "${HOME}/script/post_action.sh" ]; then
+          "${HOME}/script/post_action.sh" cc-trustee
+        fi
+
+  publish_multi_arch_image:
+    needs: build_and_push
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - kbs
+          - kbs-grpc-as
+    permissions:
+      packages: write
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Login to GHCR Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Publish Multi-Arch ${{ matrix.image }} image
       run: |
         commit_sha=${{ github.sha }}
-        DOCKER_BUILDKIT=1 docker build -t ghcr.io/confidential-containers/staged-images/kbs-grpc-as:${commit_sha} -t ghcr.io/confidential-containers/staged-images/kbs-grpc-as:latest . -f kbs/docker/Dockerfile.coco-as-grpc --push
+        docker manifest create ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha} \
+          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}-x86_64 \
+          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}-s390x
+        docker manifest push ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}
+        docker manifest create ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest \
+          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest-x86_64 \
+          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest-s390x
+        docker manifest push ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest

--- a/.github/workflows/kbs-client-build-and-push.yaml
+++ b/.github/workflows/kbs-client-build-and-push.yaml
@@ -7,14 +7,28 @@ on:
 
 jobs:
   build_and_push:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - x86_64
+          - s390x
     env:
       RUSTC_VERSION: 1.76.0
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-22.04' || 's390x' }}
     permissions:
       contents: read
       packages: write
 
     steps:
+    - name: Take a pre-action for self-hosted runner
+      run: |
+        # NOTE: Use file checking instead triggering a step based on a runner type
+        # to avoid updating the step for each new self-hosted runner.
+        if [ -f "${HOME}/script/pre_action.sh" ]; then
+          "${HOME}/script/pre_action.sh" cc-trustee
+        fi
+
     - name: Check out code
       uses: actions/checkout@v4
     - name: Install rust toolchain
@@ -29,14 +43,23 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build a statically linked kbs-client for x86_64 linux
+    - name: Build a statically linked kbs-client for ${{ matrix.arch }} linux
       working-directory: kbs
       run: |
-        make cli-static-x86_64-linux
+        make cli-static-linux
     - name: Push to ghcr.io
-      working-directory: target/x86_64-unknown-linux-gnu/release
+      working-directory: target/${{ matrix.arch }}-unknown-linux-gnu/release
       run: |
         commit_sha=${{ github.sha }}
         oras push \
-          ghcr.io/confidential-containers/staged-images/kbs-client:sample_only-x86_64-linux-gnu-${commit_sha},latest \
+          ghcr.io/confidential-containers/staged-images/kbs-client:sample_only-${{ matrix.arch }}-linux-gnu-${commit_sha},latest-${{ matrix.arch }} \
           kbs-client
+        [ "$(uname -m)" = "x86_64" ] && oras push ghcr.io/confidential-containers/staged-images/kbs-client:latest kbs-client || true
+
+    - name: Take a post-action for self-hosted runner
+      if: always()
+      run: |
+        # Please check out the note in the pre-action step for the reason of using file checking
+        if [ -f "${HOME}/script/post_action.sh" ]; then
+          "${HOME}/script/post_action.sh" cc-trustee
+        fi

--- a/attestation-service/Dockerfile.as-grpc
+++ b/attestation-service/Dockerfile.as-grpc
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM rust:latest as builder
+ARG ARCH=x86_64
 
 WORKDIR /usr/src/attestation-service
 COPY . .
@@ -11,15 +12,16 @@ COPY . .
 RUN apt-get update && apt-get install -y protobuf-compiler clang libtss2-dev
 
 # Install TDX Build Dependencies
-RUN curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
+RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
-    apt-get update && apt-get install -y libsgx-dcap-quote-verify-dev
+    apt-get update && apt-get install -y libsgx-dcap-quote-verify-dev; fi
 
 # Build and Install gRPC attestation-service
 RUN cargo install --path attestation-service/attestation-service --bin grpc-as --features grpc-bin --locked
 
 
 FROM ubuntu:22.04
+ARG ARCH=x86_64
 
 LABEL org.opencontainers.image.source="https://github.com/confidential-containers/attestation-service"
 
@@ -27,14 +29,14 @@ LABEL org.opencontainers.image.source="https://github.com/confidential-container
 RUN apt-get update && apt-get install curl gnupg openssl -y && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-RUN curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
+RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     apt-get update && \
     apt-get install -y libsgx-dcap-default-qpl libsgx-dcap-quote-verify && \
-    rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+    rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*; fi
 
 # Copy TPM Runtime Dependencies
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libtss* /usr/lib/x86_64-linux-gnu
+COPY --from=builder /usr/lib/${ARCH}-linux-gnu/libtss* /usr/lib/${ARCH}-linux-gnu
 
 COPY --from=builder /usr/local/cargo/bin/grpc-as /usr/local/bin/grpc-as
 

--- a/attestation-service/Dockerfile.as-restful
+++ b/attestation-service/Dockerfile.as-restful
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM rust:latest as builder
+ARG ARCH=x86_64
 
 WORKDIR /usr/src/attestation-service
 COPY . .
@@ -11,14 +12,15 @@ COPY . .
 RUN apt-get update && apt-get install -y protobuf-compiler clang libtss2-dev
 
 # Install TDX Build Dependencies
-RUN curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
+RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
-    apt-get update && apt-get install -y libsgx-dcap-quote-verify-dev
+    apt-get update && apt-get install -y libsgx-dcap-quote-verify-dev; fi
 
 # Build and Install RESTful attestation-service
 RUN cargo install --path attestation-service/attestation-service --bin restful-as --features restful-bin --locked
 
 FROM ubuntu:22.04
+ARG ARCH=x86_64
 
 LABEL org.opencontainers.image.source="https://github.com/confidential-containers/attestation-service"
 
@@ -26,14 +28,14 @@ LABEL org.opencontainers.image.source="https://github.com/confidential-container
 RUN apt-get update && apt-get install curl gnupg openssl -y && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-RUN curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
+RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     apt-get update && \
     apt-get install -y libsgx-dcap-default-qpl libsgx-dcap-quote-verify && \
-    rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+    rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*; fi
 
 # Copy TPM Runtime Dependencies
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libtss* /usr/lib/x86_64-linux-gnu
+COPY --from=builder /usr/lib/${ARCH}-linux-gnu/libtss* /usr/lib/${ARCH}-linux-gnu
 
 COPY --from=builder /usr/local/cargo/bin/restful-as /usr/local/bin/restful-as
 

--- a/attestation-service/attestation-service/Cargo.toml
+++ b/attestation-service/attestation-service/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = [ "restful-bin", "rvps-grpc", "rvps-builtin", "all-verifier" ]
+default = [ "restful-bin", "rvps-grpc", "rvps-builtin" ]
 all-verifier = [ "verifier/all-verifier" ]
 tdx-verifier = [ "verifier/tdx-verifier" ]
 sgx-verifier = [ "verifier/sgx-verifier" ]
@@ -64,7 +64,12 @@ thiserror = { workspace = true, optional = true }
 tokio.workspace = true
 tonic = { workspace = true, optional = true }
 uuid = { version = "1.1.2", features = ["v4"] }
-verifier = { path = "../verifier", default-features = false }
+
+[target.'cfg(not(target_arch = "s390x"))'.dependencies]
+verifier = { path = "../verifier", default-features = false, features = ["all-verifier"] }
+
+[target.'cfg(target_arch = "s390x")'.dependencies]
+verifier = { path = "../verifier", default-features = false, features = ["se-verifier"] }
 
 [build-dependencies]
 shadow-rs.workspace = true

--- a/kbs/Makefile
+++ b/kbs/Makefile
@@ -2,6 +2,12 @@ AS_TYPE ?= coco-as
 HTTPS_CRYPTO ?= rustls
 POLICY_ENGINE ?=
 
+ARCH := $(shell uname -m)
+# Check if ARCH is supported, otehrwise return error
+ifeq ($(filter $(ARCH),x86_64 s390x),)
+	$(error "Unsupported architecture: $(ARCH)")
+endif
+
 CLI_FEATURES ?= default
 
 COCO_AS_INTEGRATION_TYPE ?= builtin
@@ -34,12 +40,12 @@ passport-resource-kbs:
 cli:
 	cargo build -p kbs-client --locked --release --no-default-features --features $(CLI_FEATURES)
 
-.PHONY: cli-static-x86_64-linux
-cli-static-x86_64-linux:
+.PHONY: cli-static-linux
+cli-static-linux:
 	cargo build \
       -p kbs-client \
-      --target=x86_64-unknown-linux-gnu \
-      --config "target.x86_64-unknown-linux-gnu.rustflags = '-C target-feature=+crt-static'" \
+      --target=$(ARCH)-unknown-linux-gnu \
+      --config "target.$(ARCH)-unknown-linux-gnu.rustflags = '-C target-feature=+crt-static'" \
       --locked \
       --release \
       --no-default-features \

--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -1,4 +1,6 @@
 FROM rust:slim as builder
+ARG ARCH=x86_64
+ARG HTTPS_CRYPTO=rustls
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -9,10 +11,10 @@ RUN apt-get update && \
     gnupg-agent \
     git
 
-RUN curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
+RUN if [ "${ARCH}" = "x86_64" ]; then curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
     gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
     echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | \
-    tee /etc/apt/sources.list.d/intel-sgx.list && \
+    tee /etc/apt/sources.list.d/intel-sgx.list; fi && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     libclang-dev \
@@ -25,18 +27,19 @@ RUN curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.k
     wget \
     clang \
     cmake \
-    libtss2-dev \
+    libtss2-dev && \
+    if [ "${ARCH}" = "x86_64" ]; then apt-get install -y --no-install-recommends \
     libsgx-dcap-quote-verify-dev \
-    libtdx-attest-dev
+    libtdx-attest-dev; fi
 
 # Build and Install KBS
 WORKDIR /usr/src/kbs
 COPY . .
 
-ARG KBS_FEATURES=coco-as-builtin,rustls,resource,opa
-RUN cargo install --locked --path kbs/src/kbs --no-default-features --features ${KBS_FEATURES}
+RUN cargo install --locked --path kbs/src/kbs --no-default-features --features coco-as-builtin,resource,opa,${HTTPS_CRYPTO}
 
 FROM ubuntu:22.04
+ARG ARCH=x86_64
 
 RUN apt-get update && \
     apt-get install -y \
@@ -45,14 +48,14 @@ RUN apt-get update && \
     gnupg-agent
 
 # Install TDX Runtime Dependencies
-RUN curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
-    gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
-RUN echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list
+RUN if [ "${ARCH}" = "x86_64" ]; then curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
+    gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg; fi
+RUN if [ "${ARCH}" = "x86_64" ]; then echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list; fi
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN if [ "${ARCH}" = "x86_64" ]; then apt-get install -y --no-install-recommends \
     libsgx-dcap-default-qpl \
     libsgx-dcap-quote-verify \
-    tpm2-tools
+    tpm2-tools; fi
 
 # Intel PCCS URL Configurations
 # If you want the AS in KBS to connect to your customized PCCS for Intel TDX/SGX evidence verification,
@@ -62,7 +65,7 @@ ENV INTEL_PCCS_URL "https://localhost:8081/sgx/certification/v4/"
 ENV INTEL_PCCS_USE_SECURE_CERT false
 
 # Setup Intel PCCS URL
-RUN sed -i "s|\"pccs_url\":.*$|\"pccs_url\":$INTEL_PCCS_URL,|" /etc/sgx_default_qcnl.conf; \
-    sed -i "s/\"use_secure_cert\":.*$/\"use_secure_cert\":$INTEL_PCCS_USE_SECURE_CERT,/" /etc/sgx_default_qcnl.conf
+RUN if [ "${ARCH}" = "x86_64" ]; then sed -i "s|\"pccs_url\":.*$|\"pccs_url\":$INTEL_PCCS_URL,|" /etc/sgx_default_qcnl.conf; \
+    sed -i "s/\"use_secure_cert\":.*$/\"use_secure_cert\":$INTEL_PCCS_USE_SECURE_CERT,/" /etc/sgx_default_qcnl.conf; fi
 
 COPY --from=builder /usr/local/cargo/bin/kbs /usr/local/bin/kbs

--- a/kbs/docker/Dockerfile.coco-as-grpc
+++ b/kbs/docker/Dockerfile.coco-as-grpc
@@ -1,4 +1,6 @@
 FROM rust:latest as builder
+ARG ARCH=x86_64
+ARG HTTPS_CRYPTO=rustls
 
 WORKDIR /usr/src/kbs
 COPY . .
@@ -6,8 +8,7 @@ COPY . .
 RUN apt-get update && apt install -y protobuf-compiler git
 
 # Build and Install KBS
-RUN cargo install --path kbs/src/kbs --no-default-features --features coco-as-grpc,resource,opa,rustls
-
+RUN cargo install --path kbs/src/kbs --no-default-features --features coco-as-grpc,resource,opa,${HTTPS_CRYPTO}
 
 FROM ubuntu:22.04
 


### PR DESCRIPTION
This PR enables all artifacts (container images and binaries) for `s390x` alongside `x86_64`. The self-hosted runner to build them is already registered as `s390x-runner-01` to the organisation.

The change was verified with a private runner as follows:

AS: https://github.com/BbolroC/trustee/actions/runs/8982469105
KBS: https://github.com/BbolroC/trustee/actions/runs/8982469108
KBS-client: https://github.com/BbolroC/trustee/actions/runs/8982469107

The artifacts are available at:

- https://github.com/BbolroC/trustee/pkgs/container/staged-images%2Fcoco-as-grpc
- https://github.com/BbolroC/trustee/pkgs/container/staged-images%2Fcoco-as-restful
- https://github.com/BbolroC/trustee/pkgs/container/staged-images%2Fkbs
- https://github.com/BbolroC/trustee/pkgs/container/staged-images%2Fkbs-grpc-as
- https://github.com/BbolroC/trustee/pkgs/container/staged-images%2Fkbs-client

Fixes: #364

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>