### PR TITLE
kbs: Fix ibm-se deployment

### DIFF
--- a/kbs/config/kubernetes/README.md
+++ b/kbs/config/kubernetes/README.md
@@ -9,7 +9,11 @@ We will see how to deploy KBS (with builtin Attestation Service) on a Kubernetes
 Create a secret that you want to be served using this instance of KBS:
 
 ```bash
-echo "This is my super secret" > overlays/$(uname -m)/key.bin
+echo "This is my super secret" > overlays/key.bin
+```
+or, if deploying on IBM Secure Execution run:
+```bash
+echo "This is my super secret" > overlays/ibm-se/key.bin
 ```
 
 If you have more than one secret, copy them over to the `config/kubernetes/overlays` directory and add those to the `overlays/kustomization.yaml` file after as shown below:
@@ -147,6 +151,10 @@ kbs    ClusterIP   10.0.210.190   <none>        8080/TCP   4s
 
 ## Delete KBS
 
+```bash
+$ kubectl delete -k ${DEPLOYMENT_DIR}/
 ```
-$ kubectl delete -k ${DEPLOYMENT_DIR}/$(uname -m)
+or, if running on IBM Secure Execution run:
+```bash
+$ kubectl delete -k ${DEPLOYMENT_DIR}/ibm-se/ && kubectl delete pv test-local-pv
 ```

--- a/kbs/config/kubernetes/deploy-kbs.sh
+++ b/kbs/config/kubernetes/deploy-kbs.sh
@@ -4,13 +4,23 @@ set -euo pipefail
 
 # Environment variable that defines which directory to use the kustomization file for deployment.
 DEPLOYMENT_DIR="${DEPLOYMENT_DIR:-overlays}"
+OVERLAYS_DIR="overlays"
 
 k8s_cnf_dir="$(dirname ${BASH_SOURCE[0]})"
 
+if [ "$(uname -m)" == "s390x" ] && [ -n "${IBM_SE_CREDS_DIR:-}" ]; then
+    # We are using the ibm-se overlay
+    echo "ibm-se overlay being used as IBM_SE_CREDS_DIR was set"
+    OVERLAYS_DIR="${OVERLAYS_DIR}/ibm-se"
+    DEPLOYMENT_DIR="${DEPLOYMENT_DIR}/ibm-se"
+    export NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+    envsubst <"${k8s_cnf_dir}/${OVERLAYS_DIR}/pv.yaml" | kubectl apply -f -
+fi
+
 # Fail the script if the key.bin file does not exist.
-key_file="${k8s_cnf_dir}/overlays/key.bin"
+key_file="${k8s_cnf_dir}/${OVERLAYS_DIR}/key.bin"
 [[ -f "${key_file}" ]] || {
-    echo "key.bin not found at ${k8s_cnf_dir}/overlays/"
+    echo "key.bin not found at ${k8s_cnf_dir}/${OVERLAYS_DIR}/"
     exit 1
 }
 
@@ -21,13 +31,6 @@ kbs_cert="${k8s_cnf_dir}/base/kbs.pem"
     openssl pkey -in "${k8s_cnf_dir}/base/kbs.key" -pubout -out "${kbs_cert}"
 }
 
-if [ "$(uname -m)" == "s390x" ] && [ -n "${IBM_SE_CREDS_DIR:-}" ]; then
-    # We are using the ibm-se overlay
-    echo "ibm-se overlay being used as IBM_SE_CREDS_DIR was set"
-    DEPLOYMENT_DIR="${DEPLOYMENT_DIR}/ibm-se"
-    export NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
-    envsubst <"${k8s_cnf_dir}/${DEPLOYMENT_DIR}/pv.yaml" | kubectl apply -f -
-fi
 
 if [[ "${DEPLOYMENT_DIR}" == "nodeport" || "${DEPLOYMENT_DIR}" == "overlays" ]]; then
     kubectl apply -k "${k8s_cnf_dir}/${DEPLOYMENT_DIR}"


### PR DESCRIPTION
In #521 I re-worked the deploy-kbs script with overlays and didn't factor in that the key.bin needed to go to a different place for ibm-se, so it was causing:
```
trustee/kbs/config/kubernetes$ ls overlays/key.bin
ls: cannot access 'overlays/key.bin': No such file or directory
```
on an SE system.

I think the least bad way to resolve this is to move the ibm-se logic up before the key.bin check and rely on the updated `DEPLOYMENT_DIR`