### PR TITLE
ibmse: SE_SKIP_CERTS_VERIFICATION for all KBS image

### DIFF
--- a/deps/verifier/src/se/README.md
+++ b/deps/verifier/src/se/README.md
@@ -130,7 +130,6 @@ export SE_SKIP_CERTS_VERIFICATION=true
 ```
 DOCKER_BUILDKIT=1 docker build --build-arg HTTPS_CRYPTO="openssl" --build-arg ARCH="s390x" -t ghcr.io/confidential-containers/staged-images/kbs:latest . -f kbs/docker/Dockerfile
 ```
->Note: Please add `--debug` in statement like `cargo install` in file `kbs/docker/Dockerfile` if you're using a development host key document to skip HKD's signature verification.
 
 - Prepare a docker compose file, similar as:
 ```

--- a/deps/verifier/src/se/ibmse.rs
+++ b/deps/verifier/src/se/ibmse.rs
@@ -277,26 +277,13 @@ impl SeVerifierImpl {
             let c = certs
                 .first()
                 .ok_or(anyhow!("File does not contain a X509 certificate"))?;
-            #[cfg(debug_assertions)]
-            {
-                const DEFAULT_SE_SKIP_CERTS_VERIFICATION: &str = "false";
-                let skip_certs_env = env_or_default!(
-                    "SE_SKIP_CERTS_VERIFICATION",
-                    DEFAULT_SE_SKIP_CERTS_VERIFICATION
-                );
-                let skip_certs: bool = skip_certs_env.parse::<bool>().unwrap_or(false);
-                if !skip_certs {
-                    let verifier = CertVerifier::new(
-                        ca_certs.as_slice(),
-                        crls.as_slice(),
-                        ca_option.clone(),
-                        offline_certs_verify,
-                    )?;
-                    verifier.verify(c)?;
-                }
-            }
-            #[cfg(not(debug_assertions))]
-            {
+            const DEFAULT_SE_SKIP_CERTS_VERIFICATION: &str = "false";
+            let skip_certs_env = env_or_default!(
+                "SE_SKIP_CERTS_VERIFICATION",
+                DEFAULT_SE_SKIP_CERTS_VERIFICATION
+            );
+            let skip_certs: bool = skip_certs_env.parse::<bool>().unwrap_or(false);
+            if !skip_certs {
                 let verifier = CertVerifier::new(
                     ca_certs.as_slice(),
                     crls.as_slice(),


### PR DESCRIPTION
Enable release image to have SE_SKIP_CERTS_VERIFICATION also

Signed-off-by: Qi Feng Huo <huoqif@cn.ibm.com>