### PR TITLE
config: fix custom pccs deployment for TDX

### DIFF
--- a/kbs/config/kubernetes/custom_pccs/kustomization.yaml
+++ b/kbs/config/kubernetes/custom_pccs/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 namespace: coco-tenant
 
 resources:
-- ../nodeport
+- ../nodeport/x86_64
 
 patches:
 - path: set_custom_pccs.yaml


### PR DESCRIPTION
We recently split the nodeport yaml into an s390x
and an x86_64 directory, but we forgot to update
the custom_pccs yaml to point to the correct one.

For now let's assume that the custom_pccs will
always run on x86_64 since it's for TDX.
We might revisit that assumption in the future.