### PR TITLE
kbs: shrink the size of docker image

### DIFF
--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -60,15 +60,4 @@ RUN apt-get update && \
     apt clean all && \
     rm -rf /tmp/*
 
-# Intel PCCS URL Configurations
-# If you want the AS in KBS to connect to your customized PCCS for Intel TDX/SGX evidence verification,
-# please modify this parameter.
-# Default using localhost PCCS (Run in Host which the container land on).
-ENV INTEL_PCCS_URL "https://localhost:8081/sgx/certification/v4/"
-ENV INTEL_PCCS_USE_SECURE_CERT false
-
-# Setup Intel PCCS URL
-RUN if [ "${ARCH}" = "x86_64" ]; then sed -i "s|\"pccs_url\":.*$|\"pccs_url\":$INTEL_PCCS_URL,|" /etc/sgx_default_qcnl.conf; \
-    sed -i "s/\"use_secure_cert\":.*$/\"use_secure_cert\":$INTEL_PCCS_USE_SECURE_CERT,/" /etc/sgx_default_qcnl.conf; fi
-
 COPY --from=builder /usr/local/cargo/bin/kbs /usr/local/bin/kbs

--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -41,21 +41,24 @@ RUN cargo install --locked --path kbs/src/kbs --no-default-features --features c
 FROM ubuntu:22.04
 ARG ARCH=x86_64
 
+WORKDIR /tmp
+
 RUN apt-get update && \
     apt-get install -y \
-    clang \
     curl \
-    gnupg-agent
-
-# Install TDX Runtime Dependencies
-RUN if [ "${ARCH}" = "x86_64" ]; then curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
-    gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg; fi
-RUN if [ "${ARCH}" = "x86_64" ]; then echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list; fi
-RUN apt-get update
-RUN if [ "${ARCH}" = "x86_64" ]; then apt-get install -y --no-install-recommends \
+    gnupg-agent && \
+    if [ "${ARCH}" = "x86_64" ]; then curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
+    gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
     libsgx-dcap-default-qpl \
     libsgx-dcap-quote-verify \
-    tpm2-tools; fi
+    libtss2-tctildr0 \
+    libtss2-esys-3.0.2-0 ; \
+    fi && \
+    apt clean all && \
+    rm -rf /tmp/*
 
 # Intel PCCS URL Configurations
 # If you want the AS in KBS to connect to your customized PCCS for Intel TDX/SGX evidence verification,


### PR DESCRIPTION
After this patch, the image size will be ~215MB

```
$ docker images | grep slim
kbs     coco-as-slim      baf4fd2a16ed   37 minutes ago   215MB
```

Close #416