### PR TITLE
cluster: use latest staged images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
-version: '3.2'
 services:
   kbs:
     build:
       context: .
       dockerfile: kbs/docker/coco-as-grpc/Dockerfile
-    #image: ghcr.io/confidential-containers/key-broker-service:latest
+    image: ghcr.io/confidential-containers/staged-images/kbs-grpc-as:latest
     command: [
         "/usr/local/bin/kbs",
         "--config-file",
@@ -24,7 +23,7 @@ services:
     build:
       context: .
       dockerfile: attestation-service/docker/as-grpc/Dockerfile
-    #image: ghcr.io/confidential-containers/attestation-service:latest
+    image: ghcr.io/confidential-containers/staged-images/coco-as-grpc:latest
     ports:
     - "50004:50004"
     restart: always
@@ -43,10 +42,10 @@ services:
     - rvps
 
   rvps:
-    #image: ghcr.io/confidential-containers/reference-value-provider-service:latest
     build:
       context: .
       dockerfile: rvps/docker/Dockerfile
+    image: ghcr.io/confidential-containers/staged-images/rvps:latest
     restart: always # keep the server running
     ports:
       - "50003:50003"


### PR DESCRIPTION
ad991b7 disabled image pull because that pointed to release images and often times they had conflicts with local files in the repository.

As we now have staged images published on merge, we can try pulling images without forcing local builds (or local .yml editing).

Also, Compose warns about 'version' being obsolete so drop that too, while we're at it.