### PR TITLE
workflows: install ORAS on runners

### DIFF
--- a/.github/workflows/push-kbs-client-to-ghcr.yml
+++ b/.github/workflows/push-kbs-client-to-ghcr.yml
@@ -20,6 +20,11 @@ jobs:
       packages: write
 
     steps:
+    - name: Install ORAS
+      uses: oras-project/setup-oras@v1
+      with:
+        version: 1.0.0
+
     - name: Check out code
       uses: actions/checkout@v4
 


### PR DESCRIPTION
We recently bumped our runner images from 22.04 to 24.04. It turns out that 24.04 doesn't ship ORAS. We didn't notice this at the time because we only use ORAS in the post-merge workflow.

This step isn't needed for the self-hosted s390x runner, but supposedly the install-oras tool supports s390x so it shouldn't hurt.