### PR TITLE
verifier: Change logic to check the attestation report version

### DIFF
--- a/deps/verifier/src/snp/mod.rs
+++ b/deps/verifier/src/snp/mod.rs
@@ -37,6 +37,10 @@ const LOADER_SPL_OID: Oid<'static> = oid!(1.3.6 .1 .4 .1 .3704 .1 .3 .1);
 const KDS_CERT_SITE: &str = "https://kdsintf.amd.com";
 const KDS_VCEK: &str = "/vcek/v1";
 
+/// Attestation report versions supported 
+const REPORT_VERSION_MIN: u32 = 2;
+const REPORT_VERSION_MAX: u32 = 3;
+
 #[derive(Debug)]
 pub struct Snp {
     vendor_certs: VendorCertificates,
@@ -104,8 +108,9 @@ impl Verifier for Snp {
 
         verify_report_signature(&report, &cert_chain, &self.vendor_certs)?;
 
-        if report.version != 2 {
-            return Err(anyhow!("Unexpected report version"));
+        // See Trustee Issue#589 https://github.com/confidential-containers/trustee/issues/589
+        if report.version < REPORT_VERSION_MIN || report.version > REPORT_VERSION_MAX {
+            return Err(anyhow!("Unexpected attestation report version. Check SNP Firmware ABI specification"));
         }
 
         if report.vmpl != 0 {


### PR DESCRIPTION
Fixes Issue [#589](https://github.com/confidential-containers/trustee/issues/589)

Change the check condition to handle multiple attestation report versions.