### PR TITLE
Ci: Install Rust via `actions-rust-lang/setup-rust-toolchain@v1` rather than `rustup`

### DIFF
--- a/.github/workflows/as-e2e.yml
+++ b/.github/workflows/as-e2e.yml
@@ -35,10 +35,10 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust toolchain (${{ env.RUSTC_VERSION }})
-      run: |
-        rustup update --no-self-update ${{ env.RUSTC_VERSION }}
-        rustup component add --toolchain ${{ env.RUSTC_VERSION }} rustc
-        rustup default ${{ env.RUSTC_VERSION }}
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ env.RUSTC_VERSION }}
+        components: rustfmt, clippy
 
     - uses: actions/setup-go@v5
       with:

--- a/.github/workflows/as-rust.yml
+++ b/.github/workflows/as-rust.yml
@@ -58,10 +58,10 @@ jobs:
           sudo apt-get install -y libsgx-dcap-quote-verify-dev libsgx-dcap-default-qpl
 
       - name: Install Rust toolchain (${{ env.RUSTC_VERSION }})
-        run: |
-          rustup update --no-self-update ${{ env.RUSTC_VERSION }}
-          rustup component add --toolchain ${{ env.RUSTC_VERSION }} rustfmt rustc clippy
-          rustup default ${{ env.RUSTC_VERSION }}
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUSTC_VERSION }}
+          components: rustfmt, clippy
 
       - name: Build
         working-directory: attestation-service

--- a/.github/workflows/kbs-docker-e2e.yml
+++ b/.github/workflows/kbs-docker-e2e.yml
@@ -19,10 +19,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust ${{ env.RUSTC_VERSION }} (for client)
-      run: |
-        rustup update --no-self-update ${{ env.RUSTC_VERSION }}
-        rustup component add --toolchain ${{ env.RUSTC_VERSION }} rustc
-        rustup default ${{ env.RUSTC_VERSION }}
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ env.RUSTC_VERSION }}
+        components: rustfmt, clippy
 
     - name: Build client
       run: |

--- a/.github/workflows/kbs-e2e.yml
+++ b/.github/workflows/kbs-e2e.yml
@@ -33,10 +33,11 @@ jobs:
       run: tar xzf ./artifact/${{ inputs.tarball }}
 
     - name: Install Rust toolchain (${{ env.RUSTC_VERSION }})
-      run: |
-        rustup update --no-self-update ${{ env.RUSTC_VERSION }}
-        rustup component add --toolchain ${{ env.RUSTC_VERSION }} rustc
-        rustup default ${{ env.RUSTC_VERSION }}
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ env.RUSTC_VERSION }}
+        components: rustfmt, clippy
+        rustflags: ""
 
     - name: Set up rust build cache
       uses: actions/cache@v4

--- a/.github/workflows/kbs-rust.yml
+++ b/.github/workflows/kbs-rust.yml
@@ -31,11 +31,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust toolchain (${{ env.RUSTC_VERSION }})
-      run: |
-        rustup update --no-self-update ${{ env.RUSTC_VERSION }}
-        rustup component add --toolchain ${{ env.RUSTC_VERSION }} rustfmt rustc clippy
-        rustup target add x86_64-unknown-linux-gnu
-        rustup default ${{ env.RUSTC_VERSION }}
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ env.RUSTC_VERSION }}
+        components: rustfmt, clippy
 
     - name: Building dependencies installation
       run: |

--- a/.github/workflows/push-kbs-client-to-ghcr.yml
+++ b/.github/workflows/push-kbs-client-to-ghcr.yml
@@ -25,10 +25,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust toolchain (${{ env.RUSTC_VERSION }})
-      run: |
-        rustup update --no-self-update ${{ env.RUSTC_VERSION }}
-        rustup component add --toolchain ${{ env.RUSTC_VERSION }} rustc
-        rustup default ${{ env.RUSTC_VERSION }}
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ env.RUSTC_VERSION }}
+        components: rustfmt, clippy
 
     - name: Log in to ghcr.io
       uses: docker/login-action@v3


### PR DESCRIPTION
The original way to install rust dependency will not check if rust is already installed, thus it would require `rustup` be installed on the ci machine already while self-hosted CI machine may not.

We use `actions-rust-lang/setup-rust-toolchain@v1` to install rust because `actions-rs` has not been maintained for over 1 year and archived.