### PR TITLE
kbs: token: configuration cleanup

### DIFF
--- a/kbs/src/token/mod.rs
+++ b/kbs/src/token/mod.rs
@@ -5,7 +5,6 @@
 use anyhow::*;
 use async_trait::async_trait;
 use serde::Deserialize;
-use std::fmt;
 use std::sync::Arc;
 use strum::EnumString;
 use tokio::sync::RwLock;
@@ -49,11 +48,5 @@ pub fn create_token_verifier(
             coco::CoCoAttestationTokenVerifier::new(&config)?,
         ))
             as Arc<RwLock<dyn AttestationTokenVerifier + Send + Sync>>),
-    }
-}
-
-impl fmt::Display for AttestationTokenVerifierType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
     }
 }

--- a/kbs/src/token/mod.rs
+++ b/kbs/src/token/mod.rs
@@ -18,13 +18,15 @@ pub trait AttestationTokenVerifier {
     async fn verify(&self, token: String) -> Result<String>;
 }
 
-#[derive(Deserialize, Debug, Clone, EnumString)]
+#[derive(Deserialize, Default, Debug, Clone, EnumString)]
 pub enum AttestationTokenVerifierType {
+    #[default]
     CoCo,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct AttestationTokenVerifierConfig {
+    #[serde(default)]
     pub attestation_token_type: AttestationTokenVerifierType,
 
     // Trusted Certificates file (PEM format) path to verify Attestation Token Signature.

--- a/kbs/src/token/mod.rs
+++ b/kbs/src/token/mod.rs
@@ -30,16 +30,8 @@ pub struct AttestationTokenVerifierConfig {
     pub attestation_token_type: AttestationTokenVerifierType,
 
     // Trusted Certificates file (PEM format) path to verify Attestation Token Signature.
-    pub trusted_certs_paths: Option<Vec<String>>,
-}
-
-impl Default for AttestationTokenVerifierConfig {
-    fn default() -> Self {
-        Self {
-            attestation_token_type: AttestationTokenVerifierType::CoCo,
-            trusted_certs_paths: None,
-        }
-    }
+    #[serde(default)]
+    pub trusted_certs_paths: Vec<String>,
 }
 
 pub fn create_token_verifier(


### PR DESCRIPTION
Moving some changes from #458 to this separate PR.

While working on this, I noticed KBS can be run without `trusted_certs_paths` and have resource access approved. Are we OK with this or would it be better to have an explicit user opt-in?