### PR TITLE
gha: Skip duplicate image build on merge

### DIFF
--- a/.github/workflows/as-docker-build.yml
+++ b/.github/workflows/as-docker-build.yml
@@ -1,12 +1,5 @@
 name: AS/RVPS Container Image Build
 on:
-  push:
-    branches:
-      - "main"
-    paths:
-      - 'attestation-service/**'
-      - '.github/workflows/as-docker-build.yml'
-      - 'Cargo.toml'
   pull_request:
     paths:
       - 'attestation-service/**'
@@ -16,6 +9,5 @@ on:
 
 jobs:
   check_as_image_build:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
     uses: ./.github/workflows/build-as-image.yml
     secrets: inherit

--- a/.github/workflows/kbs-docker-build.yml
+++ b/.github/workflows/kbs-docker-build.yml
@@ -1,7 +1,5 @@
 name: KBS Container Image Build
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
The following workflows are triggered twice during a merge:

- build-kbs-image.yml
- build-as-image.yml

For self-hosted runners, which often have a limited number of available runners, this duplicate build is unnecessary and may cause CI bottlenecks.

This PR ensures the workflow of interest is skipped when `github.event_name` is `push`, which occurs during a merge.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>