### PR TITLE
verifier: Rename user_data to report_data in SeAttestationClaims

### DIFF
--- a/deps/verifier/src/se/ibmse.rs
+++ b/deps/verifier/src/se/ibmse.rs
@@ -90,7 +90,7 @@ pub struct SeAttestationResponse {
 pub struct SeAttestationClaims {
     #[serde_as(as = "Hex")]
     cuid: ConfigUid,
-    user_data: String,
+    report_data: String,
     version: u32,
     #[serde_as(as = "Hex")]
     image_phkh: Vec<u8>,
@@ -217,7 +217,7 @@ impl SeVerifierImpl {
 
         let claims = SeAttestationClaims {
             cuid: se_response.cuid,
-            user_data: String::from_utf8(se_response.user_data.clone())?,
+            report_data: String::from_utf8(se_response.user_data.clone())?,
             version: AttestationVersion::One as u32,
             image_phkh: image_phkh.to_vec(),
             attestation_phkh: attestation_phkh.to_vec(),


### PR DESCRIPTION
The EAR token broker does not insert the `report_data` for SE attestation claim because there is no matching field in `SeAttestationClaims`. The absence leads to `TokenVerifierError(NoTeePubKeyClaimFound)` after successful attestation.

As an interim solution, this PR renames the existing `user_data` to `report_data`, enabling the token broker to perform its task correctly.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>