### PR TITLE
intel-trust-authority-as: add error message log

### DIFF
--- a/kbs/src/api/src/attestation/intel_trust_authority/mod.rs
+++ b/kbs/src/api/src/attestation/intel_trust_authority/mod.rs
@@ -35,6 +35,11 @@ struct Claims {
     policy_ids_unmatched: Option<Vec<serde_json::Value>>,
 }
 
+#[derive(Deserialize, Debug)]
+struct ErrorResponse {
+    error: String,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct IntelTrustAuthorityConfig {
     pub base_url: String,
@@ -82,10 +87,16 @@ impl Attest for IntelTrustAuthority {
             .await
             .map_err(|e| anyhow!("Post attestation request failed: {:?}", e))?;
 
-        if resp.status() != reqwest::StatusCode::OK {
+        let status = resp.status();
+        if status != reqwest::StatusCode::OK {
+            let body = resp
+                .json::<ErrorResponse>()
+                .await
+                .map_err(|e| anyhow!("Deserialize error response failed: {:?}", e))?;
             bail!(
-                "Attestation request failed: respone status={}",
-                resp.status()
+                "Attestation request failed: response status={}, message={}",
+                status,
+                body.error
             );
         }
 
@@ -93,7 +104,7 @@ impl Attest for IntelTrustAuthority {
         let resp_data = resp
             .json::<AttestRespData>()
             .await
-            .map_err(|e| anyhow!("Deserialize attestation respone failed: {:?}", e))?;
+            .map_err(|e| anyhow!("Deserialize attestation response failed: {:?}", e))?;
         let header = decode_header(&resp_data.token)
             .map_err(|e| anyhow!("Decode token header failed: {:?}", e))?;
         let kid = header.kid.ok_or(anyhow!("Token missing kid"))?;


### PR DESCRIPTION
- Added logging error message for failed appraisal request.
- Fixed typos

Sample output:

 `ERROR api_server::http::error] Attestation failed: Attestation request failed: response status=400 Bad Request, message=Invalid nonce and/or run time data provided in the request`