### PR TITLE
Setup integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,31 @@
 version = 3
 
 [[package]]
+name = "actix"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de7fa236829ba0841304542f7614c42b80fca007455315c45c785ccfa873a85b"
+dependencies = [
+ "actix-macros",
+ "actix-rt",
+ "actix_derive",
+ "bitflags 2.6.0",
+ "bytes",
+ "crossbeam-channel",
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "actix-codec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +244,17 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project-lite",
+]
+
+[[package]]
+name = "actix_derive"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1295,6 +1331,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2824,6 +2869,7 @@ dependencies = [
 name = "kbs"
 version = "0.1.0"
 dependencies = [
+ "actix",
  "actix-web",
  "actix-web-httpauth",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
 dependencies = [
+ "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -430,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "arrayref"
@@ -1531,19 +1532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core 0.9.10",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,12 +2154,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
@@ -2698,6 +2680,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "integration-tests"
+version = "0.1.0"
+dependencies = [
+ "actix-rt",
+ "actix-web",
+ "anyhow",
+ "attestation-service",
+ "env_logger 0.10.2",
+ "kbs",
+ "kbs-client",
+ "log",
+ "openssl",
+ "rstest",
+ "serde_json",
+ "serial_test",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "intel-tee-quote-verification-rs"
 version = "0.3.0"
 source = "git+https://github.com/intel/SGXDataCenterAttestationPrimitives?tag=DCAP_1.22#2562057f6a3149c03f5985826ffaba978ece58c2"
@@ -3053,7 +3055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3885,30 +3887,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -4851,28 +4829,27 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "0.9.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92761393ee4dc3ff8f4af487bd58f4307c9329bbedea02cac0089ad9c411e153"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
 dependencies = [
- "dashmap",
  "futures",
- "lazy_static",
  "log",
+ "once_cell",
  "parking_lot 0.12.3",
+ "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "0.9.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6f5d1c3087fb119617cff2966fe3808a80e5eb59a8c1601d5994d66f4346a5"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5420,9 +5397,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "rvps",
     "tools/kbs-client",
     "deps/verifier",
+    "integration-tests",
 ]
 resolver = "2"
 
@@ -37,6 +38,7 @@ kbs-types = "0.7.0"
 kms = { git = "https://github.com/confidential-containers/guest-components.git", rev = "e6999a3c0fd877dae9e68ea78b8b483062db32b8", default-features = false }
 jsonwebtoken = { version = "9", default-features = false }
 log = "0.4.17"
+openssl = "0.10.55"
 prost = "0.13"
 regorus = { version = "0.2.6", default-features = false, features = [
     "regex",
@@ -51,7 +53,7 @@ rstest = "0.18.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.132"
 serde_with = { version = "1.11.0", features = ["base64", "hex"] }
-serial_test = "0.9.0"
+serial_test = { version = "3.2.0", features = ["async"] }
 sha2 = "0.10"
 shadow-rs = "0.19.0"
 strum = { version = "0.25", features = ["derive"] }

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -46,7 +46,7 @@ jsonwebtoken.workspace = true
 kbs-types.workspace = true
 lazy_static = "1.4.0"
 log.workspace = true
-openssl = "0.10.55"
+openssl.workspace = true
 prost = { workspace = true, optional = true }
 rand = "0.8.5"
 reference-value-provider-service.path = "../rvps"

--- a/attestation-service/src/token/simple_default_policy.rego
+++ b/attestation-service/src/token/simple_default_policy.rego
@@ -28,10 +28,11 @@
 package policy
 
 import future.keywords.every
+import future.keywords.if
 
-default allow = false
+default allow := false
 
-allow {
+allow if {
 	every k, v in input {
 		# `judge_field`: Traverse each key value pair in the input and make policy judgments on it.
 		#
@@ -44,7 +45,7 @@ allow {
 	}
 }
 
-judge_field(input_key, input_value) {
+judge_field(input_key, input_value) if {
 	has_key(data.reference, input_key)
 	reference_value := data.reference[input_key]
 
@@ -57,16 +58,16 @@ judge_field(input_key, input_value) {
 	match_value(reference_value, input_value)
 }
 
-judge_field(input_key, input_value) {
+judge_field(input_key, input_value) if {
 	not has_key(data.reference, input_key)
 }
 
-match_value(reference_value, input_value) {
+match_value(reference_value, input_value) if {
 	not is_array(reference_value)
 	input_value == reference_value
 }
 
-match_value(reference_value, input_value) {
+match_value(reference_value, input_value) if {
 	is_array(reference_value)
 
 	# `array_include`: judge the input value with the values in the array.
@@ -78,16 +79,16 @@ match_value(reference_value, input_value) {
 	array_include(reference_value, input_value)
 }
 
-array_include(reference_value_array, input_value) {
+array_include(reference_value_array, input_value) if {
 	reference_value_array == []
 }
 
-array_include(reference_value_array, input_value) {
+array_include(reference_value_array, input_value) if {
 	reference_value_array != []
 	some i
 	reference_value_array[i] == input_value
 }
 
-has_key(m, k) {
+has_key(m, k) if {
 	_ = m[k]
 }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "integration-tests"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+edition.workspace = true
+
+[dependencies] 
+kbs = { path = "../kbs" }
+attestation-service = { path = "../attestation-service" }
+kbs-client = { path = "../tools/kbs-client" }
+
+actix-web.workspace = true
+actix-rt = "2.10.0"
+anyhow.workspace = true
+env_logger.workspace = true
+log.workspace = true
+openssl.workspace = true
+rstest.workspace = true
+serde_json.workspace = true
+serial_test.workspace = true
+tempfile.workspace = true
+tokio.workspace = true

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -1,0 +1,218 @@
+// Copyright (c) 2024 by IBM.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use kbs::admin::config::AdminConfig;
+use kbs::attestation::config::{AttestationConfig, AttestationServiceConfig};
+use kbs::config::HttpServerConfig;
+use kbs::config::KbsConfig;
+use kbs::policy_engine::PolicyEngineConfig;
+use kbs::token::AttestationTokenVerifierConfig;
+use kbs::ApiServer;
+
+use kbs::plugins::{
+    implementations::{resource::local_fs::LocalFsRepoDesc, RepositoryConfig},
+    PluginsConfig,
+};
+
+use attestation_service::{
+    config::Config,
+    rvps::{RvpsConfig, RvpsCrateConfig},
+    token::{ear_broker, simple, AttestationTokenConfig},
+};
+
+use anyhow::{bail, Result};
+use log::info;
+use openssl::pkey::PKey;
+use rstest::rstest;
+use serial_test::serial;
+use std::io::Write;
+use tempfile::{NamedTempFile, TempDir};
+
+const KBS_URL: &str = "http://127.0.0.1:8080";
+const SECRET_BYTES: &[u8; 8] = b"shhhhhhh";
+const SECRET_PATH: &str = "default/test/secret";
+const WAIT_TIME: u64 = 3000;
+
+const ALLOW_ALL_POLICY: &str = "
+    package policy
+    allow = true
+";
+
+/*
+const DENY_ALL_POLICY: &str = "
+    package policy
+    allow = false
+";
+*/
+
+enum PolicyType {
+    AllowAll,
+    //DenyAll,
+    //Custom(String),
+}
+
+// Parameters that define test behavior (coming from rstest)
+struct TestParameters {
+    attestation_token_type: String,
+}
+
+// Internal state of tests
+struct TestHarness {
+    kbs_config: KbsConfig,
+    auth_privkey: String,
+
+    // Future tests will use some parameters at runtime
+    _test_parameters: TestParameters,
+}
+
+impl TestHarness {
+    fn new(test_parameters: TestParameters) -> Result<TestHarness> {
+        let auth_keypair = PKey::generate_ed25519()?;
+        let auth_pubkey = String::from_utf8(auth_keypair.public_key_to_pem()?)?;
+        let auth_privkey = String::from_utf8(auth_keypair.private_key_to_pem_pkcs8()?)?;
+
+        let work_dir = TempDir::new()?;
+        let resource_dir = TempDir::new()?;
+        let policy_path = NamedTempFile::new()?;
+
+        let mut auth_pubkey_path = NamedTempFile::new()?;
+        auth_pubkey_path.write(auth_pubkey.as_bytes())?;
+
+        let attestation_token_config = match &test_parameters.attestation_token_type[..] {
+            "Ear" => AttestationTokenConfig::Ear(ear_broker::Configuration {
+                duration_min: 5,
+                ..Default::default()
+            }),
+            "Simple" => AttestationTokenConfig::Simple(simple::Configuration::default()),
+            _ => bail!("Unknown attestation token type. Must be Simple or Ear"),
+        };
+
+        let kbs_config = KbsConfig {
+            attestation_token: AttestationTokenVerifierConfig {
+                trusted_certs_paths: vec![],
+                insecure_key: true,
+                trusted_jwk_sets: vec![],
+                extra_teekey_paths: vec![],
+            },
+            attestation_service: AttestationConfig {
+                attestation_service: AttestationServiceConfig::CoCoASBuiltIn(Config {
+                    work_dir: work_dir.path().to_path_buf(),
+                    rvps_config: RvpsConfig::BuiltIn(RvpsCrateConfig::default()),
+                    attestation_token_broker: attestation_token_config,
+                }),
+                timeout: 5,
+            },
+            http_server: HttpServerConfig {
+                sockets: vec!["127.0.0.1:8080".parse()?],
+                private_key: None,
+                certificate: None,
+                insecure_http: true,
+            },
+            admin: AdminConfig {
+                auth_public_key: None,
+                insecure_api: true,
+            },
+            policy_engine: PolicyEngineConfig {
+                policy_path: policy_path.path().to_path_buf(),
+            },
+            plugins: vec![PluginsConfig::ResourceStorage(RepositoryConfig::LocalFs(
+                LocalFsRepoDesc {
+                    dir_path: resource_dir.path().to_str().unwrap().to_string(),
+                },
+            ))],
+        };
+
+        Ok(TestHarness {
+            kbs_config,
+            auth_privkey,
+            _test_parameters: test_parameters,
+        })
+    }
+
+    async fn run(&self) -> Result<()> {
+        let api_server = ApiServer::new(self.kbs_config.clone()).await?;
+
+        let kbs_server = api_server.server()?;
+        let kbs_handle = kbs_server.handle();
+
+        actix_web::rt::spawn(kbs_server);
+
+        self.wait().await;
+        self.set_secret(SECRET_PATH.to_string(), SECRET_BYTES.as_ref().to_vec())
+            .await?;
+        self.set_policy(PolicyType::AllowAll).await?;
+
+        let secret = self.get_secret(SECRET_PATH.to_string()).await?;
+
+        assert_eq!(secret, SECRET_BYTES);
+        info!("TEST: test completed succesfully");
+
+        kbs_handle.stop(true).await;
+
+        Ok(())
+    }
+
+    async fn set_policy(&self, policy: PolicyType) -> Result<()> {
+        info!("TEST: Setting Resource Policy");
+
+        let policy_bytes = match policy {
+            PolicyType::AllowAll => ALLOW_ALL_POLICY.as_bytes().to_vec(),
+            //PolicyType::DenyAll => DENY_ALL_POLICY.as_bytes().to_vec(),
+            //PolicyType::Custom(p) => p.into_bytes(),
+        };
+
+        kbs_client::set_resource_policy(
+            KBS_URL,
+            self.auth_privkey.clone(),
+            policy_bytes,
+            // Optional HTTPS certs for KBS
+            vec![],
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn set_secret(&self, secret_path: String, secret_bytes: Vec<u8>) -> Result<()> {
+        info!("TEST: Setting Secret");
+        kbs_client::set_resource(
+            KBS_URL,
+            self.auth_privkey.clone(),
+            secret_bytes,
+            &secret_path,
+            // Optional HTTPS certs for KBS
+            vec![],
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn get_secret(&self, secret_path: String) -> Result<Vec<u8>> {
+        info!("TEST: Getting Secret");
+        let resource_bytes =
+            kbs_client::get_resource_with_attestation(KBS_URL, &secret_path, None, vec![]).await?;
+
+        Ok(resource_bytes)
+    }
+
+    async fn wait(&self) {
+        let duration = tokio::time::Duration::from_millis(WAIT_TIME);
+        tokio::time::sleep(duration).await;
+    }
+}
+
+#[rstest]
+#[case::ear_allow_all(TestParameters{attestation_token_type: "Ear".to_string() })]
+#[case::simple_allow_all(TestParameters{attestation_token_type: "Simple".to_string() })]
+#[serial]
+#[actix_rt::test]
+async fn integration(#[case] test_parameters: TestParameters) -> Result<()> {
+    let _ = env_logger::try_init_from_env(env_logger::Env::new().default_filter_or("debug"));
+
+    let harness = TestHarness::new(test_parameters)?;
+    harness.run().await?;
+
+    Ok(())
+}

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -34,6 +34,7 @@ aliyun = ["kms/aliyun"]
 pkcs11 = ["cryptoki"]
 
 [dependencies]
+actix = "0.13.5"
 actix-web = { workspace = true, features = ["openssl"] }
 actix-web-httpauth.workspace = true
 aes-gcm = "0.10.1"

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -69,7 +69,7 @@ time = { version = "0.3.23", features = ["std"] }
 tokio.workspace = true
 tonic = { workspace = true, optional = true }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
-openssl = "0.10.55"
+openssl.workspace = true
 az-cvm-vtpm = { version = "0.7.0", default-features = false, optional = true }
 derivative = "2.2.0"
 

--- a/kbs/Makefile
+++ b/kbs/Makefile
@@ -81,7 +81,7 @@ uninstall:
 	rm -rf $(INSTALL_DESTDIR)/kbs $(INSTALL_DESTDIR)/kbs-client $(INSTALL_DESTDIR)/issuer-kbs $(INSTALL_DESTDIR)/resource-kbs
 
 check:
-	cargo test -p kbs -p kbs-client
+	cargo test -p kbs -p kbs-client -p integration-tests
 
 lint:
 	cargo clippy -p kbs -p kbs-client -- -D warnings

--- a/kbs/src/bin/kbs.rs
+++ b/kbs/src/bin/kbs.rs
@@ -14,7 +14,7 @@ use kbs::{
 };
 use log::{debug, info};
 
-#[tokio::main]
+#[actix_web::main]
 async fn main() -> Result<()> {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
 

--- a/kbs/src/lib.rs
+++ b/kbs/src/lib.rs
@@ -10,7 +10,7 @@ pub mod attestation;
 /// KBS config
 pub mod config;
 pub use config::KbsConfig;
-mod token;
+pub mod token;
 
 /// Resource Policy Engine
 pub mod policy_engine;


### PR DESCRIPTION
Creates a framework for writing Trustee integration tests in Rust.

Put your tests in `integration-tests/tests/integration.rs` (or a similar file) and they will run when you do `cargo test` at the top level. 

I've added two simple integration tests. They aren't anything beyond what we already have in other tests, but they add a structure that should help us to create a lot more. Before I get too carried away, please take a look at the setup.

Note that running the KBS in the background was trickier than expected. I think I found a pretty good way to do it in the end.