### PR TITLE
AS: Add support for selectable verifier suites

### DIFF
--- a/.github/workflows/push-as-image-to-ghcr.yml
+++ b/.github/workflows/push-as-image-to-ghcr.yml
@@ -19,16 +19,45 @@ jobs:
           - coco-as-grpc
           - coco-as-restful
           - rvps
+        verifier:
+          - all-verifier
+          - se-verifier
         include:
           - docker_file: attestation-service/docker/as-grpc/Dockerfile
             tag: coco-as-grpc
             name: gRPC CoCo-AS
+            verifier: all-verifier
+            instance: ubuntu-latest
+          - docker_file: attestation-service/docker/as-grpc/Dockerfile
+            tag: coco-as-grpc
+            name: gRPC CoCo-AS (IBM SE)
+            verifier: se-verifier
+            instance: s390x
           - docker_file: attestation-service/docker/as-restful/Dockerfile
             tag: coco-as-restful
             name: RESTful CoCo-AS
+            verifier: all-verifier
+            instance: ubuntu-latest
+          - docker_file: attestation-service/docker/as-restful/Dockerfile
+            tag: coco-as-restful
+            name: RESTful CoCo-AS (IBM SE)
+            verifier: se-verifier
+            instance: s390x
           - docker_file: rvps/docker/Dockerfile
             tag: rvps
             name: RVPS
+            verifier: all-verifier
+            instance: ubuntu-latest
+          - docker_file: rvps/docker/Dockerfile
+            tag: rvps
+            name: RVPS
+            verifier: se-verifier
+            instance: s390x
+        exclude:
+          - instance: ubuntu-latest
+            verifier: se-verifier
+          - instance: s390x
+            verifier: all-verifier
     runs-on: ${{ matrix.instance }}
 
     steps:
@@ -50,6 +79,7 @@ jobs:
         commit_sha=${{ github.sha }}
         arch=$(uname -m)
         DOCKER_BUILDKIT=1 docker build -f "${{ matrix.docker_file }}" --push --build-arg ARCH="${arch}" \
+          --build-arg VERIFIER="${{ matrix.verifier }}" \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch}" \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch}" .
 

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = [ "restful-bin", "rvps-grpc", "rvps-builtin", "all-verifier" ]
+default = ["restful-bin", "rvps-grpc", "rvps-builtin"]
 all-verifier = [ "verifier/all-verifier" ]
 tdx-verifier = [ "verifier/tdx-verifier" ]
 sgx-verifier = [ "verifier/sgx-verifier" ]
@@ -64,12 +64,7 @@ thiserror = { workspace = true, optional = true }
 tokio.workspace = true
 tonic = { workspace = true, optional = true }
 uuid = { version = "1.1.2", features = ["v4"] }
-
-[target.'cfg(not(target_arch = "s390x"))'.dependencies]
 verifier = { path = "../deps/verifier", default-features = false }
-
-[target.'cfg(target_arch = "s390x")'.dependencies]
-verifier = { path = "../deps/verifier", default-features = false, features = ["se-verifier"] }
 
 [build-dependencies]
 shadow-rs.workspace = true

--- a/attestation-service/Makefile
+++ b/attestation-service/Makefile
@@ -8,14 +8,24 @@ BIN_NAMES := grpc-as restful-as
 DEBUG ?=
 DESTDIR ?= $(PREFIX)/bin
 
-FEATURES ?=
+VERIFIER ?= all-verifier
 
-ifdef FEATURES
-	OPTIONAL_FEATURES := ,$(FEATURES)
-	default-features := --no-default-features
+RVPS_GRPC := true
+
+# TODO: Remove `RVPS_BUILTIN`
+# when https://github.com/confidential-containers/trustee/pull/553 gets merged
+# Here we also declare another variable `RVPS_FEATURES1` because a blank will
+# be added when doing '+=' operation in Makefile
+RVPS_BUILTIN := true
+
+ifeq ($(RVPS_GRPC), true)
+	RVPS_FEATURES1 := rvps-grpc
+endif
+
+ifeq ($(RVPS_BUILTIN), true)
+	RVPS_FEATURES := $(RVPS_FEATURES1),rvps-builtin
 else
-	OPTIONAL_FEATURES :=
-	default-features :=
+	RVPS_FEATURES := $(RVPS_FEATURES1)
 endif
 
 ifdef DEBUG
@@ -29,10 +39,10 @@ endif
 build: grpc-as restful-as
 
 grpc-as:
-	cargo build --bin grpc-as $(release) $(default-features) --features grpc-bin$(OPTIONAL_FEATURES)
+	cargo build --bin grpc-as $(release) --features grpc-bin,$(VERIFIER),$(RVPS_FEATURES)
 
 restful-as:
-	cargo build --bin restful-as $(release) $(default-features) --features restful-bin$(OPTIONAL_FEATURES)
+	cargo build --bin restful-as $(release) --features restful-bin,$(VERIFIER),$(RVPS_FEATURES)
 
 install:
 	for bin_name in $(BIN_NAMES); do \

--- a/attestation-service/docker/as-grpc/Dockerfile
+++ b/attestation-service/docker/as-grpc/Dockerfile
@@ -4,6 +4,7 @@
 
 FROM rust:latest AS builder
 ARG ARCH=x86_64
+ARG VERIFIER=all-verifier
 
 WORKDIR /usr/src/attestation-service
 COPY . .
@@ -17,26 +18,36 @@ RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/
     apt-get update && apt-get install -y libsgx-dcap-quote-verify-dev; fi
 
 # Build and Install gRPC attestation-service
-RUN cargo install --path attestation-service --bin grpc-as --features grpc-bin --locked
+RUN cargo install --path attestation-service --bin grpc-as --features grpc-bin,${VERIFIER} --locked
 
 
 FROM ubuntu:22.04
 ARG ARCH=x86_64
+ARG VERIFIER=all-verifier
 
 LABEL org.opencontainers.image.source="https://github.com/confidential-containers/attestation-service"
 
-# Install TDX Runtime Dependencies
-RUN apt-get update && apt-get install curl gnupg openssl -y && \
+# Install Openssl Suites
+RUN apt-get update && apt-get install openssl -y && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
+# Install TDX Runtime Dependencies
+RUN if [ "${ARCH}" = "x86_64" ] && ( [ "${VERIFIER}" = "all-verifier" ] || [ "${VERIFIER}" = "tdx-verifier" ] ); \
+    then apt-get update && apt-get install curl gnupg -y && \
+    curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     apt-get update && \
     apt-get install -y libsgx-dcap-default-qpl libsgx-dcap-quote-verify && \
+    apt-get remove curl gnupg -y && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*; fi
 
-# Copy TPM Runtime Dependencies
-COPY --from=builder /usr/lib/${ARCH}-linux-gnu/libtss* /usr/lib/${ARCH}-linux-gnu
+# Install TPM Runtime Dependencies
+RUN if [ "${VERIFIER}" = "all-verifier" ] || [ "${VERIFIER}" = "az-snp-vtpm-verifier" ] || [ "${VERIFIER}" = "az-tdx-vtpm-verifier" ]; \
+    then apt-get update && apt-get install libtss2-dev -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*; fi
 
 COPY --from=builder /usr/local/cargo/bin/grpc-as /usr/local/bin/grpc-as
 

--- a/attestation-service/docker/as-restful/Dockerfile
+++ b/attestation-service/docker/as-restful/Dockerfile
@@ -4,6 +4,7 @@
 
 FROM rust:latest AS builder
 ARG ARCH=x86_64
+ARG VERIFIER=all-verifier
 
 WORKDIR /usr/src/attestation-service
 COPY . .
@@ -17,25 +18,34 @@ RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/
     apt-get update && apt-get install -y libsgx-dcap-quote-verify-dev; fi
 
 # Build and Install RESTful attestation-service
-RUN cargo install --path attestation-service --bin restful-as --features restful-bin --locked
+RUN cargo install --path attestation-service --bin restful-as --features restful-bin,${VERIFIER} --locked
 
 FROM ubuntu:22.04
 ARG ARCH=x86_64
 
 LABEL org.opencontainers.image.source="https://github.com/confidential-containers/attestation-service"
 
-# Install TDX Runtime Dependencies
-RUN apt-get update && apt-get install curl gnupg openssl -y && \
+# Install Openssl Suites
+RUN apt-get update && apt-get install openssl -y && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
+# Install TDX Runtime Dependencies
+RUN if [ "${ARCH}" = "x86_64" ] && ( [ "${VERIFIER}" = "all-verifier" ] || [ "${VERIFIER}" = "tdx-verifier" ] ); \
+    then apt-get update && apt-get install curl gnupg -y && \
+    curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     apt-get update && \
     apt-get install -y libsgx-dcap-default-qpl libsgx-dcap-quote-verify && \
+    apt-get remove curl gnupg -y && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*; fi
 
-# Copy TPM Runtime Dependencies
-COPY --from=builder /usr/lib/${ARCH}-linux-gnu/libtss* /usr/lib/${ARCH}-linux-gnu
+# Install TPM Runtime Dependencies
+RUN if [ "${VERIFIER}" = "all-verifier" ] || [ "${VERIFIER}" = "az-snp-vtpm-verifier" ] || [ "${VERIFIER}" = "az-tdx-vtpm-verifier" ]; \
+    then apt-get update && apt-get install libtss2-dev -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*; fi
 
 COPY --from=builder /usr/local/cargo/bin/restful-as /usr/local/bin/restful-as
 

--- a/attestation-service/docs/grpc-as.md
+++ b/attestation-service/docs/grpc-as.md
@@ -77,7 +77,9 @@ Build and install binary
 git clone https://github.com/confidential-containers/trustee
 cd trustee/attestation-service
 WORKDIR=$(pwd)
-make && make install
+make ATTESTER=all-attester && make install
+
+# You can use different attester by changing the value of ATTESTER
 ```
 
 - For help information, run:
@@ -106,7 +108,11 @@ Build and run container image
 ```shell
 git clone https://github.com/confidential-containers/trustee
 cd trustee
-docker build -t coco-as:grpc -f attestation-service/docker/as-grpc/Dockerfile .
+docker build \
+  -t coco-as:grpc \
+  -f attestation-service/docker/as-grpc/Dockerfile \
+  --build-arg ATTESTER=all-attester \
+  . 
 ```
 
 ### API

--- a/attestation-service/docs/restful-as.md
+++ b/attestation-service/docs/restful-as.md
@@ -67,7 +67,9 @@ Build and install binary
 git clone https://github.com/confidential-containers/trustee
 cd trustee/attestation-service
 WORKDIR=$(pwd)
-make && make install
+make ATTESTER=all-attester && make install
+
+# You can use different attester by changing the value of ATTESTER
 ```
 
 - For help information, run:
@@ -96,7 +98,11 @@ Build and run container image
 ```shell
 git clone https://github.com/confidential-containers/trustee
 cd trustee
-docker build -t coco-as:restful -f attestation-service/docker/as-restful/Dockerfile .
+docker build \
+  -t coco-as:restful \
+  -f attestation-service/docker/as-restful/Dockerfile \
+  --build-arg ATTESTER=all-attester \
+  . 
 ```
 
 ### HTTPS support

--- a/deps/verifier/src/lib.rs
+++ b/deps/verifier/src/lib.rs
@@ -181,7 +181,7 @@ pub trait Verifier {
 }
 
 /// Padding or truncate the given data slice to the given `len` bytes.
-fn regularize_data(data: &[u8], len: usize, data_name: &str, arch: &str) -> Vec<u8> {
+pub fn regularize_data(data: &[u8], len: usize, data_name: &str, arch: &str) -> Vec<u8> {
     let data_len = data.len();
     match data_len.cmp(&len) {
         Ordering::Less => {

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -39,7 +39,6 @@ actix-web-httpauth.workspace = true
 aes-gcm = "0.10.1"
 anyhow.workspace = true
 async-trait.workspace = true
-attestation-service = { path = "../attestation-service", default-features = false, optional = true }
 base64.workspace = true
 cfg-if.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
@@ -71,6 +70,16 @@ tonic = { workspace = true, optional = true }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 openssl = "0.10.55"
 az-cvm-vtpm = { version = "0.7.0", default-features = false, optional = true }
+
+[target.'cfg(not(target_arch = "s390x"))'.dependencies]
+attestation-service = { path = "../attestation-service", default-features = false, features = [
+    "all-verifier",
+], optional = true }
+
+[target.'cfg(target_arch = "s390x")'.dependencies]
+attestation-service = { path = "../attestation-service", default-features = false, features = [
+    "se-verifier",
+], optional = true }
 
 [dev-dependencies]
 tempfile.workspace = true


### PR DESCRIPTION
Proposed in #565 by @tylerfanelli

We soon have two needs when building an AS binary / docker image to decouple verifier dependencies.
1. Select specific verifier suites when building AS binary
2. Install specific verifier software stack due to the selected verifier suites when build docker images

This patch accomplish 1, by disabling all verifiers in CoCoAS basic code and providing a `VERIFIER` env for makefile to specify the verifier suites.

For 2, we add `make dockerfile` function which also follows `VERIFIER` env to install related verifier software stack.
By default the generation of dockerfiles will use `all-verifier`.

We add target platform detecting logic to the KBS crate cargo toml to determine the built-in AS features.

Also, the CI pipeline of CoCoAS is updated.

Close #568

The RVPS features are a little messy. It will be tidied in #553

cc @tylerfanelli @fitzthum @mkulke 