### PR TITLE
RVPS | Replace Mutex to RwLock

### DIFF
--- a/rvps/src/extractors/mod.rs
+++ b/rvps/src/extractors/mod.rs
@@ -22,7 +22,7 @@ use super::{Message, ReferenceValue};
 /// reference value (degest, s.t. hash value and name of the artifact)
 /// from the provenance. If the verification fails, no reference value
 /// will be extracted.
-
+///
 /// `Extractors` defines the interfaces of Extractors.
 pub trait Extractors {
     /// Process the message, e.g. verifying


### PR DESCRIPTION
RwLock has better performance when reads are far more than writes.