### PR TITLE
ibmse: use hash rather than hex for initdata digest in claims

### DIFF
--- a/deps/verifier/src/se/ibmse.rs
+++ b/deps/verifier/src/se/ibmse.rs
@@ -90,8 +90,7 @@ pub struct SeAttestationResponse {
 pub struct SeAttestationClaims {
     #[serde_as(as = "Hex")]
     cuid: ConfigUid,
-    #[serde_as(as = "Hex")]
-    user_data: Vec<u8>,
+    user_data: String,
     version: u32,
     #[serde_as(as = "Hex")]
     image_phkh: Vec<u8>,
@@ -218,7 +217,7 @@ impl SeVerifierImpl {
 
         let claims = SeAttestationClaims {
             cuid: se_response.cuid,
-            user_data: se_response.user_data.clone(),
+            user_data: String::from_utf8(se_response.user_data.clone())?,
             version: AttestationVersion::One as u32,
             image_phkh: image_phkh.to_vec(),
             attestation_phkh: attestation_phkh.to_vec(),


### PR DESCRIPTION
Use the initdata hash value directly rather than it's hex in claims.
It's more reasonable to use the fixed length hash value `initdata.digest` rather than its HEX in claims because it's more straight forward for user to set the hash value in attestation policy.

Related PR:
https://github.com/confidential-containers/guest-components/pull/616
https://github.com/confidential-containers/cloud-api-adaptor/pull/1991 