### PR TITLE
kbs: simplify tee-pubkey reading from the attestation token

### DIFF
--- a/kbs/src/api/src/attestation/mod.rs
+++ b/kbs/src/api/src/attestation/mod.rs
@@ -14,6 +14,11 @@ use intel_trust_authority::*;
 use kbs_types::{Challenge, Tee};
 use rand::{thread_rng, Rng};
 
+#[cfg(not(feature = "intel-trust-authority-as"))]
+pub const AS_TOKEN_TEE_PUBKEY_PATH: &str = "/customized_claims/runtime_data/tee-pubkey";
+#[cfg(feature = "intel-trust-authority-as")]
+pub const AS_TOKEN_TEE_PUBKEY_PATH: &str = "/attester_runtime_data/tee-pubkey";
+
 #[cfg(feature = "coco-as")]
 #[allow(missing_docs)]
 pub mod coco;

--- a/kbs/src/api/src/http/mod.rs
+++ b/kbs/src/api/src/http/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(feature = "as")]
-use crate::attestation::AttestationService;
+use crate::attestation::{AttestationService, AS_TOKEN_TEE_PUBKEY_PATH};
 use crate::auth::validate_auth;
 #[cfg(feature = "policy")]
 use crate::policy_engine::PolicyEngine;

--- a/kbs/src/api/src/http/resource.rs
+++ b/kbs/src/api/src/http/resource.rs
@@ -19,6 +19,9 @@ use crate::raise_error;
 
 use super::*;
 
+#[cfg(feature = "as")]
+const TOKEN_TEE_PUBKEY_PATH: &str = AS_TOKEN_TEE_PUBKEY_PATH;
+#[cfg(not(feature = "as"))]
 const TOKEN_TEE_PUBKEY_PATH: &str = "/customized_claims/runtime_data/tee-pubkey";
 
 #[allow(unused_assignments)]

--- a/kbs/src/api/src/http/resource.rs
+++ b/kbs/src/api/src/http/resource.rs
@@ -19,6 +19,8 @@ use crate::raise_error;
 
 use super::*;
 
+const TOKEN_TEE_PUBKEY_PATH: &str = "/customized_claims/runtime_data/tee-pubkey";
+
 #[allow(unused_assignments)]
 /// GET /resource/{repository}/{type}/{tag}
 /// GET /resource/{type}/{tag}
@@ -46,27 +48,12 @@ pub(crate) async fn get_resource(
         Error::AttestationClaimsParseFailed(format!("illegal attestation claims: {e}"))
     })?;
 
-    let pkey_value = claims
-        .get("customized_claims")
-        .ok_or(Error::AttestationClaimsParseFailed(String::from(
-            "No `customized_claims` in the attestation claims thus no `tee-pubkey`",
-        )))?
-        .as_object()
-        .ok_or(Error::AttestationClaimsParseFailed(String::from(
-            "`customized_claims` should be a JSON map",
-        )))?
-        .get("runtime_data")
-        .ok_or(Error::AttestationClaimsParseFailed(String::from(
-            "No `runtime_data` in the attestation claims thus no `tee-pubkey`",
-        )))?
-        .as_object()
-        .ok_or(Error::AttestationClaimsParseFailed(String::from(
-            "`runtime_data` should be a JSON map",
-        )))?
-        .get("tee-pubkey")
-        .ok_or(Error::AttestationClaimsParseFailed(String::from(
-            "No `tee-pubkey` in the attestation claims",
-        )))?;
+    let pkey_value =
+        claims
+            .pointer(TOKEN_TEE_PUBKEY_PATH)
+            .ok_or(Error::AttestationClaimsParseFailed(String::from(
+                "Failed to find `tee-pubkey` in the attestation claims",
+            )))?;
     let pubkey = TeePubKey::deserialize(pkey_value).map_err(|e| {
         Error::AttestationClaimsParseFailed(format!("illegal attestation claims: {e}"))
     })?;


### PR DESCRIPTION
get-resource API searches `tee-pubkey` claim from the attestation token. Instead of doing the search by ourselves, simply pass the desired path and leverage `pointer()` method to do the search. This simplifies the code when the search path needs to be made configurable.

One such case as of today is when attestation service provided tokens carry `tee-pubkey` under a different claims structure. We piggyback the existing cargo features to let each AS implementation define their own search paths compile time.