### PR TITLE
ci: added publishing intel trust authority AS docker

### DIFF
--- a/.github/workflows/as-build-and-push.yaml
+++ b/.github/workflows/as-build-and-push.yaml
@@ -57,9 +57,9 @@ jobs:
       run: |
         commit_sha=${{ github.sha }}
         arch=$(uname -m)
-        DOCKER_BUILDKIT=1 docker build -f ${{ matrix.docker_file }} --push --build-arg ARCH=${arch} \
-          -t ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch} \
-          -t ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch} .
+        DOCKER_BUILDKIT=1 docker build -f "${{ matrix.docker_file }}" --push --build-arg ARCH="${arch}" \
+          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch}" \
+          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch}" .
 
     - name: Take a post-action for self-hosted runner
       if: always()
@@ -102,11 +102,11 @@ jobs:
     - name: Publish Multi-arch Image for ${{ matrix.name }}
       run: |
         commit_sha=${{ github.sha }}
-        docker manifest create ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha} \
-          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-s390x \
-          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-x86_64
-        docker manifest push ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}
-        docker manifest create ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest \
-          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-s390x \
-          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-x86_64
-        docker manifest push ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest
+        docker manifest create "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}" \
+          --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-s390x" \
+          --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-x86_64"
+        docker manifest push "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}"
+        docker manifest create "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest" \
+          --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-s390x" \
+          --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-x86_64"
+        docker manifest push "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest"

--- a/.github/workflows/kbs-build-and-push.yaml
+++ b/.github/workflows/kbs-build-and-push.yaml
@@ -57,10 +57,10 @@ jobs:
         arch=$(uname -m)
         https_crypto=${{ matrix.https_crypto }}
         [ "${arch}" = "s390x" ] && https_crypto=openssl
-        DOCKER_BUILDKIT=1 docker build -f ${{ matrix.docker_file }} --push \
-          -t ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch} \
-          -t ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch} \
-          --build-arg ARCH=${arch} --build-arg HTTPS_CRYPTO=${https_crypto} .
+        DOCKER_BUILDKIT=1 docker build -f "${{ matrix.docker_file }}" --push \
+          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch}" \
+          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch}" \
+          --build-arg ARCH="${arch}" --build-arg HTTPS_CRYPTO="${https_crypto}" .
 
     - name: Take a post-action for self-hosted runner
       if: always()
@@ -93,11 +93,11 @@ jobs:
     - name: Publish Multi-Arch ${{ matrix.image }} image
       run: |
         commit_sha=${{ github.sha }}
-        docker manifest create ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha} \
-          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}-x86_64 \
-          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}-s390x
-        docker manifest push ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}
-        docker manifest create ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest \
-          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest-x86_64 \
-          --amend ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest-s390x
-        docker manifest push ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest
+        docker manifest create "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}" \
+          --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}-x86_64" \
+          --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}-s390x"
+        docker manifest push "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}"
+        docker manifest create "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest" \
+          --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest-x86_64" \
+          --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest-s390x"
+        docker manifest push "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest"

--- a/.github/workflows/kbs-build-and-push.yaml
+++ b/.github/workflows/kbs-build-and-push.yaml
@@ -18,6 +18,10 @@ jobs:
         tag:
           - kbs
           - kbs-grpc-as
+          - kbs-ita-as
+        exclude:
+          - instance: s390x
+            tag: kbs-ita-as
         include:
           - tag: kbs
             docker_file: kbs/docker/Dockerfile
@@ -27,6 +31,11 @@ jobs:
             docker_file: kbs/docker/Dockerfile.coco-as-grpc
             https_crypto: rustls
             name: gRPC AS
+          - tag: kbs-ita-as
+            docker_file: kbs/docker/Dockerfile.intel-trust-authority
+            https_crypto: rustls
+            name: Intel Trust Authority AS
+
     runs-on: ${{ matrix.instance }}
 
     steps:

--- a/.github/workflows/kbs-docker-build.yml
+++ b/.github/workflows/kbs-docker-build.yml
@@ -17,4 +17,5 @@ jobs:
         DOCKER_BUILDKIT=1 docker build -t kbs:coco-as . -f kbs/docker/Dockerfile; \
         DOCKER_BUILDKIT=1 docker build -t kbs:coco-as-openssl --build-arg KBS_FEATURES=coco-as-builtin,openssl,resource,opa . -f kbs/docker/Dockerfile; \
         DOCKER_BUILDKIT=1 docker build -t kbs:coco-as-grpc . -f kbs/docker/Dockerfile.coco-as-grpc; \
-        DOCKER_BUILDKIT=1 docker build -t kbs:coco-as-rhel-ubi . -f kbs/docker/Dockerfile.rhel-ubi
+        DOCKER_BUILDKIT=1 docker build -t kbs:coco-as-rhel-ubi . -f kbs/docker/Dockerfile.rhel-ubi; \
+        DOCKER_BUILDKIT=1 docker build -t kbs:coco-as-ita . -f kbs/docker/Dockerfile.intel-trust-authority

--- a/hack/release-helper.sh
+++ b/hack/release-helper.sh
@@ -6,15 +6,19 @@ declare -g gh_username
 declare -g gh_token
 declare -g release_candidate_sha
 declare -g release_tag
+
+# Output naming convention along with release guide can be found in release-guide.md
 declare -A staged_to_release=(
     ["staged-images/kbs"]="key-broker-service"
     ["staged-images/kbs-grpc-as"]="key-broker-service"
+    ["staged-images/kbs-ita-as"]="key-broker-service"
     ["staged-images/rvps"]="reference-value-provider-service"
     ["staged-images/coco-as-grpc"]="attestation-service"
     ["staged-images/coco-as-restful"]="attestation-service"
 )
 declare -A staged_to_release_tag_prefix=(
     ["staged-images/kbs"]="built-in-as-"
+    ["staged-images/kbs-ita-as"]="ita-as-"
     ["staged-images/coco-as-restful"]="rest-"
 )
 

--- a/kbs/docker/Dockerfile.intel-trust-authority
+++ b/kbs/docker/Dockerfile.intel-trust-authority
@@ -1,4 +1,5 @@
 FROM rust:latest as builder
+ARG HTTPS_CRYPTO=rustls
 
 WORKDIR /usr/src/kbs
 COPY . .
@@ -6,7 +7,7 @@ COPY . .
 RUN apt-get update && apt install -y git
 
 # Build and Install KBS
-RUN cargo install --path kbs/src/kbs --no-default-features --features intel-trust-authority-as,rustls,resource,opa
+RUN cargo install --path kbs/src/kbs --no-default-features --features intel-trust-authority-as,${HTTPS_CRYPTO},resource,opa
 
 FROM ubuntu:22.04
 

--- a/release-guide.md
+++ b/release-guide.md
@@ -17,6 +17,7 @@ mappings:
 ```
 staged-images/kbs:latest -> key-broker-service:built-in-as-v0.8.2
 staged-images/kbs-grpc-as:latest -> key-broker-service:v0.8.2
+staged-images/kbs-ita-as:latest -> key-broker-service:ita-as-v0.8.2
 staged-images/rvps:latest -> reference-value-provider-service:v0.8.2
 staged-images/coco-as-grpc:latest -> attestation-service:v0.8.2
 staged-images/coco-as-restful:latest -> attestation-service:rest-v0.8.2


### PR DESCRIPTION
- Refactored directory structure for building KBS docker images
- Added publishing KBS intel trust authority AS docker image on ghcr.io