### PR TITLE
AS: Add error log print

### DIFF
--- a/attestation-service/src/bin/restful/mod.rs
+++ b/attestation-service/src/bin/restful/mod.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, bail, Context};
 use attestation_service::{AttestationService, HashAlgorithm};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use kbs_types::Tee;
-use log::{debug, info};
+use log::{debug, error, info};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use strum::AsRefStr;
@@ -22,6 +22,7 @@ impl ResponseError for Error {
     fn error_response(&self) -> HttpResponse {
         let body = format!("{self:#?}");
 
+        error!("{self:#?}");
         let mut res = match self {
             Error::InternalError(_) => HttpResponse::InternalServerError(),
             // _ => HttpResponse::NotImplemented(),


### PR DESCRIPTION
Before this commit, if error happens during serving the API, no explicit errors information will be printed on the terminal of AS.

With this patch, there will be an `error` log saying something like
```
[2024-11-15T09:41:59Z ERROR restful_as::restful] InternalError(
        Error {
            context: "attestation report evaluate",
            source: "Verifier evaluate failed: TDX Verifier: AA eventlog does not pass check. AAEL value : bb3dd9d0d81bcb0674b57992e6f8e8e3614fb6ce9006e7cf65c860bdea02db53df8e05b2d8479eae4fa8c8a06d5c4a88, Quote value 3f5b43108e554a781c46c3f47e6daf3de52e353358f032dc92add9b980ffdfb5e4861b7593d3d022538043c3fb72d431",
        },
    )
```