### PR TITLE
attestation-service: Allow conditional compilation of some features

### DIFF
--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = [ "restful-bin", "rvps-grpc", "rvps-builtin" ]
+default = [ "restful-bin", "rvps-grpc", "rvps-builtin", "all-verifier" ]
 all-verifier = [ "verifier/all-verifier" ]
 tdx-verifier = [ "verifier/tdx-verifier" ]
 sgx-verifier = [ "verifier/sgx-verifier" ]
@@ -66,7 +66,7 @@ tonic = { workspace = true, optional = true }
 uuid = { version = "1.1.2", features = ["v4"] }
 
 [target.'cfg(not(target_arch = "s390x"))'.dependencies]
-verifier = { path = "../deps/verifier", default-features = false, features = ["all-verifier"] }
+verifier = { path = "../deps/verifier", default-features = false }
 
 [target.'cfg(target_arch = "s390x")'.dependencies]
 verifier = { path = "../deps/verifier", default-features = false, features = ["se-verifier"] }

--- a/attestation-service/Makefile
+++ b/attestation-service/Makefile
@@ -8,6 +8,16 @@ BIN_NAMES := grpc-as restful-as
 DEBUG ?=
 DESTDIR ?= $(PREFIX)/bin
 
+FEATURES ?=
+
+ifdef FEATURES
+	OPTIONAL_FEATURES := ,$(FEATURES)
+	default-features := --no-default-features
+else
+	OPTIONAL_FEATURES :=
+	default-features :=
+endif
+
 ifdef DEBUG
     release :=
     TARGET_DIR := $(TARGET_DIR)/debug
@@ -19,10 +29,10 @@ endif
 build: grpc-as restful-as
 
 grpc-as:
-	cargo build --bin grpc-as $(release) --features grpc-bin
+	cargo build --bin grpc-as $(release) $(default-features) --features grpc-bin$(OPTIONAL_FEATURES)
 
 restful-as:
-	cargo build --bin restful-as $(release) --features restful-bin
+	cargo build --bin restful-as $(release) $(default-features) --features restful-bin$(OPTIONAL_FEATURES)
 
 install:
 	for bin_name in $(BIN_NAMES); do \


### PR DESCRIPTION
The Makefile is a bit strict on conditional compilation. Add some conditional verifier compilation in `Cargo.toml` and introduce a new configurable `FEATURES` variable to specify feature compilation other than default features.