### PR TITLE
update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,2 @@
-# Global owner for changes not matched by more specific rules
-* @sameo
-
-/kbs/ @kbs-maintainers
-/attestation-service/ @attestation-service-maintainers
+# https://github.com/orgs/confidential-containers/teams/trustee-maintainers
+* @confidential-containers/trustee-maintainers


### PR DESCRIPTION
Make kbs-maintainers the CODEOWNERS for this repo. This also fixes the broken syntax with org-wide teams.

Ref: https://github.com/confidential-containers/confidential-containers/issues/31
Ref: https://github.com/confidential-containers/confidential-containers/pull/235