### PR TITLE
Bump CSV crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
  "az-tdx-vtpm",
  "base64 0.22.1",
  "codicon",
- "csv-rs",
+ "csv-rs 0.1.0 (git+https://github.com/openanolis/csv-rs?rev=b74aa8c)",
  "hex",
  "hyper 0.14.30",
  "hyper-tls 0.5.0",
@@ -1350,6 +1350,28 @@ dependencies = [
  "generic-array",
  "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "csv-rs"
+version = "0.1.0"
+source = "git+https://github.com/openanolis/csv-rs?rev=3045440#3045440238a4487fc468a69dce07313662992a64"
+dependencies = [
+ "bitfield 0.13.2",
+ "bitflags 1.3.2",
+ "codicon",
+ "dirs",
+ "hyper 0.14.30",
+ "hyper-tls 0.5.0",
+ "iocuddle",
+ "libc",
+ "openssl",
+ "openssl-sys",
+ "rand",
+ "serde",
+ "serde-big-array",
+ "static_assertions",
+ "tokio",
 ]
 
 [[package]]
@@ -5870,7 +5892,7 @@ dependencies = [
  "byteorder",
  "cfg-if",
  "codicon",
- "csv-rs",
+ "csv-rs 0.1.0 (git+https://github.com/openanolis/csv-rs?rev=3045440)",
  "ear",
  "eventlog-rs",
  "hex",

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -28,7 +28,7 @@ byteorder = "1"
 cfg-if = "1.0.0"
 codicon = { version = "3.0", optional = true }
 # TODO: change it to "0.1", once released.
-csv-rs = { git = "https://github.com/openanolis/csv-rs", rev = "b74aa8c", optional = true }
+csv-rs = { git = "https://github.com/openanolis/csv-rs", rev = "3045440", optional = true }
 eventlog-rs = { version = "0.1.3", optional = true }
 hex.workspace = true
 jsonwebkey = "0.3.5"


### PR DESCRIPTION
With the new version of this crate I think we might not need to use the `--locked` flag when we built. Should we remove it?