### PR TITLE
ear: add TDX sample policy checks

### DIFF
--- a/attestation-service/src/token/ear_default_policy.rego
+++ b/attestation-service/src/token/ear_default_policy.rego
@@ -86,7 +86,33 @@ else := 3 if {
 	input.snp.policy_migrate_ma == 0
 }
 
-##### TDX TODO
+##### TDX
+executables := 3 if {
+	# Check the kernel, initrd, and cmdline (including dmverity parameters) measurements
+	# TODO: add individual CCEL measurements from input.tdx.ccel instead
+	input.tdx.quote.body.rtmr_1 in data.reference.rtmr_1
+	input.tdx.quote.body.rtmr_2 in data.reference.rtmr_2
+}
+
+hardware := 2 if {
+	# Check the quote is a TDX quote signed by Intel SGX Quoting Enclave
+	input.tdx.quote.header.tee_type == "81000000"
+	input.tdx.quote.header.vendor_id == "939a7233f79c4ca9940a0db3957f0607"
+
+	# Check TDX Module version and its hash. Also check OVMF code hash.
+	input.tdx.quote.body.mr_seam in data.reference.mr_seam
+	input.tdx.quote.body.tcb_svn in data.reference.tcb_svn
+	input.tdx.quote.body.mr_td in data.reference.mr_td
+}
+
+configuration := 2 if {
+	# Check the TD has the expected attributes (e.g., debug not enabled)
+	# and features.
+	# TODO: split td_attribute bits to their own claims
+	input.tdx.quote.body.td_attributes in data.reference.td_attributes
+	input.tdx.quote.body.xfam in data.reference.xfam
+}
+
 ##### AZ SNP TODO
 ##### AZ TDX TODO
 ##### SE TODO


### PR DESCRIPTION
Something I drafted together with @jorgealmansa.

Populate the default EAR policy with an initial TDX policy configuration.