### PR TITLE
Add runtime dependencies to Dockerfile.rhel-ubi

### DIFF
--- a/kbs/docker/Dockerfile.rhel-ubi
+++ b/kbs/docker/Dockerfile.rhel-ubi
@@ -1,8 +1,8 @@
-# Use Fedora to build.
-FROM registry.fedoraproject.org/fedora-minimal:40 as builder
+# Use CentOS Stream to build.
+FROM quay.io/centos/centos:stream9 as builder
 
-# Install build dependencies from Fedora repos.
-RUN microdnf -y --setopt=install_weak_deps=0 install \
+# Install build dependencies from CentOS repos.
+RUN dnf -y --setopt=install_weak_deps=0 --enablerepo=crb install \
 cargo pkg-config perl-FindBin openssl-devel perl-lib perl-IPC-Cmd perl-File-Compare perl-File-Copy tpm2-tss-devel clang-devel protobuf-compiler \
 tar gzip
 
@@ -10,7 +10,7 @@ tar gzip
 WORKDIR /root
 RUN curl -O https://download.01.org/intel-sgx/sgx-linux/2.24/distro/centos-stream9/sgx_rpm_local_repo.tgz && \
 tar -xaf sgx_rpm_local_repo.tgz && \
-microdnf -y install --nogpgcheck --repofrompath "sgx,file:///root/sgx_rpm_local_repo" libsgx-dcap-quote-verify-devel
+dnf -y install --nogpgcheck --repofrompath "sgx,file:///root/sgx_rpm_local_repo" libsgx-dcap-quote-verify-devel
 
 # Build.
 WORKDIR /usr/src/kbs

--- a/kbs/docker/Dockerfile.rhel-ubi
+++ b/kbs/docker/Dockerfile.rhel-ubi
@@ -22,7 +22,13 @@ cargo install --locked --root /usr/local/ --path kbs/src/kbs --no-default-featur
 mkdir -p /root/trustee/lib64 && \
 ldd /usr/local/bin/kbs | sed 's@.*\s/@/@' | sed 's/\s.*//' | xargs -I {} cp {} /root/trustee/lib64
 
-# Package minimal image.
-FROM registry.access.redhat.com/ubi9-micro
+# Package UBI image.
+FROM registry.access.redhat.com/ubi9
+
+# Install runtime dependencies from Intel repo.
+COPY --from=builder /root/sgx_rpm_local_repo /root/sgx_rpm_local_repo
+RUN dnf -y install --nogpgcheck --setopt=install_weak_deps=0 --repofrompath "sgx,file:///root/sgx_rpm_local_repo" \
+libsgx-dcap-default-qpl libsgx-dcap-quote-verify && \
+rm -rf /root/sgx_rpm_local_repo
+
 COPY --from=builder /usr/local/bin/kbs /usr/local/bin/kbs
-COPY --from=builder /root/trustee/lib64/* /lib64/


### PR DESCRIPTION
Follow-up to #403. Add runtime dependencies, as pointed out by @mythi. Also changes the builder image from Fedora to CentOS Stream.