### PR TITLE
gha: Add image build check for s390x

### DIFF
--- a/.github/workflows/as-docker-build.yml
+++ b/.github/workflows/as-docker-build.yml
@@ -1,4 +1,4 @@
-name: AS & RVPS Container Image Build
+name: AS/RVPS Container Image Build
 on:
   push:
     branches:
@@ -15,25 +15,7 @@ on:
   create:
 
 jobs:
-  basic_ci:
+  check_as_image_build:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
-    name: Check
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
-    steps:
-    - name: Code checkout
-      uses: actions/checkout@v4
-    
-    - name: Build gRPC AS Container Image
-      run: |
-        DOCKER_BUILDKIT=1 docker build -t attestation-service:latest . -f attestation-service/docker/as-grpc/Dockerfile
-    
-    - name: Build RESTful AS Container Image
-      run: |
-        DOCKER_BUILDKIT=1 docker build -t attestation-service:latest . -f attestation-service/docker/as-restful/Dockerfile
-
-    - name: Build RVPS Container Image
-      run: |
-        Docker_BUILDKIT=1 docker build -t rvps:latest . -f rvps/docker/Dockerfile
+    uses: ./.github/workflows/build-as-image.yml
+    secrets: inherit

--- a/.github/workflows/build-as-image.yml
+++ b/.github/workflows/build-as-image.yml
@@ -1,0 +1,85 @@
+name: Build CoCo AS/RVPS Image
+
+on:
+  workflow_call:
+    inputs:
+      build_option:
+        description: 'Build option for the image'
+        type: string
+        required: false
+
+jobs:
+  build_as_image:
+    strategy:
+      fail-fast: false
+      matrix:
+        instance:
+          - ubuntu-latest
+          - s390x
+        tag:
+          - coco-as-grpc
+          - coco-as-restful
+          - rvps
+        verifier:
+          - all-verifier
+          - se-verifier
+        include:
+          - docker_file: attestation-service/docker/as-grpc/Dockerfile
+            tag: coco-as-grpc
+            name: gRPC CoCo-AS
+            verifier: all-verifier
+            instance: ubuntu-latest
+          - docker_file: attestation-service/docker/as-grpc/Dockerfile
+            tag: coco-as-grpc
+            name: gRPC CoCo-AS (IBM SE)
+            verifier: se-verifier
+            instance: s390x
+          - docker_file: attestation-service/docker/as-restful/Dockerfile
+            tag: coco-as-restful
+            name: RESTful CoCo-AS
+            verifier: all-verifier
+            instance: ubuntu-latest
+          - docker_file: attestation-service/docker/as-restful/Dockerfile
+            tag: coco-as-restful
+            name: RESTful CoCo-AS (IBM SE)
+            verifier: se-verifier
+            instance: s390x
+          - docker_file: rvps/docker/Dockerfile
+            tag: rvps
+            name: RVPS
+            verifier: all-verifier
+            instance: ubuntu-latest
+          - docker_file: rvps/docker/Dockerfile
+            tag: rvps
+            name: RVPS
+            verifier: se-verifier
+            instance: s390x
+        exclude:
+          - instance: ubuntu-latest
+            verifier: se-verifier
+          - instance: s390x
+            verifier: all-verifier
+    runs-on: ${{ matrix.instance }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GHCR Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build ${{ matrix.name }} Container Image
+      run: |
+        commit_sha=${{ github.sha }}
+        arch=$(uname -m)
+        DOCKER_BUILDKIT=1 docker build -f "${{ matrix.docker_file }}" ${{ inputs.build_option }} --build-arg ARCH="${arch}" \
+          --build-arg VERIFIER="${{ matrix.verifier }}" \
+          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch}" \
+          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch}" .

--- a/.github/workflows/build-kbs-image.yml
+++ b/.github/workflows/build-kbs-image.yml
@@ -1,0 +1,66 @@
+name: Build KBS Image
+
+on:
+  workflow_call:
+    inputs:
+      build_option:
+        description: 'Build option for the image'
+        type: string
+        required: false
+
+jobs:
+  build_kbs_image:
+    strategy:
+      fail-fast: false
+      matrix:
+        instance:
+          - ubuntu-latest
+          - s390x
+        tag:
+          - kbs
+          - kbs-grpc-as
+          - kbs-ita-as
+          - rhel-ubi
+        exclude:
+          - instance: s390x
+            tag: kbs-ita-as
+          - instance: s390x
+            tag: rhel-ubi
+        include:
+          - tag: kbs
+            docker_file: kbs/docker/Dockerfile
+            name: build-in AS
+          - tag: kbs-grpc-as
+            docker_file: kbs/docker/coco-as-grpc/Dockerfile
+            name: gRPC AS
+          - tag: kbs-ita-as
+            docker_file: kbs/docker/intel-trust-authority/Dockerfile
+            name: Intel Trust Authority AS
+          - tag: rhel-ubi
+            docker_file: kbs/docker/rhel-ubi/Dockerfile
+            name: RHEL UBI AS
+
+    runs-on: ${{ matrix.instance }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GHCR Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build Container Image KBS (${{ matrix.name }})
+      run: |
+        commit_sha=${{ github.sha }}
+        arch=$(uname -m)
+        DOCKER_BUILDKIT=1 docker build -f "${{ matrix.docker_file }}" ${{ inputs.build_option }} \
+          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch}" \
+          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch}" \
+          --build-arg ARCH="${arch}" .

--- a/.github/workflows/kbs-docker-build.yml
+++ b/.github/workflows/kbs-docker-build.yml
@@ -6,16 +6,6 @@ on:
     branches: [ "main" ]
 
 jobs:
-  ci:
-    runs-on: ubuntu-latest
-    name: Check
-    steps:
-    - name: Code checkout
-      uses: actions/checkout@v4
-
-    - name: Build KBS Container Image
-      run: |
-        DOCKER_BUILDKIT=1 docker build -t kbs:coco-as . -f kbs/docker/Dockerfile; \
-        DOCKER_BUILDKIT=1 docker build -t kbs:coco-as-grpc . -f kbs/docker/coco-as-grpc/Dockerfile; \
-        DOCKER_BUILDKIT=1 docker build -t kbs:coco-as-rhel-ubi . -f kbs/docker/rhel-ubi/Dockerfile; \
-        DOCKER_BUILDKIT=1 docker build -t kbs:coco-as-ita . -f kbs/docker/intel-trust-authority/Dockerfile
+  check_kbs_image_build:
+    uses: ./.github/workflows/build-kbs-image.yml
+    secrets: inherit

--- a/.github/workflows/push-as-image-to-ghcr.yml
+++ b/.github/workflows/push-as-image-to-ghcr.yml
@@ -6,85 +6,16 @@ on:
       - main
 
 jobs:
-  build_and_push:
+  build_and_push_as_image:
     permissions:
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        instance:
-          - ubuntu-latest
-          - s390x
-        tag:
-          - coco-as-grpc
-          - coco-as-restful
-          - rvps
-        verifier:
-          - all-verifier
-          - se-verifier
-        include:
-          - docker_file: attestation-service/docker/as-grpc/Dockerfile
-            tag: coco-as-grpc
-            name: gRPC CoCo-AS
-            verifier: all-verifier
-            instance: ubuntu-latest
-          - docker_file: attestation-service/docker/as-grpc/Dockerfile
-            tag: coco-as-grpc
-            name: gRPC CoCo-AS (IBM SE)
-            verifier: se-verifier
-            instance: s390x
-          - docker_file: attestation-service/docker/as-restful/Dockerfile
-            tag: coco-as-restful
-            name: RESTful CoCo-AS
-            verifier: all-verifier
-            instance: ubuntu-latest
-          - docker_file: attestation-service/docker/as-restful/Dockerfile
-            tag: coco-as-restful
-            name: RESTful CoCo-AS (IBM SE)
-            verifier: se-verifier
-            instance: s390x
-          - docker_file: rvps/docker/Dockerfile
-            tag: rvps
-            name: RVPS
-            verifier: all-verifier
-            instance: ubuntu-latest
-          - docker_file: rvps/docker/Dockerfile
-            tag: rvps
-            name: RVPS
-            verifier: se-verifier
-            instance: s390x
-        exclude:
-          - instance: ubuntu-latest
-            verifier: se-verifier
-          - instance: s390x
-            verifier: all-verifier
-    runs-on: ${{ matrix.instance }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Login to GHCR Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Build ${{ matrix.name }} Container Image
-      run: |
-        commit_sha=${{ github.sha }}
-        arch=$(uname -m)
-        DOCKER_BUILDKIT=1 docker build -f "${{ matrix.docker_file }}" --push --build-arg ARCH="${arch}" \
-          --build-arg VERIFIER="${{ matrix.verifier }}" \
-          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch}" \
-          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch}" .
+    uses: ./.github/workflows/build-as-image.yml
+    with:
+      build_option: --push
+    secrets: inherit
 
   publish_multi_arch_image:
-    needs: build_and_push
+    needs: build_and_push_as_image
     permissions:
       packages: write
     strategy:

--- a/.github/workflows/push-kbs-image-to-ghcr.yml
+++ b/.github/workflows/push-kbs-image-to-ghcr.yml
@@ -6,60 +6,16 @@ on:
       - main
 
 jobs:
-  build_and_push:
+  build_and_push_kbs_image:
     permissions:
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        instance:
-          - ubuntu-latest
-          - s390x
-        tag:
-          - kbs
-          - kbs-grpc-as
-          - kbs-ita-as
-        exclude:
-          - instance: s390x
-            tag: kbs-ita-as
-        include:
-          - tag: kbs
-            docker_file: kbs/docker/Dockerfile
-            name: build-in AS
-          - tag: kbs-grpc-as
-            docker_file: kbs/docker/coco-as-grpc/Dockerfile
-            name: gRPC AS
-          - tag: kbs-ita-as
-            docker_file: kbs/docker/intel-trust-authority/Dockerfile
-            name: Intel Trust Authority AS
-
-    runs-on: ${{ matrix.instance }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Login to GHCR Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Build Container Image KBS (${{ matrix.name }})
-      run: |
-        commit_sha=${{ github.sha }}
-        arch=$(uname -m)
-        DOCKER_BUILDKIT=1 docker build -f "${{ matrix.docker_file }}" --push \
-          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch}" \
-          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch}" \
-          --build-arg ARCH="${arch}" .
+    uses: ./.github/workflows/build-kbs-image.yml
+    with:
+      build_option: --push
+    secrets: inherit
 
   publish_multi_arch_image:
-    needs: build_and_push
+    needs: build_and_push_kbs_image
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Issue #568 highlights the need for an image build check for s390x, similar to what we have for x86_64. 
This PR addresses the need by:
- Extracting the image build steps from the push-{kbs,as}-image-to-ghcr workflow into separate workflows
- Configuring these workflows to run on PR events or after merging a PR

Notable change:
- On merge, the workflow now pushes `ghcr.io/confidential-containers/staged-images/rhel-ubi`

The changes on PR events have been verified with:
- KBS: https://github.com/BbolroC/trustee/actions/runs/11840113329
- AS: https://github.com/BbolroC/trustee/actions/runs/11839493749

The changes on merge needs to be verified after merging this PR. I will keep an eye on how it goes and bring things up immediately when something goes wrong. Thanks.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>
