### PR TITLE
k8s: remove token signer from k8s config

### DIFF
--- a/kbs/config/kubernetes/base/kbs-config.toml
+++ b/kbs/config/kubernetes/base/kbs-config.toml
@@ -15,9 +15,6 @@ work_dir = "/opt/confidential-containers/attestation-service"
 type = "Ear"
 duration_min = 5
 
-[attestation_service.attestation_token_broker.signer]
-key_path = "/kbs/as-private-key.pem"
-
 [attestation_service.rvps_config]
 type = "BuiltIn"
 


### PR DESCRIPTION
The Kata CI does not setup the attestation token signing keys. This causes the KBS to break when we bump the repo version and pick up this new config which had the signing key specified.

In the future we can change the CI to setup the signing keys (although we are already testing this in our Makefile test), but for now let's stick with the existing behavior.