### PR TITLE
Put `rvps` dependencies behind `rvps-builtin` feature flag

### DIFF
--- a/attestation-service/src/rvps/mod.rs
+++ b/attestation-service/src/rvps/mod.rs
@@ -34,9 +34,12 @@ pub mod builtin;
 fn default_store_type() -> String {
     #[cfg(feature = "rvps-builtin")]
     {
-        return DEFAULT_STORAGE_TYPE.into()
+        DEFAULT_STORAGE_TYPE.into()
     }
-    return "LocalFs".into()
+    #[cfg(not(feature = "rvps-builtin"))]
+    {
+        return "LocalFs".into()
+    }
 }
 
 fn default_store_config() -> Value {


### PR DESCRIPTION
First of all thank you for building and maintaining such a wonderful suite of libraries! CoCo has been immensely valuable for our team and we appreciate all of the work that the community has put into these projects

### Problem
Currently if you run build without the `rvps-builtin` feature, it fails:

`cargo build --no-default-features --features restful-bin,rvps-grpc`

This is because the `reference-value-provider-service` dependency is not included under this feature set (requires `rvps-builtin`), yet it is used outside of that flag

### Proposed solution
This change tucks usage of `rvps` behind that flag, so the above built command will complete successfully