### PR TITLE
Fix broken SE link

### DIFF
--- a/kbs/config/kubernetes/README.md
+++ b/kbs/config/kubernetes/README.md
@@ -112,7 +112,7 @@ $ tree $IBM_SE_CREDS_DIR
 5 directories, 7 files
 ```
 
-Please check out the [documentation](https://github.com/confidential-containers/trustee/tree/main/attestation-service/verifier/src/se) for details.
+Please check out the [documentation](https://github.com/confidential-containers/trustee/tree/main/deps/verifier/src/se) for details.
 
 ## Check deployment
 


### PR DESCRIPTION
The refactor of the repository broke this link.

We also have some issues with rustup not being available on the az runners. I wasn't sure if we should add rustup installation to the tests or do it locally. wdyt @mkulke 