### PR TITLE
e2e-test: fix binary build on self-hosted runners

### DIFF
--- a/.github/workflows/kbs-e2e.yml
+++ b/.github/workflows/kbs-e2e.yml
@@ -21,12 +21,13 @@ defaults:
     shell: bash
 
 jobs:
-  e2e-test:
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+  build-binaries:
+    runs-on: ubuntu-22.04
     env:
       RUSTC_VERSION: 1.76.0
     steps:
-    - uses: actions/download-artifact@v4
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
 
     - name: Extract tarball
       run: tar xzf ./artifact/${{ inputs.tarball }}
@@ -47,6 +48,30 @@ jobs:
           target/
         key: rust-${{ hashFiles('./Cargo.lock') }}
 
+    - name: Build bins
+      working-directory: kbs/test
+      run: |
+        make install-dev-dependencies
+        make bins
+
+    - name: Archive test folder
+      run: tar czf test.tar.gz kbs/test
+
+    - uses: actions/upload-artifact@v4
+      with:
+        path: test.tar.gz
+        overwrite: true
+
+  e2e-test:
+    needs: build-binaries
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+
+    - name: Extract test folder
+      run: tar xzf ./artifact/test.tar.gz
+
     - name: Set up SGX/TDX certificates cache
       uses: actions/cache@v4
       with:
@@ -59,10 +84,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y make --no-install-recommends
         sudo make install-dependencies
-
-    - name: Build bins
-      working-directory: kbs/test
-      run: make bins
 
     - name: Set cc_kbc sample attester env
       if: inputs.tee == 'sample'

--- a/kbs/test/Makefile
+++ b/kbs/test/Makefile
@@ -51,6 +51,19 @@ allow {
 endef
 export TEE_POLICY_REGO
 
+.PHONY: install-dev-dependencies
+install-dev-dependencies: install-dependencies
+	sudo apt-get update && \
+	sudo apt-get install -y \
+		build-essential \
+		clang \
+		libsgx-dcap-quote-verify-dev \
+		libssl-dev \
+		libtdx-attest-dev \
+		libtss2-dev \
+		pkg-config \
+		protobuf-compiler
+
 .PHONY: install-dependencies
 install-dependencies:
 	curl -L "$(SGX_REPO_URL)/intel-sgx-deb.key" | sudo apt-key add - && \
@@ -58,19 +71,13 @@ install-dependencies:
 		| sudo tee /etc/apt/sources.list.d/intel-sgx.list && \
 	sudo apt-get update && \
 	sudo apt-get install -y \
-		build-essential \
-		clang \
 		libsgx-dcap-default-qpl \
 		libsgx-dcap-quote-verify \
-		libsgx-dcap-quote-verify-dev \
 		libsgx-urts \
-		libssl-dev \
 		libtdx-attest \
-		libtdx-attest-dev \
-		libtss2-dev \
-		openssl \
-		pkg-config \
-		protobuf-compiler && \
+		libtss2-esys-3.0.2-0 \
+		libtss2-tctildr0 \
+		openssl && \
 	echo '{"collateral_service": "$(SGX_COLLATERAL_URL)"}' | sudo tee $(SGX_QCNL_CONFIG)
 
 kbs:


### PR DESCRIPTION
Split the build of the binaries out to a gh-hosted runner, only the tests need to run on TEE hw.

This fixes missing build tools on self-hosted runners and improves the caching.

~Since the CI will use the workflow files on main, the test results won't reflect the changes, a test run on a fork can be seen [here](https://github.com/mkulke/trustee/actions/runs/9792837867/job/27039594116)~

n/m that doesn't apply to the sample attester