### PR TITLE
kbs: add ProtocolVersion error

### DIFF
--- a/kbs/src/http/error.rs
+++ b/kbs/src/http/error.rs
@@ -58,6 +58,9 @@ pub enum Error {
     #[error("Resource not permitted.")]
     PolicyReject,
 
+    #[error("KBS Client Protocol Version Mismatch: {0}")]
+    ProtocolVersion(String),
+
     #[error("Public key get failed: {0}")]
     PublicKeyGetFailed(String),
 
@@ -140,6 +143,7 @@ mod tests {
     #[case(Error::JWEFailed("test".into()))]
     #[case(Error::PolicyEndpoint("test".into()))]
     #[case(Error::PolicyReject)]
+    #[case(Error::ProtocolVersion("test".into()))]
     #[case(Error::PublicKeyGetFailed("test".into()))]
     #[case(Error::ReadSecretFailed("test".into()))]
     #[case(Error::SetSecretFailed("test".into()))]

--- a/kbs/src/lib.rs
+++ b/kbs/src/lib.rs
@@ -24,7 +24,6 @@ use attestation::AttestationService;
 use jwt_simple::prelude::Ed25519PublicKey;
 #[cfg(feature = "resource")]
 use resource::RepositoryConfig;
-use semver::{BuildMetadata, Prerelease, Version, VersionReq};
 #[cfg(feature = "as")]
 use std::sync::Arc;
 use std::{net::SocketAddr, path::PathBuf};
@@ -68,28 +67,11 @@ mod token;
 /// Resource Policy Engine
 pub mod policy_engine;
 
-static KBS_PREFIX: &str = "/kbs";
-static KBS_MAJOR_VERSION: u64 = 0;
-static KBS_MINOR_VERSION: u64 = 1;
-static KBS_PATCH_VERSION: u64 = 0;
-
-lazy_static! {
-    static ref VERSION_REQ: VersionReq = {
-        let kbs_version = Version {
-            major: KBS_MAJOR_VERSION,
-            minor: KBS_MINOR_VERSION,
-            patch: KBS_PATCH_VERSION,
-            pre: Prerelease::EMPTY,
-            build: BuildMetadata::EMPTY,
-        };
-
-        VersionReq::parse(&format!("<={kbs_version}")).unwrap()
-    };
-}
+static KBS_PREFIX: &str = "/kbs/v0";
 
 macro_rules! kbs_path {
     ($path:expr) => {
-        format!("{}/v{}/{}", KBS_PREFIX, KBS_MAJOR_VERSION, $path)
+        format!("{}/{}", KBS_PREFIX, $path)
     };
 }
 

--- a/kbs/src/session.rs
+++ b/kbs/src/session.rs
@@ -6,10 +6,9 @@ use actix_web::cookie::{
     time::{Duration, OffsetDateTime},
     Cookie,
 };
-use anyhow::{bail, Result};
+use anyhow::Result;
 use kbs_types::{Challenge, Request};
 use log::warn;
-use semver::Version;
 use uuid::Uuid;
 
 pub(crate) static KBS_SESSION_ID: &str = "kbs-session-id";
@@ -52,10 +51,6 @@ macro_rules! impl_member {
 
 impl SessionStatus {
     pub fn auth(request: Request, timeout: i64, challenge: Challenge) -> Result<Self> {
-        let version = Version::parse(&request.version).map_err(anyhow::Error::from)?;
-        if !crate::VERSION_REQ.matches(&version) {
-            bail!("Invalid Request version {}", request.version);
-        }
         let id = Uuid::new_v4().as_simple().to_string();
 
         let timeout = OffsetDateTime::now_utc() + Duration::minutes(timeout);


### PR DESCRIPTION
kbs already supports checking the Request version but any version mismatch is not correctly returned to the client (nor checked by the current RCAR client handshake).

Add an explicit kbs ProtocolVersion error that is returned when the Request version is higher than what the KBS claims to support.