### PR TITLE
ita: Build the kustomization based on nodeport

### DIFF
--- a/kbs/config/kubernetes/ita/kustomization.yaml
+++ b/kbs/config/kubernetes/ita/kustomization.yaml
@@ -7,7 +7,7 @@ images:
   newTag: ita-as-v0.9.0
 
 resources:
-- ../overlays/x86_64
+- ../nodeport/x86_64
 
 configMapGenerator:
 - name: kbs-config


### PR DESCRIPTION
While testing on an environment as close as possible to the Kata Containers CI, I've noticed that we need to build ITA based on nodeport in order to get it working as expected there.

The tests I ran earlier, in a different environment, already had this based on nodeport, but I didn't realise it while reviewing bdaa4b2185d.