### PR TITLE
verifier: Use the VirTEE CA Chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "futures-core",
- "h2 0.3.26",
+ "h2",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -491,12 +491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "attestation-agent"
 version = "0.1.0"
 source = "git+https://github.com/confidential-containers/guest-components.git?rev=9bd6f06a9704e01808e91abde130dffb20e632a5#9bd6f06a9704e01808e91abde130dffb20e632a5"
@@ -573,7 +567,7 @@ dependencies = [
  "csv-rs",
  "hex",
  "hyper 0.14.28",
- "hyper-tls 0.5.0",
+ "hyper-tls",
  "kbs-types",
  "log",
  "nix",
@@ -583,7 +577,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sev",
+ "sev 3.2.0",
  "sha2",
  "strum",
  "tdx-attest-rs",
@@ -668,7 +662,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
- "sev",
+ "sev 3.2.0",
  "sha2",
  "thiserror",
  "tss-esapi",
@@ -688,7 +682,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
- "sev",
+ "sev 3.2.0",
  "sha2",
  "thiserror",
  "tss-esapi",
@@ -706,7 +700,7 @@ dependencies = [
  "clap 4.5.4",
  "openssl",
  "serde",
- "sev",
+ "sev 3.2.0",
  "thiserror",
  "ureq",
 ]
@@ -721,7 +715,7 @@ dependencies = [
  "bincode",
  "clap 4.5.4",
  "serde",
- "sev",
+ "sev 3.2.0",
  "thiserror",
  "ureq",
 ]
@@ -893,6 +887,12 @@ name = "bitfield"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+
+[[package]]
+name = "bitfield"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c821a6e124197eb56d907ccc2188eab1038fb919c914f47976e64dd8dbc855d1"
 
 [[package]]
 name = "bitflags"
@@ -1417,7 +1417,7 @@ dependencies = [
  "codicon",
  "dirs",
  "hyper 0.14.28",
- "hyper-tls 0.5.0",
+ "hyper-tls",
  "iocuddle",
  "libc",
  "openssl",
@@ -2078,25 +2078,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.1.0",
- "indexmap 2.2.6",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,7 +2276,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2318,7 +2299,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.5",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
@@ -2383,22 +2363,6 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.3.1",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -4043,6 +4007,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdrand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4168,12 +4141,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-rustls 0.24.2",
- "hyper-tls 0.5.0",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
@@ -4211,22 +4184,18 @@ dependencies = [
  "bytes",
  "cookie 0.17.0",
  "cookie_store",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.5",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.3.1",
  "hyper-rustls 0.26.0",
- "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4237,9 +4206,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.25.0",
  "tower-service",
  "url",
@@ -4868,13 +4835,13 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "3.1.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2890179f8ef689340f441ba05f0b268bc14f672ae4b36d629cc2266d0d747ab"
+checksum = "35156eab65ff1b63432b5a11a06b770e92120033e2831c7dee064865de5dbbbd"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bincode",
- "bitfield 0.13.2",
+ "bitfield 0.15.0",
  "bitflags 1.3.2",
  "byteorder",
  "codicon",
@@ -4884,6 +4851,32 @@ dependencies = [
  "lazy_static",
  "libc",
  "openssl",
+ "serde",
+ "serde-big-array",
+ "serde_bytes",
+ "static_assertions",
+ "uuid",
+]
+
+[[package]]
+name = "sev"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97bd0b2e2d937951add10c8512a2dacc6ad29b39e5c5f26565a3e443329857d"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "bitfield 0.15.0",
+ "bitflags 1.3.2",
+ "byteorder",
+ "codicon",
+ "dirs",
+ "hex",
+ "iocuddle",
+ "lazy_static",
+ "libc",
+ "openssl",
+ "rdrand",
  "serde",
  "serde-big-array",
  "serde_bytes",
@@ -5511,7 +5504,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -5538,7 +5531,7 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
- "h2 0.3.26",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -5927,7 +5920,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serial_test",
- "sev",
+ "sev 4.0.0",
  "sha2",
  "shadow-rs",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ jsonwebtoken = { version = "9", default-features = false }
 log = "0.4.17"
 prost = "0.12"
 regorus = { version = "0.1.5", default-features = false, features = ["regex", "base64", "time"] }
-reqwest = "0.12"
+reqwest = { version = "0.12", default-features = false }
 rstest = "0.18.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.89"
@@ -46,7 +46,7 @@ sha2 = "0.10"
 shadow-rs = "0.19.0"
 strum = { version = "0.25", features = ["derive"] }
 thiserror = "1.0"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["full"], default-features = false }
 tempfile = "3.4.0"
 tonic = "0.11"
 tonic-build = "0.11"

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -28,7 +28,7 @@ byteorder = "1"
 cfg-if = "1.0.0"
 codicon = { version = "3.0", optional = true }
 # TODO: change it to "0.1", once released.
-csv-rs = { git = "https://github.com/openanolis/csv-rs", rev = "b74aa8c", optional = true }
+csv-rs = { version = "=0.1.0", git = "https://github.com/openanolis/csv-rs", rev = "b74aa8c", optional = true }
 eventlog-rs = { version = "0.1.3", optional = true }
 hex.workspace = true
 jsonwebkey = "0.3.5"
@@ -41,9 +41,9 @@ scroll = { version = "0.11.0", default-features = false, features = ["derive"], 
 serde.workspace = true
 serde_json.workspace = true
 serde_with = { workspace = true, optional = true }
-sev = { version = "3.1.1", features = ["openssl", "snp"], optional = true }
+sev = { version = "4.0.0", features = ["openssl", "snp"], optional = true }
 sha2.workspace = true 
-tokio = { workspace = true, optional = true, default-features = false }
+tokio = { workspace = true, optional = true }
 intel-tee-quote-verification-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", tag = "DCAP_1.21", optional = true }
 strum.workspace = true
 veraison-apiclient = { git = "https://github.com/chendave/rust-apiclient", branch = "token", optional = true }

--- a/deps/verifier/src/lib.rs
+++ b/deps/verifier/src/lib.rs
@@ -39,7 +39,7 @@ pub fn to_verifier(tee: &Tee) -> Result<Box<dyn Verifier + Send + Sync>> {
         Tee::AzSnpVtpm => {
             cfg_if::cfg_if! {
                 if #[cfg(feature = "az-snp-vtpm-verifier")] {
-                    let verifier = az_snp_vtpm::AzSnpVtpm::new()?;
+                    let verifier = az_snp_vtpm::AzSnpVtpm::new();
                     Ok(Box::new(verifier) as Box<dyn Verifier + Send + Sync>)
                 } else {
                     bail!("feature `az-snp-vtpm-verifier` is not enabled for `verifier` crate.")
@@ -67,7 +67,7 @@ pub fn to_verifier(tee: &Tee) -> Result<Box<dyn Verifier + Send + Sync>> {
         Tee::Snp => {
             cfg_if::cfg_if! {
                 if #[cfg(feature = "snp-verifier")] {
-                    let verifier = snp::Snp::new()?;
+                    let verifier = snp::Snp::new();
                     Ok(Box::new(verifier) as Box<dyn Verifier + Send + Sync>)
                 } else {
                     bail!("feature `snp-verifier` is not enabled for `verifier` crate.")

--- a/deps/verifier/src/tdx/eventlog.rs
+++ b/deps/verifier/src/tdx/eventlog.rs
@@ -124,6 +124,7 @@ impl CcEventLog {
 
 /// Defined in TCG PC Client Platform Firmware Profile Specification section
 /// 'UEFI_PLATFORM_FIRMWARE_BLOB Structure Definition'
+#[allow(dead_code)]
 pub struct ParsedUefiPlatformFirmwareBlob2 {
     pub desc_len: u8,
     pub desc: Vec<u8>,


### PR DESCRIPTION
This introduces changes into the code to utilize the cert chain provided by the VirTEE sev crate, pushing resposibility for upkeep and maintainership back to the library itself. This also reduces duplication of code and expands functionality for future changes.