### PR TITLE
GHA: Remove {pre,post}-action steps for self-hosted runners

### DIFF
--- a/.github/workflows/push-as-image-to-ghcr.yml
+++ b/.github/workflows/push-as-image-to-ghcr.yml
@@ -32,14 +32,6 @@ jobs:
     runs-on: ${{ matrix.instance }}
 
     steps:
-    - name: Take a pre-action for self-hosted runner
-      run: |
-        # NOTE: Use file checking instead triggering a step based on a runner type
-        # to avoid updating the step for each new self-hosted runner.
-        if [ -f "${HOME}/script/pre_action.sh" ]; then
-          "${HOME}/script/pre_action.sh" cc-trustee
-        fi
-
     - name: Checkout code
       uses: actions/checkout@v4
 
@@ -60,14 +52,6 @@ jobs:
         DOCKER_BUILDKIT=1 docker build -f "${{ matrix.docker_file }}" --push --build-arg ARCH="${arch}" \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch}" \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch}" .
-
-    - name: Take a post-action for self-hosted runner
-      if: always()
-      run: |
-        # Please check out the note in the pre-action step for the reason of using file checking
-        if [ -f "${HOME}/script/post_action.sh" ]; then
-          "${HOME}/script/post_action.sh" cc-trustee
-        fi
 
   publish_multi_arch_image:
     needs: build_and_push

--- a/.github/workflows/push-kbs-client-to-ghcr.yml
+++ b/.github/workflows/push-kbs-client-to-ghcr.yml
@@ -21,14 +21,6 @@ jobs:
       packages: write
 
     steps:
-    - name: Take a pre-action for self-hosted runner
-      run: |
-        # NOTE: Use file checking instead triggering a step based on a runner type
-        # to avoid updating the step for each new self-hosted runner.
-        if [ -f "${HOME}/script/pre_action.sh" ]; then
-          "${HOME}/script/pre_action.sh" cc-trustee
-        fi
-
     - name: Check out code
       uses: actions/checkout@v4
 
@@ -59,12 +51,4 @@ jobs:
           kbs-client
         if [ "$(uname -m)" = "x86_64" ]; then
           oras push ghcr.io/confidential-containers/staged-images/kbs-client:latest kbs-client
-        fi
-
-    - name: Take a post-action for self-hosted runner
-      if: always()
-      run: |
-        # Please check out the note in the pre-action step for the reason of using file checking
-        if [ -f "${HOME}/script/post_action.sh" ]; then
-          "${HOME}/script/post_action.sh" cc-trustee
         fi

--- a/.github/workflows/push-kbs-image-to-ghcr.yml
+++ b/.github/workflows/push-kbs-image-to-ghcr.yml
@@ -39,14 +39,6 @@ jobs:
     runs-on: ${{ matrix.instance }}
 
     steps:
-    - name: Take a pre-action for self-hosted runner
-      run: |
-        # NOTE: Use file checking instead triggering a step based on a runner type
-        # to avoid updating the step for each new self-hosted runner.
-        if [ -f "${HOME}/script/pre_action.sh" ]; then
-          "${HOME}/script/pre_action.sh" cc-trustee
-        fi
-
     - name: Checkout code
       uses: actions/checkout@v4
 
@@ -70,14 +62,6 @@ jobs:
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch}" \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch}" \
           --build-arg ARCH="${arch}" --build-arg HTTPS_CRYPTO="${https_crypto}" .
-
-    - name: Take a post-action for self-hosted runner
-      if: always()
-      run: |
-        # Please check out the note in the pre-action step for the reason of using file checking
-        if [ -f "${HOME}/script/post_action.sh" ]; then
-          "${HOME}/script/post_action.sh" cc-trustee
-        fi
 
   publish_multi_arch_image:
     needs: build_and_push


### PR DESCRIPTION
The following hooks:

- ACTIONS_RUNNER_HOOK_JOB_STARTED
- ACTIONS_RUNNER_HOOK_JOB_COMPLETED

could perfectly replace the existing {pre,post}-action scripts and will make a workflow independent of the runner context. This PR wipes out all GHA steps where the actions are triggered.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>