### PR TITLE
kbs: Avoid logging sensitive information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,6 +1564,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2711,6 +2722,7 @@ dependencies = [
  "clap 4.5.20",
  "config",
  "cryptoki",
+ "derivative",
  "env_logger 0.10.2",
  "jsonwebtoken",
  "jwt-simple 0.11.9",

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -71,6 +71,7 @@ tonic = { workspace = true, optional = true }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 openssl = "0.10.55"
 az-cvm-vtpm = { version = "0.7.0", default-features = false, optional = true }
+derivative = "2.2.0"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/kbs/src/attestation/intel_trust_authority/mod.rs
+++ b/kbs/src/attestation/intel_trust_authority/mod.rs
@@ -10,6 +10,7 @@ use anyhow::*;
 use async_trait::async_trait;
 use az_cvm_vtpm::hcl::HclReport;
 use base64::{engine::general_purpose::STANDARD, Engine};
+use derivative::Derivative;
 use kbs_types::Challenge;
 use kbs_types::{Attestation, Tee};
 use reqwest::header::{ACCEPT, CONTENT_TYPE, USER_AGENT};
@@ -74,9 +75,11 @@ struct ErrorResponse {
     error: String,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Default)]
+#[derive(Clone, Derivative, Deserialize, PartialEq, Default)]
+#[derivative(Debug)]
 pub struct IntelTrustAuthorityConfig {
     pub base_url: String,
+    #[derivative(Debug = "ignore")]
     pub api_key: String,
     pub certs_file: String,
     pub allow_unmatched_policy: Option<bool>,

--- a/kbs/src/bin/kbs.rs
+++ b/kbs/src/bin/kbs.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     info!("Using config file {}", cli.config_file);
     let kbs_config = KbsConfig::try_from(Path::new(&cli.config_file))?;
 
-    debug!("Config: {:#?}", kbs_config);
+    debug!("Config (sensitive fields are omitted): {:#?}", kbs_config);
 
     let api_server = ApiServer::new(kbs_config).await?;
 

--- a/kbs/src/plugins/implementations/resource/aliyun_kms.rs
+++ b/kbs/src/plugins/implementations/resource/aliyun_kms.rs
@@ -4,14 +4,18 @@
 
 use super::backend::{ResourceDesc, StorageBackend};
 use anyhow::{Context, Result};
+use derivative::Derivative;
 use kms::{plugins::aliyun::AliyunKmsClient, Annotations, Getter};
 use log::info;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Derivative, Deserialize, Clone, PartialEq)]
+#[derivative(Debug)]
 pub struct AliyunKmsBackendConfig {
+    #[derivative(Debug = "ignore")]
     client_key: String,
     kms_instance_id: String,
+    #[derivative(Debug = "ignore")]
     password: String,
     cert_pem: String,
 }

--- a/kbs/src/plugins/implementations/resource/pkcs11.rs
+++ b/kbs/src/plugins/implementations/resource/pkcs11.rs
@@ -7,13 +7,15 @@ use cryptoki::context::{CInitializeArgs, Pkcs11};
 use cryptoki::object::{Attribute, AttributeInfo, AttributeType, KeyType, ObjectClass};
 use cryptoki::session::{Session, UserType};
 use cryptoki::types::AuthPin;
+use derivative::Derivative;
 use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use super::backend::{ResourceDesc, StorageBackend};
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Derivative, Deserialize, Clone, PartialEq)]
+#[derivative(Debug)]
 pub struct Pkcs11Config {
     /// Path to the Pkcs11 module
     module: String,
@@ -23,6 +25,7 @@ pub struct Pkcs11Config {
     slot_index: Option<u8>,
 
     /// The user pin for authenticating the session
+    #[derivative(Debug = "ignore")]
     pin: String,
 }
 


### PR DESCRIPTION
In a few parts of our code, we'd end up logging sensitive information when the KBS is running in "debug" mode.

A simple way to avoid doing that is taking advantage of the "derivative" crate, and simply omit the sensitive fields, which is the approach taken.