### PR TITLE
kbs: Fix rate limit error with busybox

### DIFF
--- a/kbs/config/kubernetes/base/deployment.yaml
+++ b/kbs/config/kubernetes/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         - sh
         - -c
         - cp -r /config/$(dirname $(readlink /config/policy.rego))/* /opa/confidential-containers/kbs/
-        image: busybox
+        image: quay.io/prometheus/busybox:latest
         imagePullPolicy: Always
         name: copy-config
         volumeMounts:


### PR DESCRIPTION
Fix rate limit error with docker.io/library/busybox:latest when deploying kbs.

```
Warning  Failed     76s                 kubelet            Failed to pull image "busybox": rpc error: code = Unknown
desc = failed to pull and unpack image "docker.io/library/busybox:latest": failed to copy: httpReadSeeker: failed open:
unexpected status code https://registry-1.docker.io/v2/library/busybox/manifests/sha256:50aa4698fa6262977cff89181b2664b99d8a56dbca847bf62f2ef04854597cf8:
429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit.
You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

Error log in kata: https://github.com/kata-containers/kata-containers/actions/runs/10172722668/job/28136683102?pr=9999