### PR TITLE
kbs: fix configs in kubernetes deployments

### DIFF
--- a/kbs/config/kubernetes/base/kbs-config.toml
+++ b/kbs/config/kubernetes/base/kbs-config.toml
@@ -22,3 +22,8 @@ attestation_token_broker = "Simple"
 
 [admin]
 auth_public_key = "/kbs/kbs.pem"
+
+[[plugins]]
+name = "resource"
+type = "LocalFs"
+dir_path = "/opt/confidential-containers/kbs/repository"

--- a/kbs/config/kubernetes/ita/kbs-config.toml
+++ b/kbs/config/kubernetes/ita/kbs-config.toml
@@ -5,7 +5,7 @@ sockets = ["0.0.0.0:8080"]
 insecure_http = true
 
 [attestation_token]
-trusted_certs_paths = ["https://portal.trustauthority.intel.com"]
+trusted_jwk_sets = ["https://portal.trustauthority.intel.com"]
 
 [attestation_service]
 type = "intel_ta"
@@ -15,3 +15,8 @@ certs_file = "https://portal.trustauthority.intel.com"
 
 [admin]
 auth_public_key = "/kbs/kbs.pem"
+
+[[plugins]]
+name = "resource"
+type = "LocalFs"
+dir_path = "/opt/confidential-containers/kbs/repository"


### PR DESCRIPTION
some of the mandatory TOML entries were not correctly updated to the kubernetes deployments.

Follow ca9bf40e3b changes to update kbs/config/kubernetes TOML files too.