### PR TITLE
Push AS, RVPS, KBS and KBS Client for arm64

### DIFF
--- a/.github/workflows/build-as-image.yml
+++ b/.github/workflows/build-as-image.yml
@@ -35,14 +35,17 @@ jobs:
         # add instance and verifier flag to target
         - target_arch: x86_64
           target_platform: linux/amd64
+          build_platform: linux/amd64
           instance: ubuntu-latest
           verifier: all-verifier
         - target_arch: s390x
           target_platform: linux/s390x
+          build_platform: linux/s390x
           instance: s390x
           verifier: se-verifier
         - target_arch: aarch64
           target_platform: linux/arm64
+          build_platform: linux/amd64
           instance: ubuntu-latest
           verifier: cca-verifier
     runs-on: ${{ matrix.instance }}
@@ -66,6 +69,7 @@ jobs:
         commit_sha=${{ github.sha }}
         docker buildx build --platform "${{ matrix.target_platform }}" \
           -f "${{ matrix.docker_file }}" ${{ inputs.build_option }} \
+          --build-arg BUILDPLATFORM="${{ matrix.build_platform }}" \
           --build-arg ARCH="${{ matrix.target_arch }}" \
           --build-arg VERIFIER="${{ matrix.verifier }}" \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${{ matrix.target_arch }}" \

--- a/.github/workflows/build-as-image.yml
+++ b/.github/workflows/build-as-image.yml
@@ -13,9 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        instance:
-        - ubuntu-latest
+        target_arch:
+        - x86_64
         - s390x
+        - aarch64
         name:
         - RESTful CoCo-AS
         - gRPC CoCo-AS
@@ -31,11 +32,19 @@ jobs:
         - name: RVPS
           docker_file: rvps/docker/Dockerfile
           tag: rvps
-        # add verifier flag to arch
-        - instance: ubuntu-latest
+        # add instance and verifier flag to target
+        - target_arch: x86_64
+          target_platform: linux/amd64
+          instance: ubuntu-latest
           verifier: all-verifier
-        - instance: s390x
+        - target_arch: s390x
+          target_platform: linux/s390x
+          instance: s390x
           verifier: se-verifier
+        - target_arch: aarch64
+          target_platform: linux/arm64
+          instance: ubuntu-latest
+          verifier: cca-verifier
     runs-on: ${{ matrix.instance }}
 
     steps:
@@ -55,8 +64,9 @@ jobs:
     - name: Build ${{ matrix.name }} Container Image
       run: |
         commit_sha=${{ github.sha }}
-        arch=$(uname -m)
-        DOCKER_BUILDKIT=1 docker build -f "${{ matrix.docker_file }}" ${{ inputs.build_option }} --build-arg ARCH="${arch}" \
+        docker buildx build --platform "${{ matrix.target_platform }}" \
+          -f "${{ matrix.docker_file }}" ${{ inputs.build_option }} \
+          --build-arg ARCH="${{ matrix.target_arch }}" \
           --build-arg VERIFIER="${{ matrix.verifier }}" \
-          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch}" \
-          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch}" .
+          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${{ matrix.target_arch }}" \
+          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${{ matrix.target_arch }}" .

--- a/.github/workflows/build-kbs-image.yml
+++ b/.github/workflows/build-kbs-image.yml
@@ -13,20 +13,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        instance:
-          - ubuntu-latest
+        target_arch:
+          - x86_64
           - s390x
+          - aarch64
         tag:
           - kbs
           - kbs-grpc-as
           - kbs-ita-as
           - rhel-ubi
         exclude:
-          - instance: s390x
+          - target_arch: s390x
             tag: kbs-ita-as
-          - instance: s390x
+          - target_arch: s390x
+            tag: rhel-ubi
+          - target_arch: aarch64
+            tag: kbs-ita-as
+          - target_arch: aarch64
             tag: rhel-ubi
         include:
+          # add docker_file + name to each tag
           - tag: kbs
             docker_file: kbs/docker/Dockerfile
             name: build-in AS
@@ -39,6 +45,16 @@ jobs:
           - tag: rhel-ubi
             docker_file: kbs/docker/rhel-ubi/Dockerfile
             name: RHEL UBI AS
+          # add instance flag to target
+          - target_arch: x86_64
+            target_platform: linux/amd64
+            instance: ubuntu-latest
+          - target_arch: s390x
+            target_platform: linux/s390x
+            instance: s390x
+          - target_arch: aarch64
+            target_platform: linux/arm64
+            instance: ubuntu-latest
 
     runs-on: ${{ matrix.instance }}
 
@@ -59,8 +75,8 @@ jobs:
     - name: Build Container Image KBS (${{ matrix.name }})
       run: |
         commit_sha=${{ github.sha }}
-        arch=$(uname -m)
-        DOCKER_BUILDKIT=1 docker build -f "${{ matrix.docker_file }}" ${{ inputs.build_option }} \
-          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${arch}" \
-          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${arch}" \
-          --build-arg ARCH="${arch}" .
+        docker buildx build --platform "${{ matrix.target_platform }}" \
+          -f "${{ matrix.docker_file }}" ${{ inputs.build_option }} \
+          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${{ matrix.target_arch }}" \
+          -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${{ matrix.target_arch }}" \
+          --build-arg ARCH="${{ matrix.target_arch }}" .

--- a/.github/workflows/build-kbs-image.yml
+++ b/.github/workflows/build-kbs-image.yml
@@ -48,12 +48,15 @@ jobs:
           # add instance flag to target
           - target_arch: x86_64
             target_platform: linux/amd64
+            build_platform: linux/amd64
             instance: ubuntu-latest
           - target_arch: s390x
             target_platform: linux/s390x
+            build_platform: linux/s390x
             instance: s390x
           - target_arch: aarch64
             target_platform: linux/arm64
+            build_platform: linux/amd64
             instance: ubuntu-latest
 
     runs-on: ${{ matrix.instance }}
@@ -79,4 +82,5 @@ jobs:
           -f "${{ matrix.docker_file }}" ${{ inputs.build_option }} \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${{ matrix.target_arch }}" \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${{ matrix.target_arch }}" \
+          --build-arg BUILDPLATFORM="${{ matrix.build_platform }}" \
           --build-arg ARCH="${{ matrix.target_arch }}" .

--- a/.github/workflows/push-as-image-to-ghcr.yml
+++ b/.github/workflows/push-as-image-to-ghcr.yml
@@ -49,9 +49,11 @@ jobs:
         commit_sha=${{ github.sha }}
         docker manifest create "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}" \
           --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-s390x" \
+          --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-aarch64" \
           --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-x86_64"
         docker manifest push "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}"
         docker manifest create "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest" \
           --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-s390x" \
+          --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-aarch64" \
           --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-x86_64"
         docker manifest push "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest"

--- a/.github/workflows/push-kbs-client-to-ghcr.yml
+++ b/.github/workflows/push-kbs-client-to-ghcr.yml
@@ -14,13 +14,6 @@ jobs:
           - x86_64
           - s390x
           - aarch64
-        include:
-          - arch: x86_64
-            platform: linux/amd64
-          - arch: s390x
-            platform: linux/s390x
-          - arch: aarch64
-            platform: linux/arm64
     runs-on: ${{ matrix.arch == 's390x' && 's390x' || 'ubuntu-22.04' }}
     permissions:
       contents: read
@@ -42,8 +35,7 @@ jobs:
 
     - name: Build a statically linked kbs-client for ${{ matrix.arch }} linux
       run: |
-        docker buildx build --platform "${{ matrix.platform }}" \
-          -f kbs/docker/kbs-client/Dockerfile \
+        docker buildx build -f kbs/docker/kbs-client/Dockerfile \
           --build-arg ARCH="${{ matrix.arch }}" --output ./ .
 
     - name: Push to ghcr.io

--- a/.github/workflows/push-kbs-client-to-ghcr.yml
+++ b/.github/workflows/push-kbs-client-to-ghcr.yml
@@ -13,9 +13,15 @@ jobs:
         arch:
           - x86_64
           - s390x
-    env:
-      RUSTC_VERSION: 1.76.0
-    runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-22.04' || 's390x' }}
+          - aarch64
+        include:
+          - arch: x86_64
+            platform: linux/amd64
+          - arch: s390x
+            platform: linux/s390x
+          - arch: aarch64
+            platform: linux/arm64
+    runs-on: ${{ matrix.arch == 's390x' && 's390x' || 'ubuntu-22.04' }}
     permissions:
       contents: read
       packages: write
@@ -24,11 +30,8 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
 
-    - name: Install Rust toolchain (${{ env.RUSTC_VERSION }})
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: ${{ env.RUSTC_VERSION }}
-        components: rustfmt, clippy
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - name: Log in to ghcr.io
       uses: docker/login-action@v3
@@ -38,17 +41,17 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build a statically linked kbs-client for ${{ matrix.arch }} linux
-      working-directory: kbs
       run: |
-        make cli-static-linux
+        docker buildx build --platform "${{ matrix.platform }}" \
+          -f kbs/docker/kbs-client/Dockerfile \
+          --build-arg ARCH="${{ matrix.arch }}" --output ./ .
 
     - name: Push to ghcr.io
-      working-directory: target/${{ matrix.arch }}-unknown-linux-gnu/release
       run: |
         commit_sha=${{ github.sha }}
         oras push \
           ghcr.io/confidential-containers/staged-images/kbs-client:sample_only-${{ matrix.arch }}-linux-gnu-${commit_sha},latest-${{ matrix.arch }} \
           kbs-client
-        if [ "$(uname -m)" = "x86_64" ]; then
+        if [ "${{ matrix.arch }}" = "x86_64" ]; then
           oras push ghcr.io/confidential-containers/staged-images/kbs-client:latest kbs-client
         fi

--- a/.github/workflows/push-kbs-image-to-ghcr.yml
+++ b/.github/workflows/push-kbs-image-to-ghcr.yml
@@ -39,9 +39,11 @@ jobs:
         commit_sha=${{ github.sha }}
         docker manifest create "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}" \
           --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}-x86_64" \
+          --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}-aarch64" \
           --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}-s390x"
         docker manifest push "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:${commit_sha}"
         docker manifest create "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest" \
           --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest-x86_64" \
+          --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest-aarch64" \
           --amend "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest-s390x"
         docker manifest push "ghcr.io/confidential-containers/staged-images/${{ matrix.image }}:latest"

--- a/attestation-service/docker/as-grpc/Dockerfile
+++ b/attestation-service/docker/as-grpc/Dockerfile
@@ -2,7 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM rust:latest AS builder
+FROM --platform=$BUILDPLATFORM rust:latest AS builder
+ARG BUILDPLATFORM=linux/amd64
 ARG ARCH=x86_64
 ARG VERIFIER=all-verifier
 
@@ -18,7 +19,16 @@ RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/
     apt-get update && apt-get install -y libsgx-dcap-quote-verify-dev; fi
 
 # Build and Install gRPC attestation-service
-RUN cargo install --path attestation-service --bin grpc-as --features grpc-bin,${VERIFIER} --locked
+RUN if [ "$(uname -m)" != "${ARCH}" ]; then \
+    export GCC_PACKAGE="gcc-${ARCH}-linux-gnu"; \
+    export GCC_COMPILER="${ARCH}-linux-gnu-gcc"; \
+    export RUSTC_TARGET="${ARCH}-unknown-linux-gnu"; \
+    export TARGET_FLAG="--target ${RUSTC_TARGET}"; \
+    export RUSTFLAGS_ARGS=" -C linker=${GCC_COMPILER}"; \
+    export RUSTFLAGS="${RUSTFLAGS_ARGS}"; \
+    apt-get install -y ${GCC_PACKAGE}; \
+    rustup target add ${RUSTC_TARGET}; fi; \
+    cargo install --path attestation-service --bin grpc-as --features grpc-bin,${VERIFIER} --locked ${TARGET_FLAG}
 
 
 FROM ubuntu:22.04

--- a/attestation-service/docker/as-restful/Dockerfile
+++ b/attestation-service/docker/as-restful/Dockerfile
@@ -2,7 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM rust:latest AS builder
+FROM --platform=$BUILDPLATFORM rust:latest AS builder
+ARG BUILDPLATFORM=linux/amd64
 ARG ARCH=x86_64
 ARG VERIFIER=all-verifier
 
@@ -18,7 +19,16 @@ RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/
     apt-get update && apt-get install -y libsgx-dcap-quote-verify-dev; fi
 
 # Build and Install RESTful attestation-service
-RUN cargo install --path attestation-service --bin restful-as --features restful-bin,${VERIFIER} --locked
+RUN if [ "$(uname -m)" != "${ARCH}" ]; then \
+    export GCC_PACKAGE="gcc-${ARCH}-linux-gnu"; \
+    export GCC_COMPILER="${ARCH}-linux-gnu-gcc"; \
+    export RUSTC_TARGET="${ARCH}-unknown-linux-gnu"; \
+    export TARGET_FLAG="--target ${RUSTC_TARGET}"; \
+    export RUSTFLAGS_ARGS=" -C linker=${GCC_COMPILER}"; \
+    export RUSTFLAGS="${RUSTFLAGS_ARGS}"; \
+    apt-get install -y ${GCC_PACKAGE}; \
+    rustup target add ${RUSTC_TARGET}; fi; \
+    cargo install --path attestation-service --bin restful-as --features restful-bin,${VERIFIER} --locked ${TARGET_FLAG}
 
 FROM ubuntu:22.04
 ARG ARCH=x86_64

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -72,7 +72,7 @@ openssl = "0.10.55"
 az-cvm-vtpm = { version = "0.7.0", default-features = false, optional = true }
 derivative = "2.2.0"
 
-[target.'cfg(not(target_arch = "s390x"))'.dependencies]
+[target.'cfg(not(any(target_arch = "s390x", target_arch = "aarch64")))'.dependencies]
 attestation-service = { path = "../attestation-service", default-features = false, features = [
     "all-verifier",
 ], optional = true }
@@ -80,6 +80,11 @@ attestation-service = { path = "../attestation-service", default-features = fals
 [target.'cfg(target_arch = "s390x")'.dependencies]
 attestation-service = { path = "../attestation-service", default-features = false, features = [
     "se-verifier",
+], optional = true }
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+attestation-service = { path = "../attestation-service", default-features = false, features = [
+    "cca-verifier",
 ], optional = true }
 
 

--- a/kbs/Makefile
+++ b/kbs/Makefile
@@ -1,10 +1,33 @@
 AS_TYPE ?= coco-as
 ALIYUN ?= false
 
-ARCH := $(shell uname -m)
+BUILD_ARCH := $(shell uname -m)
+ARCH ?= $(shell uname -m)
 # Check if ARCH is supported, otehrwise return error
 ifeq ($(filter $(ARCH),x86_64 s390x aarch64),)
 	$(error "Unsupported architecture: $(ARCH)")
+endif
+
+RELEASE_DIR := ../target/release
+TARGET_FLAG :=
+CARGO_ENV :=
+ifneq ($(BUILD_ARCH), $(ARCH))
+  ifneq (,$(wildcard /etc/debian_version))
+    GCC_PACKAGE := gcc-$(ARCH)-linux-gnu
+    GCC_COMPILER := $(ARCH)-linux-gnu-gcc
+    RUSTC_TARGET := $(ARCH)-unknown-linux-gnu
+    GCC_INSTALL := $(shell sudo apt-get install -y ${GCC_PACKAGE})
+    RUST_INSTALL := $(shell rustup target add ${RUSTC_TARGET})
+    RUSTFLAGS_ARGS := -C linker=$(GCC_COMPILER)
+    TARGET_FLAG := --target $(RUSTC_TARGET)
+    RELEASE_DIR := ../target/$(RUSTC_TARGET)/release
+    OS_ARCH := $(ARCH)
+    OS_ARCH := $(OS_ARCH:x86_64=amd64)
+    OS_ARCH := $(OS_ARCH:aarch64=arm64)
+    CARGO_ENV := OPENSSL_INCLUDE_DIR=/usr/include/$(ARCH)-linux-gnu OPENSSL_LIB_DIR=/usr/lib/$(ARCH)-linux-gnu RUSTFLAGS="$(RUSTFLAGS_ARGS)"
+  else
+    $(error ERROR: Cross-compiling is only tested on Debian-like OSes)
+  endif
 endif
 
 CLI_FEATURES ?=
@@ -37,25 +60,25 @@ build: background-check-kbs
 
 .PHONY: background-check-kbs
 background-check-kbs:
-	cargo build -p kbs --locked --release --no-default-features --features $(FEATURES),$(AS_FEATURE)
+	$(CARGO_ENV) cargo build -p kbs --locked --release --no-default-features --features $(FEATURES),$(AS_FEATURE) $(TARGET_FLAG)
 
 .PHONY: passport-issuer-kbs
 passport-issuer-kbs:
-	cargo build -p kbs --locked --release --no-default-features --features $(AS_FEATURE),$(FEATURES)
+	$(CARGO_ENV) cargo build -p kbs --locked --release --no-default-features --features $(AS_FEATURE),$(FEATURES) $(TARGET_FLAG)
 	mv ../target/release/kbs ../target/release/issuer-kbs
 
 .PHONY: passport-resource-kbs
 passport-resource-kbs:
-	cargo build -p kbs --locked --release --no-default-features --features $(FEATURES),
+	$(CARGO_ENV) cargo build -p kbs --locked --release --no-default-features --features $(FEATURES), $(TARGET_FLAG)
 	mv ../target/release/kbs ../target/release/resource-kbs
 
 .PHONY: cli
 cli:
-	cargo build -p kbs-client --locked --release --no-default-features --features $(CLI_FEATURES)
+	$(CARGO_ENV) cargo build -p kbs-client --locked --release --no-default-features --features $(CLI_FEATURES) $(TARGET_FLAG)
 
 .PHONY: cli-static-linux
 cli-static-linux:
-	cargo build \
+	$(CARGO_ENV) cargo build \
       -p kbs-client \
       --target=$(ARCH)-unknown-linux-gnu \
       --config "target.$(ARCH)-unknown-linux-gnu.rustflags = '-C target-feature=+crt-static'" \
@@ -65,17 +88,17 @@ cli-static-linux:
       --features sample_only
 
 install-kbs:
-	install -D -m0755 ../target/release/kbs $(INSTALL_DESTDIR)
+	install -D -m0755 $(RELEASE_DIR)/kbs $(INSTALL_DESTDIR)
 
 install-issuer-kbs:
-	install -D -m0755 ../target/release/issuer-kbs $(INSTALL_DESTDIR)
-	install -D -m0755 ../target/release/kbs-client $(INSTALL_DESTDIR)
+	install -D -m0755 $(RELEASE_DIR)/issuer-kbs $(INSTALL_DESTDIR)
+	install -D -m0755 $(RELEASE_DIR)/kbs-client $(INSTALL_DESTDIR)
 
 install-resource-kbs:
-	install -D -m0755 ../target/release/resource-kbs $(INSTALL_DESTDIR)
+	install -D -m0755 $(RELEASE_DIR)/resource-kbs $(INSTALL_DESTDIR)
 
 install-cli:
-	install -D -m0755 ../target/release/kbs-client $(INSTALL_DESTDIR)
+	install -D -m0755 $(RELEASE_DIR)/kbs-client $(INSTALL_DESTDIR)
 
 uninstall:
 	rm -rf $(INSTALL_DESTDIR)/kbs $(INSTALL_DESTDIR)/kbs-client $(INSTALL_DESTDIR)/issuer-kbs $(INSTALL_DESTDIR)/resource-kbs

--- a/kbs/Makefile
+++ b/kbs/Makefile
@@ -3,7 +3,7 @@ ALIYUN ?= false
 
 ARCH := $(shell uname -m)
 # Check if ARCH is supported, otehrwise return error
-ifeq ($(filter $(ARCH),x86_64 s390x),)
+ifeq ($(filter $(ARCH),x86_64 s390x aarch64),)
 	$(error "Unsupported architecture: $(ARCH)")
 endif
 

--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:slim AS builder
+FROM --platform=$BUILDPLATFORM rust:slim AS builder
+ARG BUILDPLATFORM=linux/amd64
 ARG ARCH=x86_64
 ARG ALIYUN=false
 
@@ -9,7 +10,8 @@ RUN apt-get update && \
     curl \
     gpg \
     gnupg-agent \
-    git
+    git \
+    sudo
 
 RUN if [ "${ARCH}" = "x86_64" ]; then curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
     gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
@@ -36,8 +38,8 @@ RUN if [ "${ARCH}" = "x86_64" ]; then curl -fsSL https://download.01.org/intel-s
 WORKDIR /usr/src/kbs
 COPY . .
 
-RUN cd kbs && make AS_FEATURE=coco-as-builtin ALIYUN=${ALIYUN} && \
-    make install-kbs
+RUN cd kbs && make AS_FEATURE=coco-as-builtin ALIYUN=${ALIYUN} ARCH=${ARCH} && \
+    make ARCH=${ARCH} install-kbs
 
 FROM ubuntu:22.04
 ARG ARCH=x86_64

--- a/kbs/docker/coco-as-grpc/Dockerfile
+++ b/kbs/docker/coco-as-grpc/Dockerfile
@@ -1,15 +1,24 @@
-FROM rust:latest AS builder
+FROM --platform=$BUILDPLATFORM rust:latest AS builder
+ARG BUILDPLATFORM=linux/amd64
 ARG ARCH=x86_64
 ARG ALIYUN=false
 
 WORKDIR /usr/src/kbs
 COPY . .
 
-RUN apt-get update && apt install -y protobuf-compiler git
+RUN apt-get update && apt install -y protobuf-compiler git sudo
+
+ENV OS_ARCH=${ARCH}
+RUN if [ $(uname -m) != ${ARCH} ]; then \
+    OS_ARCH=$(echo $OS_ARCH | sed s/x86_64/amd64/); \
+    OS_ARCH=$(echo $OS_ARCH | sed s/aarch64/arm64/); \
+    dpkg --add-architecture ${OS_ARCH}; \
+    apt-get update; \
+    apt-get install -y libssl-dev:${OS_ARCH}; fi
 
 # Build and Install KBS
-RUN cd kbs && make AS_FEATURE=coco-as-grpc ALIYUN=${ALIYUN} && \
-    make install-kbs
+RUN cd kbs && make AS_FEATURE=coco-as-grpc ALIYUN=${ALIYUN} ARCH=${ARCH} && \
+    make ARCH=${ARCH} install-kbs
 
 FROM ubuntu:22.04
 

--- a/kbs/docker/kbs-client/Dockerfile
+++ b/kbs/docker/kbs-client/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:1.76.0 AS builder
+ARG ARCH=x86_64
+
+WORKDIR /usr/src/kbs
+COPY . .
+
+RUN apt-get update && apt install -y pkg-config libssl-dev git sudo
+
+# Build KBS Client
+RUN cd kbs && make ARCH=${ARCH} cli-static-linux && \
+    cp ../target/${ARCH}-unknown-linux-gnu/release/kbs-client /
+
+# Export view.txt
+FROM scratch AS export
+COPY --from=builder /kbs-client .

--- a/kbs/docker/kbs-client/Dockerfile
+++ b/kbs/docker/kbs-client/Dockerfile
@@ -6,6 +6,14 @@ COPY . .
 
 RUN apt-get update && apt install -y pkg-config libssl-dev git sudo
 
+ENV OS_ARCH=${ARCH}
+RUN if [ $(uname -m) != ${ARCH} ]; then \
+    OS_ARCH=$(echo $OS_ARCH | sed s/x86_64/amd64/); \
+    OS_ARCH=$(echo $OS_ARCH | sed s/aarch64/arm64/); \
+    dpkg --add-architecture ${OS_ARCH}; \
+    apt-get update; \
+    apt-get install -y libssl-dev:${OS_ARCH}; fi
+
 # Build KBS Client
 RUN cd kbs && make ARCH=${ARCH} cli-static-linux && \
     cp ../target/${ARCH}-unknown-linux-gnu/release/kbs-client /

--- a/rvps/docker/Dockerfile
+++ b/rvps/docker/Dockerfile
@@ -2,7 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM rust:latest AS builder
+FROM --platform=$BUILDPLATFORM rust:latest AS builder
+ARG BUILDPLATFORM=linux/amd64
+ARG ARCH=x86_64
 
 WORKDIR /usr/src/rvps
 
@@ -10,7 +12,16 @@ COPY . .
 
 RUN apt-get update && apt-get install protobuf-compiler -y
 
-RUN cargo install --bin rvps --path rvps
+RUN if [ "$(uname -m)" != "${ARCH}" ]; then \
+    export GCC_PACKAGE="gcc-${ARCH}-linux-gnu"; \
+    export GCC_COMPILER="${ARCH}-linux-gnu-gcc"; \
+    export RUSTC_TARGET="${ARCH}-unknown-linux-gnu"; \
+    export TARGET_FLAG="--target ${RUSTC_TARGET}"; \
+    export RUSTFLAGS_ARGS=" -C linker=${GCC_COMPILER}"; \
+    export RUSTFLAGS="${RUSTFLAGS_ARGS}"; \
+    apt-get install -y ${GCC_PACKAGE}; \
+    rustup target add ${RUSTC_TARGET}; fi; \
+    cargo install --bin rvps --path rvps ${TARGET_FLAG}
 
 FROM debian
 


### PR DESCRIPTION
Pushing AS, RVPS, KBS and KBS Client for arm64 to the project's GHCR using cross-compilation. This is an interim step. The native compilation will be introduced when arm runner is set up for CI.

Related: https://github.com/confidential-containers/trustee/issues/631