### PR TITLE
Update release scripting for kbs-client

### DIFF
--- a/.github/workflows/push-kbs-client-to-ghcr.yml
+++ b/.github/workflows/push-kbs-client-to-ghcr.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         commit_sha=${{ github.sha }}
         oras push \
-          ghcr.io/confidential-containers/staged-images/kbs-client:sample_only-${{ matrix.arch }}-linux-gnu-${commit_sha},latest-${{ matrix.arch }} \
+          ghcr.io/confidential-containers/staged-images/kbs-client:sample_only-${commit_sha}-${{ matrix.arch }},latest-${{ matrix.arch }} \
           kbs-client
         if [ "${{ matrix.arch }}" = "x86_64" ]; then
           oras push ghcr.io/confidential-containers/staged-images/kbs-client:latest kbs-client

--- a/release-guide.md
+++ b/release-guide.md
@@ -17,6 +17,7 @@ mappings:
 ```
 staged-images/kbs:latest -> key-broker-service:built-in-as-v0.8.2
 staged-images/kbs-grpc-as:latest -> key-broker-service:v0.8.2
+staged-images/kbs-client:latest -> kbs-client:v0.8.2
 staged-images/kbs-ita-as:latest -> key-broker-service:ita-as-v0.8.2
 staged-images/rvps:latest -> reference-value-provider-service:v0.8.2
 staged-images/coco-as-grpc:latest -> attestation-service:v0.8.2


### PR DESCRIPTION
This PR adds `kbs-client` to the release script and updates the release guide.

The PR also changes the naming convention of the staged packages in [ghcr](ghcr.io/confidential-containers/staged-images/kbs-client) to be more consistent with other packages.
Current: `sample_only-${{ matrix.arch }}-linux-gnu-${commit_sha}`.
Proposed: `sample_only-${commit_sha}-${{ matrix.arch }}`.

I see this could affect two places in the repos:

1) I'm ignoring the [example in the website](https://github.com/confidential-containers/confidentialcontainers.org/blob/d563250a124bcf407fa38a0c1bbd5572600ebaea/content/en/blog/2024/coco-without-confidential-hardware.md?plain=1#L297) (as it's still a valid example anyway).

2) There is a cloud [cloud-api-adaptor script](https://github.com/confidential-containers/cloud-api-adaptor/blob/63e7228d5929ab8cff3a75826c517e761ae969b8/src/cloud-api-adaptor/test/utils/checkout_kbs.sh#L20C1-L20C114).
**Can we update the cloud-api-adaptor script after this change goes in?** I'm not clear on how `checkout_kbs.sh` is used, but clearly `oras` expects to be able to pull `kbs-client`.


