### PR TITLE
attestation: fix clippy error in intel_trust_authority AS

### DIFF
--- a/kbs/src/api/src/attestation/intel_trust_authority/mod.rs
+++ b/kbs/src/api/src/attestation/intel_trust_authority/mod.rs
@@ -116,7 +116,7 @@ impl Attest for IntelTrustAuthority {
 
         // check unmatched policy
         let allow = self.config.allow_unmatched_policy.unwrap_or(false);
-        if allow == false && token.claims.policy_ids_unmatched.is_some() {
+        if !allow && token.claims.policy_ids_unmatched.is_some() {
             bail!("Evidence doesn't match policy");
         }
 


### PR DESCRIPTION
cargo clippy errors on:

```
error: equality checks against false can be replaced by a negation
   --> kbs/src/api/src/attestation/intel_trust_authority/mod.rs:119:12
    |
119 |         if allow == false && token.claims.policy_ids_unmatched.is_some() {
    |            ^^^^^^^^^^^^^^ help: try simplifying it as shown: `!allow
```