### PR TITLE
Snp add report claim

### DIFF
--- a/deps/verifier/src/snp/mod.rs
+++ b/deps/verifier/src/snp/mod.rs
@@ -317,11 +317,10 @@ pub(crate) fn parse_tee_evidence(report: &AttestationReport) -> TeeEvidenceParse
         "platform_tsme_enabled": format!("{}", report.plat_info.tsme_enabled()),
         "platform_smt_enabled": format!("{}", report.plat_info.smt_enabled()),
 
-        // measurement
+        // measurements
         "measurement": format!("{}", STANDARD.encode(report.measurement)),
-
-        // report data
         "report_data": format!("{}", STANDARD.encode(report.report_data)),
+        "init_data": format!("{}", STANDARD.encode(report.host_data)),
     });
 
     claims_map as TeeEvidenceParsedClaim

--- a/deps/verifier/src/snp/mod.rs
+++ b/deps/verifier/src/snp/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use base64::Engine;
+use base64::{Engine, engine::general_purpose::STANDARD};
 use log::{debug, warn};
 extern crate serde;
 use self::serde::{Deserialize, Serialize};
@@ -318,7 +318,10 @@ pub(crate) fn parse_tee_evidence(report: &AttestationReport) -> TeeEvidenceParse
         "platform_smt_enabled": format!("{}", report.plat_info.smt_enabled()),
 
         // measurement
-        "measurement": format!("{}", base64::engine::general_purpose::STANDARD.encode(report.measurement)),
+        "measurement": format!("{}", STANDARD.encode(report.measurement)),
+
+        // report data
+        "report_data": format!("{}", STANDARD.encode(report.report_data)),
     });
 
     claims_map as TeeEvidenceParsedClaim


### PR DESCRIPTION
The EAR broker expects the verifier to include `report_data` in the TCB claims as a signal that the verifier has checked the binding of the report data and the hw evidence.

Since we do check `report_data` in the SNP verifier, add the claim. Also add `init_data` claim for similar reasons.