### PR TITLE
CLI: specify ATTESTER to build kbs-client

### DIFF
--- a/kbs/Makefile
+++ b/kbs/Makefile
@@ -8,7 +8,8 @@ ifeq ($(filter $(ARCH),x86_64 s390x),)
 	$(error "Unsupported architecture: $(ARCH)")
 endif
 
-CLI_FEATURES ?= default
+CLI_FEATURES ?=
+ATTESTER ?=
 
 COCO_AS_INTEGRATION_TYPE ?= builtin
 
@@ -18,6 +19,14 @@ ifeq ($(AS_TYPE), coco-as)
   AS_FEATURE = $(AS_TYPE)-$(COCO_AS_INTEGRATION_TYPE)
 else
   AS_FEATURE = $(AS_TYPE)
+endif
+
+ifndef CLI_FEATURES
+  ifdef ATTESTER
+    CLI_FEATURES = "sample_only,$(ATTESTER)"
+  else
+    CLI_FEATURES += "sample_only,all-attesters"
+  endif
 endif
 
 build: background-check-kbs

--- a/kbs/tools/client/Cargo.toml
+++ b/kbs/tools/client/Cargo.toml
@@ -28,3 +28,13 @@ tokio.workspace = true
 [features]
 default = ["kbs_protocol/default"]
 sample_only = ["kbs_protocol/background_check", "kbs_protocol/passport", "kbs_protocol/rust-crypto"]
+
+all-attesters = ["kbs_protocol/all-attesters"]
+tdx-attester = ["kbs_protocol/tdx-attester"]
+sgx-attester = ["kbs_protocol/sgx-attester"]
+az-snp-vtpm-attester = ["kbs_protocol/az-snp-vtpm-attester"]
+az-tdx-vtpm-attester = ["kbs_protocol/az-tdx-vtpm-attester"]
+snp-attester = ["kbs_protocol/snp-attester"]
+csv-attester = ["kbs_protocol/csv-attester"]
+cca-attester = ["kbs_protocol/cca-attester"]
+se-attester  = ["kbs_protocol/se-attester"]


### PR DESCRIPTION
We can't build kbs-client on s390x host with default feature including all attesters. 

I tried to add a new variable ATTESTER in Makefile, so that we can specify separate attester when building kbs-client

* by default, `make cli` will build kbs-client with all attesters
* keep feature sample_only: `CLI_FEATURES=sample_only make cli`
* specify ATTESTER: `ATTESTER=se-attester make cli`
