### PR TITLE
Fix ci failure

### DIFF
--- a/.github/workflows/build-as-image.yml
+++ b/.github/workflows/build-as-image.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Build ${{ matrix.name }} Container Image
       run: |
         commit_sha=${{ github.sha }}
-        docker buildx build --platform "${{ matrix.target_platform }}" \
+        docker buildx build --platform "${{ matrix.target_platform }}" --provenance false \
           -f "${{ matrix.docker_file }}" ${{ inputs.build_option }} \
           --build-arg BUILDPLATFORM="${{ matrix.build_platform }}" \
           --build-arg ARCH="${{ matrix.target_arch }}" \

--- a/.github/workflows/build-kbs-image.yml
+++ b/.github/workflows/build-kbs-image.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Build Container Image KBS (${{ matrix.name }})
       run: |
         commit_sha=${{ github.sha }}
-        docker buildx build --platform "${{ matrix.target_platform }}" \
+        docker buildx build --platform "${{ matrix.target_platform }}" --provenance false \
           -f "${{ matrix.docker_file }}" ${{ inputs.build_option }} \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${{ matrix.target_arch }}" \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${{ matrix.target_arch }}" \

--- a/kbs/docker/kbs-client/Dockerfile
+++ b/kbs/docker/kbs-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.76.0 AS builder
+FROM rust:1.78.0 AS builder
 ARG ARCH=x86_64
 
 WORKDIR /usr/src/kbs


### PR DESCRIPTION
related to https://github.com/confidential-containers/trustee/pull/639

Fix CI tests failures:

* The official rust docker image above v1.78.0 supports s390x - fix following
  * https://github.com/confidential-containers/trustee/actions/runs/12459314628/job/34775998845
* The multi-arch image can not be generated using manifest lists (including provenance) - fix following
  * https://github.com/confidential-containers/trustee/actions/runs/12459314629/job/34776189139
  * https://github.com/confidential-containers/trustee/actions/runs/12459314639/job/34776287203
  * https://github.com/confidential-containers/trustee/actions/runs/12459314629/job/34776189234
  * https://github.com/confidential-containers/trustee/actions/runs/12459314639/job/34776287307
  * https://github.com/confidential-containers/trustee/actions/runs/12459314629/job/34776189328