### PR TITLE
ear: remove productId from default policy

### DIFF
--- a/attestation-service/src/policy_engine/opa/mod.rs
+++ b/attestation-service/src/policy_engine/opa/mod.rs
@@ -198,10 +198,9 @@ mod tests {
         "sourced_data",
     ];
 
-    fn dummy_reference(product_id: u64, svn: u64, launch_digest: String) -> String {
+    fn dummy_reference(svn: u64, launch_digest: String) -> String {
         json!({
             "reference": {
-                "productId": [product_id.to_string()],
                 "svn": [svn.to_string()],
                 "launch_digest": [launch_digest]
             }
@@ -209,10 +208,9 @@ mod tests {
         .to_string()
     }
 
-    fn dummy_input(product_id: u64, svn: u64, launch_digest: String) -> String {
+    fn dummy_input(svn: u64, launch_digest: String) -> String {
         json!({
             "sample": {
-                "productId": product_id.to_string(),
                 "svn": svn.to_string(),
                 "launch_digest": launch_digest
             }
@@ -221,14 +219,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case(5,5,1,1,"aac43bb3".to_string(),"aac43bb3".to_string(),3,2)]
-    #[case(5,4,1,1,"aac43bb3".to_string(),"aac43bb3".to_string(),3,97)]
-    #[case(5,5,1,1,"aac43bb4".to_string(),"aac43bb3".to_string(),33,2)]
-    #[case(5,5,2,1,"aac43bb4".to_string(),"aac43bb3".to_string(),33,97)]
+    #[case(1,1,"aac43bb3".to_string(),"aac43bb3".to_string(),3,2)]
+    #[case(2,1,"aac43bb3".to_string(),"aac43bb3".to_string(),3,97)]
+    #[case(1,1,"aac43bb4".to_string(),"aac43bb3".to_string(),33,2)]
+    #[case(2,1,"aac43bb4".to_string(),"aac43bb3".to_string(),33,97)]
     #[tokio::test]
     async fn test_evaluate(
-        #[case] pid_a: u64,
-        #[case] pid_b: u64,
         #[case] svn_a: u64,
         #[case] svn_b: u64,
         #[case] digest_a: String,
@@ -243,8 +239,8 @@ mod tests {
 
         let output = opa
             .evaluate(
-                &dummy_reference(pid_a, svn_a, digest_a),
-                &dummy_input(pid_b, svn_b, digest_b),
+                &dummy_reference(svn_a, digest_a),
+                &dummy_input(svn_b, digest_b),
                 &default_policy_id,
                 &EAR_RULES,
             )

--- a/attestation-service/src/token/ear_default_policy.rego
+++ b/attestation-service/src/token/ear_default_policy.rego
@@ -78,10 +78,6 @@ sample_executables := 3 if {
 #  verifications needed to demonstrate that these are genuine/
 #  supported.
 sample_hardware := 2 if {
-	# The sample attester does not report any productId.
-	# This is an exmple of how a real platform might identify the hardware
-	# that is running.
-	input.sample.productId in data.reference.productId
 	input.sample.svn in data.reference.svn
 }
 


### PR DESCRIPTION
The sample attester does not report a fake productId field, but we have used productId in our tests since before EAR.

The EAR policy erroneously expects the evidence to contain a productId, this leads to generating contra-indicated tokens for EAR.

Remove this field and update the tests.

cc @lmilleri 