### PR TITLE
Dockerfile: fix capitalization

### DIFF
--- a/attestation-service/docker/as-grpc/Dockerfile
+++ b/attestation-service/docker/as-grpc/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM rust:latest as builder
+FROM rust:latest AS builder
 ARG ARCH=x86_64
 
 WORKDIR /usr/src/attestation-service

--- a/attestation-service/docker/as-restful/Dockerfile
+++ b/attestation-service/docker/as-restful/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM rust:latest as builder
+FROM rust:latest AS builder
 ARG ARCH=x86_64
 
 WORKDIR /usr/src/attestation-service

--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:slim as builder
+FROM rust:slim AS builder
 ARG ARCH=x86_64
 ARG ALIYUN=false
 

--- a/kbs/docker/coco-as-grpc/Dockerfile
+++ b/kbs/docker/coco-as-grpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest as builder
+FROM rust:latest AS builder
 ARG ARCH=x86_64
 ARG ALIYUN=false
 

--- a/kbs/docker/intel-trust-authority/Dockerfile
+++ b/kbs/docker/intel-trust-authority/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest as builder
+FROM rust:latest AS builder
 ARG ALIYUN=false
 
 WORKDIR /usr/src/kbs

--- a/kbs/docker/rhel-ubi/Dockerfile
+++ b/kbs/docker/rhel-ubi/Dockerfile
@@ -1,5 +1,5 @@
 # Use CentOS Stream to build.
-FROM quay.io/centos/centos:stream9 as builder
+FROM quay.io/centos/centos:stream9 AS builder
 
 # Install build dependencies from CentOS repos.
 RUN dnf -y --setopt=install_weak_deps=0 --enablerepo=crb install \

--- a/rvps/docker/Dockerfile
+++ b/rvps/docker/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM rust:latest as builder
+FROM rust:latest AS builder
 
 WORKDIR /usr/src/rvps
 


### PR DESCRIPTION
Docker prefers that statements using FROM and AS have those two words in the same case and will even warn you about it if you don't.

See https://docs.docker.com/reference/build-checks/from-as-casing/