### PR TITLE
Reorganized integration tests and add negative tests

### DIFF
--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 by IBM.
+// Copyright (c) 2025 by IBM.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,30 +8,25 @@ use kbs::config::HttpServerConfig;
 use kbs::config::KbsConfig;
 use kbs::policy_engine::PolicyEngineConfig;
 use kbs::token::AttestationTokenVerifierConfig;
-use kbs::ApiServer;
 
 use kbs::plugins::{
-    implementations::{resource::local_fs::LocalFsRepoDesc, RepositoryConfig},
-    PluginsConfig,
+        implementations::{resource::local_fs::LocalFsRepoDesc, RepositoryConfig},
+            PluginsConfig,
 };
 
 use attestation_service::{
-    config::Config,
-    rvps::{RvpsConfig, RvpsCrateConfig},
-    token::{ear_broker, simple, AttestationTokenConfig},
+        config::Config,
+            rvps::{RvpsConfig, RvpsCrateConfig},
+                token::{ear_broker, simple, AttestationTokenConfig},
 };
 
 use anyhow::{bail, Result};
 use log::info;
 use openssl::pkey::PKey;
-use rstest::rstest;
-use serial_test::serial;
 use std::io::Write;
 use tempfile::{NamedTempFile, TempDir};
 
 const KBS_URL: &str = "http://127.0.0.1:8080";
-const SECRET_BYTES: &[u8; 8] = b"shhhhhhh";
-const SECRET_PATH: &str = "default/test/secret";
 const WAIT_TIME: u64 = 3000;
 
 const ALLOW_ALL_POLICY: &str = "
@@ -44,20 +39,20 @@ const DENY_ALL_POLICY: &str = "
     allow = false
 ";
 
-enum PolicyType {
+pub enum PolicyType {
     AllowAll,
     DenyAll,
     //Custom(String),
 }
 
 // Parameters that define test behavior (coming from rstest)
-struct TestParameters {
-    attestation_token_type: String,
+pub struct TestParameters {
+    pub attestation_token_type: String,
 }
 
 // Internal state of tests
-struct TestHarness {
-    kbs_config: KbsConfig,
+pub struct TestHarness {
+    pub kbs_config: KbsConfig,
     auth_privkey: String,
 
     // Future tests will use some parameters at runtime
@@ -65,7 +60,7 @@ struct TestHarness {
 }
 
 impl TestHarness {
-    fn new(test_parameters: TestParameters) -> Result<TestHarness> {
+    pub fn new(test_parameters: TestParameters) -> Result<TestHarness> {
         let auth_keypair = PKey::generate_ed25519()?;
         let auth_pubkey = String::from_utf8(auth_keypair.public_key_to_pem()?)?;
         let auth_privkey = String::from_utf8(auth_keypair.private_key_to_pem_pkcs8()?)?;
@@ -128,7 +123,7 @@ impl TestHarness {
         })
     }
 
-    async fn set_policy(&self, policy: PolicyType) -> Result<()> {
+    pub async fn set_policy(&self, policy: PolicyType) -> Result<()> {
         info!("TEST: Setting Resource Policy");
 
         let policy_bytes = match policy {
@@ -149,7 +144,7 @@ impl TestHarness {
         Ok(())
     }
 
-    async fn set_secret(&self, secret_path: String, secret_bytes: Vec<u8>) -> Result<()> {
+    pub async fn set_secret(&self, secret_path: String, secret_bytes: Vec<u8>) -> Result<()> {
         info!("TEST: Setting Secret");
         kbs_client::set_resource(
             KBS_URL,
@@ -164,7 +159,7 @@ impl TestHarness {
         Ok(())
     }
 
-    async fn get_secret(&self, secret_path: String) -> Result<Vec<u8>> {
+    pub async fn get_secret(&self, secret_path: String) -> Result<Vec<u8>> {
         info!("TEST: Getting Secret");
         let resource_bytes =
             kbs_client::get_resource_with_attestation(KBS_URL, &secret_path, None, vec![]).await?;
@@ -172,71 +167,8 @@ impl TestHarness {
         Ok(resource_bytes)
     }
 
-    async fn wait(&self) {
+    pub async fn wait(&self) {
         let duration = tokio::time::Duration::from_millis(WAIT_TIME);
         tokio::time::sleep(duration).await;
     }
-}
-
-#[rstest]
-#[case::ear_allow_all(TestParameters{attestation_token_type: "Ear".to_string() })]
-#[case::simple_allow_all(TestParameters{attestation_token_type: "Simple".to_string() })]
-#[serial]
-#[actix_rt::test]
-async fn get_secret_allow_all(#[case] test_parameters: TestParameters) -> Result<()> {
-    let _ = env_logger::try_init_from_env(env_logger::Env::new().default_filter_or("debug"));
-    let harness = TestHarness::new(test_parameters)?;
-
-    let api_server = ApiServer::new(harness.kbs_config.clone()).await?;
-
-    let kbs_server = api_server.server()?;
-    let kbs_handle = kbs_server.handle();
-
-    actix_web::rt::spawn(kbs_server);
-
-    harness.wait().await;
-    harness.set_secret(SECRET_PATH.to_string(), SECRET_BYTES.as_ref().to_vec())
-        .await?;
-    harness.set_policy(PolicyType::AllowAll).await?;
-
-    let secret = harness.get_secret(SECRET_PATH.to_string()).await?;
-
-    assert_eq!(secret, SECRET_BYTES);
-    info!("TEST: test completed succesfully");
-
-    kbs_handle.stop(true).await;
-
-    Ok(())
-}
-
-#[rstest]
-#[case::ear_deny_all(TestParameters{attestation_token_type: "Ear".to_string() })]
-#[case::simple_deny_all(TestParameters{attestation_token_type: "Simple".to_string() })]
-#[serial]
-#[actix_rt::test]
-async fn get_secret_deny_all(#[case] test_parameters: TestParameters) -> Result<()> {
-    let _ = env_logger::try_init_from_env(env_logger::Env::new().default_filter_or("debug"));
-    let harness = TestHarness::new(test_parameters)?;
-
-    let api_server = ApiServer::new(harness.kbs_config.clone()).await?;
-
-    let kbs_server = api_server.server()?;
-    let kbs_handle = kbs_server.handle();
-
-    actix_web::rt::spawn(kbs_server);
-
-    harness.wait().await;
-    harness.set_secret(SECRET_PATH.to_string(), SECRET_BYTES.as_ref().to_vec())
-        .await?;
-    harness.set_policy(PolicyType::DenyAll).await?;
-
-    let secret = harness.get_secret(SECRET_PATH.to_string()).await;
-
-    assert!(secret.is_err());
-    assert_eq!(secret.unwrap_err().to_string(), "request unauthorized".to_string());
-    info!("TEST: test completed succesfully");
-
-    kbs_handle.stop(true).await;
-
-    Ok(())
 }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,0 +1,5 @@
+// Copyright (c) 2025 by IBM.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod common;

--- a/integration-tests/tests/get_resource.rs
+++ b/integration-tests/tests/get_resource.rs
@@ -1,0 +1,79 @@
+// Copyright (c) 2024 by IBM.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use kbs::ApiServer;
+
+use anyhow::Result;
+use log::info;
+use rstest::rstest;
+use serial_test::serial;
+
+extern crate integration_tests;
+use crate::integration_tests::common::{PolicyType, TestHarness, TestParameters};
+
+const SECRET_BYTES: &[u8; 8] = b"shhhhhhh";
+const SECRET_PATH: &str = "default/test/secret";
+
+#[rstest]
+#[case::ear_allow_all(TestParameters{attestation_token_type: "Ear".to_string() })]
+#[case::simple_allow_all(TestParameters{attestation_token_type: "Simple".to_string() })]
+#[serial]
+#[actix_rt::test]
+async fn get_secret_allow_all(#[case] test_parameters: TestParameters) -> Result<()> {
+    let _ = env_logger::try_init_from_env(env_logger::Env::new().default_filter_or("debug"));
+    let harness = TestHarness::new(test_parameters)?;
+
+    let api_server = ApiServer::new(harness.kbs_config.clone()).await?;
+
+    let kbs_server = api_server.server()?;
+    let kbs_handle = kbs_server.handle();
+
+    actix_web::rt::spawn(kbs_server);
+
+    harness.wait().await;
+    harness.set_secret(SECRET_PATH.to_string(), SECRET_BYTES.as_ref().to_vec())
+        .await?;
+    harness.set_policy(PolicyType::AllowAll).await?;
+
+    let secret = harness.get_secret(SECRET_PATH.to_string()).await?;
+
+    assert_eq!(secret, SECRET_BYTES);
+    info!("TEST: test completed succesfully");
+
+    kbs_handle.stop(true).await;
+
+    Ok(())
+}
+
+#[rstest]
+#[case::ear_deny_all(TestParameters{attestation_token_type: "Ear".to_string() })]
+#[case::simple_deny_all(TestParameters{attestation_token_type: "Simple".to_string() })]
+#[serial]
+#[actix_rt::test]
+async fn get_secret_deny_all(#[case] test_parameters: TestParameters) -> Result<()> {
+    let _ = env_logger::try_init_from_env(env_logger::Env::new().default_filter_or("debug"));
+    let harness = TestHarness::new(test_parameters)?;
+
+    let api_server = ApiServer::new(harness.kbs_config.clone()).await?;
+
+    let kbs_server = api_server.server()?;
+    let kbs_handle = kbs_server.handle();
+
+    actix_web::rt::spawn(kbs_server);
+
+    harness.wait().await;
+    harness.set_secret(SECRET_PATH.to_string(), SECRET_BYTES.as_ref().to_vec())
+        .await?;
+    harness.set_policy(PolicyType::DenyAll).await?;
+
+    let secret = harness.get_secret(SECRET_PATH.to_string()).await;
+
+    assert!(secret.is_err());
+    assert_eq!(secret.unwrap_err().to_string(), "request unauthorized".to_string());
+    info!("TEST: test completed succesfully");
+
+    kbs_handle.stop(true).await;
+
+    Ok(())
+}

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -130,29 +130,6 @@ impl TestHarness {
         })
     }
 
-    async fn run(&self) -> Result<()> {
-        let api_server = ApiServer::new(self.kbs_config.clone()).await?;
-
-        let kbs_server = api_server.server()?;
-        let kbs_handle = kbs_server.handle();
-
-        actix_web::rt::spawn(kbs_server);
-
-        self.wait().await;
-        self.set_secret(SECRET_PATH.to_string(), SECRET_BYTES.as_ref().to_vec())
-            .await?;
-        self.set_policy(PolicyType::AllowAll).await?;
-
-        let secret = self.get_secret(SECRET_PATH.to_string()).await?;
-
-        assert_eq!(secret, SECRET_BYTES);
-        info!("TEST: test completed succesfully");
-
-        kbs_handle.stop(true).await;
-
-        Ok(())
-    }
-
     async fn set_policy(&self, policy: PolicyType) -> Result<()> {
         info!("TEST: Setting Resource Policy");
 
@@ -208,11 +185,28 @@ impl TestHarness {
 #[case::simple_allow_all(TestParameters{attestation_token_type: "Simple".to_string() })]
 #[serial]
 #[actix_rt::test]
-async fn integration(#[case] test_parameters: TestParameters) -> Result<()> {
+async fn get_secret_allow_all(#[case] test_parameters: TestParameters) -> Result<()> {
     let _ = env_logger::try_init_from_env(env_logger::Env::new().default_filter_or("debug"));
-
     let harness = TestHarness::new(test_parameters)?;
-    harness.run().await?;
+
+    let api_server = ApiServer::new(harness.kbs_config.clone()).await?;
+
+    let kbs_server = api_server.server()?;
+    let kbs_handle = kbs_server.handle();
+
+    actix_web::rt::spawn(kbs_server);
+
+    harness.wait().await;
+    harness.set_secret(SECRET_PATH.to_string(), SECRET_BYTES.as_ref().to_vec())
+        .await?;
+    harness.set_policy(PolicyType::AllowAll).await?;
+
+    let secret = harness.get_secret(SECRET_PATH.to_string()).await?;
+
+    assert_eq!(secret, SECRET_BYTES);
+    info!("TEST: test completed succesfully");
+
+    kbs_handle.stop(true).await;
 
     Ok(())
 }

--- a/integration-tests/tests/integration.rs
+++ b/integration-tests/tests/integration.rs
@@ -39,16 +39,14 @@ const ALLOW_ALL_POLICY: &str = "
     allow = true
 ";
 
-/*
 const DENY_ALL_POLICY: &str = "
     package policy
     allow = false
 ";
-*/
 
 enum PolicyType {
     AllowAll,
-    //DenyAll,
+    DenyAll,
     //Custom(String),
 }
 
@@ -135,7 +133,7 @@ impl TestHarness {
 
         let policy_bytes = match policy {
             PolicyType::AllowAll => ALLOW_ALL_POLICY.as_bytes().to_vec(),
-            //PolicyType::DenyAll => DENY_ALL_POLICY.as_bytes().to_vec(),
+            PolicyType::DenyAll => DENY_ALL_POLICY.as_bytes().to_vec(),
             //PolicyType::Custom(p) => p.into_bytes(),
         };
 
@@ -204,6 +202,38 @@ async fn get_secret_allow_all(#[case] test_parameters: TestParameters) -> Result
     let secret = harness.get_secret(SECRET_PATH.to_string()).await?;
 
     assert_eq!(secret, SECRET_BYTES);
+    info!("TEST: test completed succesfully");
+
+    kbs_handle.stop(true).await;
+
+    Ok(())
+}
+
+#[rstest]
+#[case::ear_deny_all(TestParameters{attestation_token_type: "Ear".to_string() })]
+#[case::simple_deny_all(TestParameters{attestation_token_type: "Simple".to_string() })]
+#[serial]
+#[actix_rt::test]
+async fn get_secret_deny_all(#[case] test_parameters: TestParameters) -> Result<()> {
+    let _ = env_logger::try_init_from_env(env_logger::Env::new().default_filter_or("debug"));
+    let harness = TestHarness::new(test_parameters)?;
+
+    let api_server = ApiServer::new(harness.kbs_config.clone()).await?;
+
+    let kbs_server = api_server.server()?;
+    let kbs_handle = kbs_server.handle();
+
+    actix_web::rt::spawn(kbs_server);
+
+    harness.wait().await;
+    harness.set_secret(SECRET_PATH.to_string(), SECRET_BYTES.as_ref().to_vec())
+        .await?;
+    harness.set_policy(PolicyType::DenyAll).await?;
+
+    let secret = harness.get_secret(SECRET_PATH.to_string()).await;
+
+    assert!(secret.is_err());
+    assert_eq!(secret.unwrap_err().to_string(), "request unauthorized".to_string());
     info!("TEST: test completed succesfully");
 
     kbs_handle.stop(true).await;

--- a/kbs/docs/kbs_attestation_protocol.md
+++ b/kbs/docs/kbs_attestation_protocol.md
@@ -473,7 +473,7 @@ A POST request with the content of resource to `/kbs/v0/resource/<repository>/<t
 Authenticated attesters can also receive an attestation token from the KBS in the response body of `/kbs/v0/attest`.
 Attesters can use the attestation result token to request additional resources from external services, a.k.a. relying parties. 
 
-The provided attestation results token follows the [JSON web token](https://jwt.io/) standard and format.
+The provided attestation results token follows the [JSON web token](https://datatracker.ietf.org/doc/html/rfc7519) standard and format.
 
 ##### Header
 


### PR DESCRIPTION
Main changes:

- Move the test logic out of the test harness so we can write more flexible tests using helpers provided by the harness.
- Separate the common testing code from the get_resource tests and move the common code into `src`.
- Add simple negative test

This is an incremental step towards more legit tests that have sophisticated policies and deal with reference values.