### PR TITLE
Fix KBS AS build warning

### DIFF
--- a/kbs/src/api/src/lib.rs
+++ b/kbs/src/api/src/lib.rs
@@ -25,8 +25,9 @@ use jwt_simple::prelude::Ed25519PublicKey;
 #[cfg(feature = "resource")]
 use resource::RepositoryConfig;
 use semver::{BuildMetadata, Prerelease, Version, VersionReq};
-use std::path::PathBuf;
-use std::{net::SocketAddr, sync::Arc};
+#[cfg(feature = "as")]
+use std::sync::Arc;
+use std::{net::SocketAddr, path::PathBuf};
 #[cfg(feature = "resource")]
 use token::AttestationTokenVerifierConfig;
 


### PR DESCRIPTION
This introduces a compiler feature check for `as` when importing `sync::Arc`. This removes the `unused_imports` warning when building as specified in #419.

Resolves: #419