### PR TITLE
token: avoid hard-coding ear claim names

### DIFF
--- a/attestation-service/src/policy_engine/mod.rs
+++ b/attestation-service/src/policy_engine/mod.rs
@@ -97,7 +97,7 @@ pub trait PolicyEngine: Send + Sync {
         data: &str,
         input: &str,
         policy_id: &str,
-        evaluation_rules: &[&str],
+        evaluation_rules: Vec<String>,
     ) -> Result<EvaluationResult, PolicyError>;
 
     async fn set_policy(&self, policy_id: String, policy: String) -> Result<(), PolicyError>;

--- a/attestation-service/src/policy_engine/opa/mod.rs
+++ b/attestation-service/src/policy_engine/opa/mod.rs
@@ -55,7 +55,7 @@ impl PolicyEngine for OPA {
         data: &str,
         input: &str,
         policy_id: &str,
-        evaluation_rules: &[&str],
+        evaluation_rules: Vec<String>,
     ) -> Result<EvaluationResult, PolicyError> {
         let policy_dir_path = self
             .policy_dir_path
@@ -192,21 +192,11 @@ impl PolicyEngine for OPA {
 
 #[cfg(test)]
 mod tests {
+    use ear::TrustVector;
     use rstest::rstest;
     use serde_json::json;
 
     use super::*;
-
-    const EAR_RULES: [&str; 8] = [
-        "instance_identity",
-        "configuration",
-        "executables",
-        "file_system",
-        "hardware",
-        "runtime_opaque",
-        "storage_opaque",
-        "sourced_data",
-    ];
 
     fn dummy_reference(svn: u64, launch_digest: String) -> String {
         json!({
@@ -247,12 +237,17 @@ mod tests {
         };
         let default_policy_id = "ear_default_policy".to_string();
 
+        let ear_rules = TrustVector::new()
+            .into_iter()
+            .map(|c| c.tag().to_string())
+            .collect();
+
         let output = opa
             .evaluate(
                 &dummy_reference(svn_a, digest_a),
                 &dummy_input(svn_b, digest_b),
                 &default_policy_id,
-                &EAR_RULES,
+                ear_rules,
             )
             .await
             .unwrap();

--- a/attestation-service/src/token/simple.rs
+++ b/attestation-service/src/token/simple.rs
@@ -40,8 +40,6 @@ const SIMPLE_TOKEN_ALG: &str = "RS384";
 
 const DEFAULT_POLICY_DIR: &str = concatcp!(DEFAULT_TOKEN_WORK_DIR, "/simple/policies");
 
-const RULES: &str = "allow";
-
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct TokenSignerConfig {
     pub key_path: String,
@@ -221,11 +219,13 @@ impl AttestationTokenBroker for SimpleAttestationTokenBroker {
         let reference_data = serde_json::to_string(&reference_data)?;
         let tcb_claims = serde_json::to_string(&flattened_claims)?;
 
+        let rules = vec!["allow".to_string()];
+
         let mut policies = HashMap::new();
         for policy_id in policy_ids {
             let policy_results = self
                 .policy_engine
-                .evaluate(&reference_data, &tcb_claims, &policy_id, &[RULES])
+                .evaluate(&reference_data, &tcb_claims, &policy_id, rules.clone())
                 .await?;
 
             // TODO add policy allowlist


### PR DESCRIPTION
Minor change to avoid hard-coding claim names.

Changes the policy engine to take `Vec<String>` to better suit this kind of dynamic configuration.