### PR TITLE
bump: guest-components to candidate v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "attester"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=3f2fd793c0a67c74f7ce62b115ed5be293616386#3f2fd793c0a67c74f7ce62b115ed5be293616386"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=df60725afe0ba452a25a740cf460c2855442c49a#df60725afe0ba452a25a740cf460c2855442c49a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1330,7 +1330,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=3f2fd793c0a67c74f7ce62b115ed5be293616386#3f2fd793c0a67c74f7ce62b115ed5be293616386"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=df60725afe0ba452a25a740cf460c2855442c49a#df60725afe0ba452a25a740cf460c2855442c49a"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2714,7 +2714,7 @@ dependencies = [
 [[package]]
 name = "kbs_protocol"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=3f2fd793c0a67c74f7ce62b115ed5be293616386#3f2fd793c0a67c74f7ce62b115ed5be293616386"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=df60725afe0ba452a25a740cf460c2855442c49a#df60725afe0ba452a25a740cf460c2855442c49a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4062,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "resource_uri"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=3f2fd793c0a67c74f7ce62b115ed5be293616386#3f2fd793c0a67c74f7ce62b115ed5be293616386"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=df60725afe0ba452a25a740cf460c2855442c49a#df60725afe0ba452a25a740cf460c2855442c49a"
 dependencies = [
  "anyhow",
  "serde",
@@ -5617,9 +5617,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna 0.5.0",

--- a/kbs/tools/client/Cargo.toml
+++ b/kbs/tools/client/Cargo.toml
@@ -18,7 +18,7 @@ base64.workspace = true
 clap = { version = "4.0.29", features = ["derive"] }
 env_logger.workspace = true
 jwt-simple = "0.11.4"
-kbs_protocol = { git = "https://github.com/confidential-containers/guest-components.git", rev="3f2fd793c0a67c74f7ce62b115ed5be293616386", default-features = false }
+kbs_protocol = { git = "https://github.com/confidential-containers/guest-components.git", rev="df60725afe0ba452a25a740cf460c2855442c49a", default-features = false }
 log.workspace = true
 reqwest = { version = "0.12", default-features = false, features = ["cookies", "json"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This is for cutting release of v0.9.0 of trustee. To align with guest-components side.