### PR TITLE
CI: consolidate matrix configurations

### DIFF
--- a/.github/workflows/as-docker-build.yml
+++ b/.github/workflows/as-docker-build.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - 'attestation-service/**'
       - '.github/workflows/as-docker-build.yml'
+      - '.github/workflows/build-as-image.yml'
       - 'Cargo.toml'
   create:
 

--- a/.github/workflows/build-as-image.yml
+++ b/.github/workflows/build-as-image.yml
@@ -14,51 +14,28 @@ jobs:
       fail-fast: false
       matrix:
         instance:
-          - ubuntu-latest
-          - s390x
-        tag:
-          - coco-as-grpc
-          - coco-as-restful
-          - rvps
-        verifier:
-          - all-verifier
-          - se-verifier
+        - ubuntu-latest
+        - s390x
+        name:
+        - RESTful CoCo-AS
+        - gRPC CoCo-AS
+        - RVPS
         include:
-          - docker_file: attestation-service/docker/as-grpc/Dockerfile
-            tag: coco-as-grpc
-            name: gRPC CoCo-AS
-            verifier: all-verifier
-            instance: ubuntu-latest
-          - docker_file: attestation-service/docker/as-grpc/Dockerfile
-            tag: coco-as-grpc
-            name: gRPC CoCo-AS (IBM SE)
-            verifier: se-verifier
-            instance: s390x
-          - docker_file: attestation-service/docker/as-restful/Dockerfile
-            tag: coco-as-restful
-            name: RESTful CoCo-AS
-            verifier: all-verifier
-            instance: ubuntu-latest
-          - docker_file: attestation-service/docker/as-restful/Dockerfile
-            tag: coco-as-restful
-            name: RESTful CoCo-AS (IBM SE)
-            verifier: se-verifier
-            instance: s390x
-          - docker_file: rvps/docker/Dockerfile
-            tag: rvps
-            name: RVPS
-            verifier: all-verifier
-            instance: ubuntu-latest
-          - docker_file: rvps/docker/Dockerfile
-            tag: rvps
-            name: RVPS
-            verifier: se-verifier
-            instance: s390x
-        exclude:
-          - instance: ubuntu-latest
-            verifier: se-verifier
-          - instance: s390x
-            verifier: all-verifier
+        # add docker_file + tag to each target
+        - name: gRPC CoCo-AS
+          docker_file: attestation-service/docker/as-grpc/Dockerfile
+          tag: coco-as-grpc
+        - name: RESTful CoCo-AS
+          docker_file: attestation-service/docker/as-restful/Dockerfile
+          tag: coco-as-restful
+        - name: RVPS
+          docker_file: rvps/docker/Dockerfile
+          tag: rvps
+        # add verifier flag to arch
+        - instance: ubuntu-latest
+          verifier: all-verifier
+        - instance: s390x
+          verifier: se-verifier
     runs-on: ${{ matrix.instance }}
 
     steps:


### PR DESCRIPTION
The current matrix configurations are more like an manual enumeration of build options expressed in verbose matrix/include/exclude statement.

The PR changes this into a simple matrix of the build and then use include to add required auxiliary fields to each of the valid matrix combinations.

(the kbs workflow already follows the same scheme)