### PR TITLE
workflows: Rename Docker build step from gRPC to RESTful

### DIFF
--- a/.github/workflows/as-dockerbuild.yml
+++ b/.github/workflows/as-dockerbuild.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         DOCKER_BUILDKIT=1 docker build -t attestation-service:latest . -f attestation-service/Dockerfile.as-grpc
     
-    - name: Build gRPC AS Container Image
+    - name: Build RESTful AS Container Image
       run: |
         DOCKER_BUILDKIT=1 docker build -t attestation-service:latest . -f attestation-service/Dockerfile.as-restful
 

--- a/attestation-service/verifier/src/tdx/quote.rs
+++ b/attestation-service/verifier/src/tdx/quote.rs
@@ -463,7 +463,7 @@ pub async fn ecdsa_quote_verification(quote: &[u8]) -> Result<()> {
         0 => None,
         _ => Some(&mut supp_data_desc),
     };
-    
+
     // call DCAP quote verify library for quote verification
     let (collateral_expiration_status, quote_verification_result) =
         tee_verify_quote(quote, collateral.as_deref(), current_time, None, p_supplemental_data)


### PR DESCRIPTION
Updates the naming in the CI build step to accurately reflect the RESTful AS image, replacing the previous gRPC name.

Fixes: #388