### PR TITLE
verifier: add parsing tdx td attributes and usage in policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -33,7 +33,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -57,7 +57,7 @@ dependencies = [
  "actix-utils",
  "ahash 0.8.11",
  "base64 0.22.1",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "brotli",
  "bytes",
  "bytestring",
@@ -892,9 +892,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "blake2b_simd"
@@ -3065,7 +3065,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libc",
 ]
 
@@ -3413,7 +3413,7 @@ version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -4086,7 +4086,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -4430,7 +4430,7 @@ version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4694,7 +4694,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5869,6 +5869,7 @@ dependencies = [
  "az-tdx-vtpm",
  "base64 0.22.1",
  "bincode",
+ "bitflags 2.8.0",
  "byteorder",
  "cfg-if",
  "codicon",

--- a/attestation-service/src/token/ear_default_policy.rego
+++ b/attestation-service/src/token/ear_default_policy.rego
@@ -106,10 +106,8 @@ hardware := 2 if {
 }
 
 configuration := 2 if {
-	# Check the TD has the expected attributes (e.g., debug not enabled)
-	# and features.
-	# TODO: split td_attribute bits to their own claims
-	input.tdx.quote.body.td_attributes in data.reference.td_attributes
+	# Check the TD has the expected attributes (e.g., debug not enabled) and features.
+	input.tdx.td_attributes.debug == false
 	input.tdx.quote.body.xfam in data.reference.xfam
 }
 

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -50,6 +50,7 @@ veraison-apiclient = { git = "https://github.com/chendave/rust-apiclient", branc
 ear = { git = "https://github.com/veraison/rust-ear", rev = "43f7f480d09ea2ebc03137af8fbcd70fe3df3468", optional = true }
 x509-parser = { version = "0.16.0", optional = true }
 reqwest.workspace = true
+bitflags = "2.8.0"
 
 [build-dependencies]
 shadow-rs.workspace = true

--- a/deps/verifier/src/tdx/claims.rs
+++ b/deps/verifier/src/tdx/claims.rs
@@ -4,9 +4,16 @@
 //
 
 //! This module helps parse all fields inside a TDX Quote and CCEL and
-//! serialize them into a JSON. The format will look lile
+//! serialize them into a JSON. The format will look like
 //! ```json
 //! {
+//!  "td_attributes": {
+//!    "debug": true,
+//!    "key_locker": false,
+//!    "perfmon": false,
+//!    "protection_keys": false,
+//!    "septve_disable": true
+//!  },
 //!  "ccel": {
 //!    "kernel": "5b7aa6572f649714ff00b6a2b9170516a068fd1a0ba72aa8de27574131d454e6396d3bfa1727d9baf421618a942977fa",
 //!    "kernel_parameters": {
@@ -46,6 +53,7 @@
 //! ```
 
 use anyhow::*;
+use bitflags::{bitflags, Flags};
 use byteorder::{LittleEndian, ReadBytesExt};
 use log::{debug, warn};
 use serde_json::{Map, Value};
@@ -160,6 +168,7 @@ pub fn generate_parsed_claim(
 
                     parse_claim!(quote_body, "tee_tcb_svn2", body.tee_tcb_svn2);
                     parse_claim!(quote_body, "mr_servicetd", body.mr_servicetd);
+
                     parse_claim!(quote_map, "header", quote_header);
                     parse_claim!(quote_map, "body", quote_body);
                 }
@@ -173,6 +182,8 @@ pub fn generate_parsed_claim(
         parse_ccel(ccel, &mut ccel_map)?;
     }
 
+    let td_attributes = parse_td_attributes(quote.td_attributes())?;
+
     let mut claims = Map::new();
 
     // Claims from AA eventlog
@@ -183,6 +194,7 @@ pub fn generate_parsed_claim(
 
     parse_claim!(claims, "quote", quote_map);
     parse_claim!(claims, "ccel", ccel_map);
+    parse_claim!(claims, "td_attributes", td_attributes);
 
     parse_claim!(claims, "report_data", quote.report_data());
     parse_claim!(claims, "init_data", quote.mr_config_id());
@@ -238,6 +250,33 @@ fn parse_ccel(ccel: CcEventLog, ccel_map: &mut Map<String, Value>) -> Result<()>
     }
 
     Ok(())
+}
+
+bitflags! {
+    #[derive(Debug, Clone)]
+    struct TdAttributesFlags: u64 {
+        const DEBUG            = 1 << 0;
+        const SEPTVE_DISABLE   = 1 << 28;
+        const PROTECTION_KEYS  = 1 << 30;
+        const KEY_LOCKER       = 1 << 31;
+        const PERFMON          = 1 << 63;
+    }
+}
+
+fn parse_td_attributes(data: &[u8]) -> Result<Map<String, Value>> {
+    let arr = <[u8; 8]>::try_from(data)?;
+    let td = TdAttributesFlags::from_bits_retain(u64::from_le_bytes(arr));
+    let attribs = TdAttributesFlags::FLAGS
+        .iter()
+        .map(|f| {
+            (
+                f.name().to_string().to_lowercase(),
+                Value::Bool(td.contains(f.value().clone())),
+            )
+        })
+        .collect();
+
+    Ok(attribs)
 }
 
 #[derive(Error, Debug, PartialEq)]
@@ -354,6 +393,13 @@ mod tests {
         let ccel = CcEventLog::try_from(ccel_bin).expect("parse ccel");
         let claims = generate_parsed_claim(quote, Some(ccel), None).expect("parse claim failed");
         let expected = json!({
+            "td_attributes": {
+                "debug": true,
+                "key_locker": false,
+                "perfmon": false,
+                "protection_keys": false,
+                "septve_disable": true
+            },
             "ccel": {
                 "kernel": "5b7aa6572f649714ff00b6a2b9170516a068fd1a0ba72aa8de27574131d454e6396d3bfa1727d9baf421618a942977fa",
                 "kernel_parameters": {

--- a/deps/verifier/src/tdx/quote.rs
+++ b/deps/verifier/src/tdx/quote.rs
@@ -314,6 +314,7 @@ impl Quote {
     body_field!(rtmr_1);
     body_field!(rtmr_2);
     body_field!(rtmr_3);
+    body_field!(td_attributes);
 }
 
 impl fmt::Display for Quote {


### PR DESCRIPTION
Add parsing tdx td attributes from hex value and include them in claims report to be accessible in policies definition.