### PR TITLE
ita: use AttestationTokenVerifier

### DIFF
--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -34,7 +34,7 @@ coco-as-builtin-no-verifier = ["coco-as", "attestation-service/rvps-builtin"]
 coco-as-grpc = ["coco-as", "mobc", "tonic", "tonic-build", "prost"]
 
 # Use Intel TA as backend attestation service
-intel-trust-authority-as = ["as", "reqwest", "jsonwebtoken"]
+intel-trust-authority-as = ["as", "reqwest", "resource"]
 
 # Use pure rust crypto stack for KBS
 rustls = ["actix-web/rustls", "dep:rustls", "dep:rustls-pemfile"]

--- a/kbs/config/kbs-config-intel-trust-authority.toml
+++ b/kbs/config/kbs-config-intel-trust-authority.toml
@@ -2,9 +2,10 @@ insecure_http = true
 insecure_api = true
 
 [attestation_token_config]
-attestation_token_type = "CoCo"
+attestation_token_type = "Jwk"
+trusted_certs_paths = ["https://portal.trustauthority.intel.com"]
 
 [intel_trust_authority_config]
 base_url = "https://api.trustauthority.intel.com"
 api_key = "tBfd5kKX2x9ahbodKV1..."
-certs_file = "/etc/intel-trust-authority-certs.txt"
+certs_file = "https://portal.trustauthority.intel.com"

--- a/kbs/src/attestation/mod.rs
+++ b/kbs/src/attestation/mod.rs
@@ -98,8 +98,8 @@ impl AttestationService {
 
     /// Create and initialize AttestationService.
     #[cfg(feature = "intel-trust-authority-as")]
-    pub fn new(config: IntelTrustAuthorityConfig) -> Result<Self> {
-        let ta_client = intel_trust_authority::IntelTrustAuthority::new(config)?;
+    pub async fn new(config: IntelTrustAuthorityConfig) -> Result<Self> {
+        let ta_client = intel_trust_authority::IntelTrustAuthority::new(config).await?;
         Ok(Self::IntelTA(ta_client))
     }
 

--- a/kbs/src/bin/kbs.rs
+++ b/kbs/src/bin/kbs.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<()> {
             } else if #[cfg(feature = "coco-as-grpc")] {
                 AttestationService::new(kbs_config.grpc_config.unwrap_or_default()).await?
             } else if #[cfg(feature = "intel-trust-authority-as")] {
-                AttestationService::new(kbs_config.intel_trust_authority_config)?
+                AttestationService::new(kbs_config.intel_trust_authority_config).await?
             } else {
                 compile_error!("Please enable at least one of the following features: `coco-as-builtin`, `coco-as-builtin-no-verifier`, `coco-as-grpc` or `intel-trust-authority-as` to continue.");
             }

--- a/kbs/src/token/mod.rs
+++ b/kbs/src/token/mod.rs
@@ -10,7 +10,7 @@ use strum::EnumString;
 use tokio::sync::RwLock;
 
 mod coco;
-mod jwk;
+pub(crate) mod jwk;
 
 #[async_trait]
 pub trait AttestationTokenVerifier {


### PR DESCRIPTION
minor cleanup to deduplicate JWK token verification code.