### PR TITLE
AS/verifier: Enhance quote verification with multi-thread support in tdx

### DIFF
--- a/attestation-service/verifier/src/tdx/quote.rs
+++ b/attestation-service/verifier/src/tdx/quote.rs
@@ -441,7 +441,7 @@ pub async fn ecdsa_quote_verification(quote: &[u8]) -> Result<()> {
     }
 
     // get collateral
-    let _collateral = match tee_qv_get_collateral(quote) {
+    let collateral = match tee_qv_get_collateral(quote) {
         Ok(c) => {
             debug!("tee_qv_get_collateral successfully returned.");
             Some(c)
@@ -451,8 +451,6 @@ pub async fn ecdsa_quote_verification(quote: &[u8]) -> Result<()> {
             None
         }
     };
-
-    let p_collateral: Option<&[u8]> = None;
 
     // set current time. This is only for sample purposes, in production mode a trusted time should be used.
     //
@@ -465,10 +463,10 @@ pub async fn ecdsa_quote_verification(quote: &[u8]) -> Result<()> {
         0 => None,
         _ => Some(&mut supp_data_desc),
     };
-
+    
     // call DCAP quote verify library for quote verification
     let (collateral_expiration_status, quote_verification_result) =
-        tee_verify_quote(quote, p_collateral, current_time, None, p_supplemental_data)
+        tee_verify_quote(quote, collateral.as_deref(), current_time, None, p_supplemental_data)
             .map_err(|e| anyhow!("tee_verify_quote failed: {:#04x}", e as u32))?;
 
     debug!("tee_verify_quote successfully returned.");


### PR DESCRIPTION
When the qvl is linked to a process, it needs to know the proper enclave loading policy. But the default policy of qvl is SGX_QL_PERSISTENT, which means that all threads will share single QvE instance.

So we set QvE loading policy to multi-thread to enhance quote verification with multi-thread support in tdx.

Fixes: #386