### PR TITLE
docs: fix doctest error

### DIFF
--- a/kbs/src/http/error.rs
+++ b/kbs/src/http/error.rs
@@ -84,11 +84,11 @@ pub enum Error {
 }
 
 /// For example, if we want to raise an error of `MissingCookie`
-/// ```no-run
+/// ```ignore
 /// raise_error!(Error::MissingCookie);
 /// ```
 /// is short for
-/// ```no-run
+/// ```ignore
 /// return Err(Error::MissingCookie);
 /// ```
 #[macro_export]


### PR DESCRIPTION
For doctests, there is no keyword `no-run`.
Doctests recognizes `no_run`, but this still compiles the code, which will fail in this case.

We could fixup these examples with some hidden lines so that they compile, but since we don't really use rustdoc currently, let's just have the compiler ignore these examples.