### PR TITLE
kbs: Bail if the jwk sets cannot be downloaded

### DIFF
--- a/kbs/src/token/jwk.rs
+++ b/kbs/src/token/jwk.rs
@@ -93,7 +93,7 @@ impl JwkAttestationTokenVerifier {
         for path in config.trusted_jwk_sets.iter() {
             match get_jwks_from_file_or_url(path).await {
                 Ok(mut jwkset) => trusted_jwk_sets.keys.append(&mut jwkset.keys),
-                Err(e) => log::warn!("error getting JWKS: {:?}", e),
+                Err(e) => bail!("error getting JWKS: {:?}", e),
             }
         }
 


### PR DESCRIPTION
Instead of just warning and proceeding, as done right now[0], let's bail as the current behaviour leads to an unusable KBS[1].

By bailing earlier at that point, when trustee pod is being deployed by the trustee-operator, we ensure that the pod will error out and kubernetes will take care of restarting the pod till its startup properly succeeds.

[0]:
```
[INFO  kbs] Using config file /etc/kbs-config/kbs-config.json
[WARN  kbs::token::jwk] error getting JWKS: SourceAccess("error sending request for url (https://portal.trustauthority.intel.com/.well-known/openid-configuration)")
[INFO  kbs] Starting HTTP server at [0.0.0.0:8080]
[WARN  kbs::token::jwk] error getting JWKS: SourceAccess("error sending request for url (https://portal.trustauthority.intel.com/.well-known/openid-configuration)")
[INFO  actix_server::builder] starting 56 workers
[INFO  actix_server::server] Tokio runtime found; starting in existing Tokio runtime
```

[1]:
```
[INFO  actix_web::middleware::logger] 10.128.0.32 "POST /kbs/v0/attest HTTP/1.1" 401 218 "-" "attestation-agent-kbs-client/0.1.0" 0.279838
[INFO  kbs::http::attest] Auth API called.
[INFO  actix_web::middleware::logger] 10.128.0.32 "POST /kbs/v0/auth HTTP/1.1" 200 108 "-" "attestation-agent-kbs-client/0.1.0" 0.000334
[INFO  kbs::http::attest] Attest API called.
[INFO  kbs::attestation::intel_trust_authority] POST attestation request ...
[ERROR kbs::http::error] Attestation failed: Failed to verify attestation token

    Caused by:
        Cannot verify token since trusted JWK Set is empty
```