### PR TITLE
kbs/plugins: Add ID_KEY plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,6 +2880,7 @@ dependencies = [
  "cryptoki",
  "derivative",
  "env_logger 0.10.2",
+ "generic-array",
  "jsonwebtoken",
  "jwt-simple",
  "kbs-types",
@@ -2888,6 +2889,7 @@ dependencies = [
  "log",
  "mobc",
  "openssl",
+ "p384",
  "prost",
  "rand",
  "reference-value-provider-service",
@@ -2900,6 +2902,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "strum",
  "tempfile",
  "thiserror 2.0.3",
@@ -3514,9 +3517,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -46,6 +46,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 config.workspace = true
 cryptoki = { version = "0.8.0", optional = true }
 env_logger.workspace = true
+generic-array = "0.14.7"
 jsonwebtoken = { workspace = true, default-features = false }
 jwt-simple.workspace = true
 kbs-types.workspace = true
@@ -53,6 +54,7 @@ kms = { workspace = true, default-features = false }
 lazy_static = "1.4.0"
 log.workspace = true
 mobc = { version = "0.8.5", optional = true }
+p384 = { version = "0.13.1", features = ["arithmetic", "ecdh"] }
 prost = { workspace = true, optional = true }
 rand = "0.8.5"
 regex = "1.11.1"
@@ -63,6 +65,7 @@ scc = "2"
 semver = "1.0.16"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+sha2 = "0.10.8"
 strum.workspace = true
 thiserror.workspace = true
 time = { version = "0.3.37", features = ["std"] }

--- a/kbs/docs/id-key.md
+++ b/kbs/docs/id-key.md
@@ -1,0 +1,84 @@
+# ID-key Plugin
+
+In addition to fetchable resources upon successful attestation, KBS also offers the ID-key plugin for encrypting and decrypting data with a key provisioned by the KBS. This key can be persisted across multiple reboots of CVMs and help tie decryption resources to a specific KBS instance.
+
+## Data Encryption
+
+As a guest owner would be responsible for encrypting persistent storage, they are the sole authority that is permitted to request resources be encrypted. The KBS is expected to be fully in control by the guest owner with credentials configured.
+
+## Flow
+
+### Provisioning encrypted data
+
+A credentialed guest owner is the only one authorized to request that keys be encrypted by the ID-key plugin. To do this, the guest owner will POST some plaintext data (created locally) to be encrypted. This plaintext data could be a LUKS passphrase, SecureBoot keys, etc. The actual purpose of the data is of no concern to the KBS.
+
+`POST /kbs/v0/id-key/{base64-plaintext-data}`
+
+
+```
+          ┌───────────┐        
+          │   POST    │        
+Owner ──► ├───────────┤ ──► KBS
+  ▲       │ Plaintext │        
+  │       │ data      │      │ 
+  │       └───────────┘      │ 
+  │                          │ 
+  │                          │ 
+  │       ┌───────────┐      │ 
+  └────── │ Encrypted │ ◄────┘ 
+          │ data      │        
+          └───────────┘        
+```
+
+With this, the guest owner is now free to configure persistent storage as they wish for their CVMs to have access to encrypted data when they boot. Upon successful attestation, this encrypted data will be presented to the KBS by the CVM for decryption.
+
+### Post-attestation, decrypting data
+
+With a CVM booted and attested, it is now assumed that the CVM was configured in such a way that it has access to readable storage that contains the encrypted data. The CVM can now send this data to the KBS for decryption.
+
+To prevent replay attacks, the CVM must wrap the encrypted data in a ECDH key cipher. To support this, the ID-key plugin presents an endpoint `ecdh-pub-sec1` that a VM can use to fetch the EC public key in order to wrap the encrypted data.
+
+`GET /kbs/v0/id-key/ecdh-pub-sec1`
+
+```
+          ┌────────┐
+          │  GET   │
+          ┤        │
+Client ──►│ EC     │ ──► KBS
+          │ public │
+  ▲       │ key    │      │
+  │       └────────┘      │
+  │                       │
+  │                       │
+  │  ┌─────────────────┐  │
+  │  │       EC        │  │
+  └──┤     public      │◄─┘
+     │       key       │
+     │  (sec1 encoded) │
+     └─────────────────┘
+```
+
+With the KBS's public EC key, the CVM can create its own ephemeral EC key and wrap the encrypted data with an ECDH/SHA256/AES256GCM cipher.
+
+The CVM will then present the ECDH-wrapped encrypted data along with all data needed for unwrapping (client EC public key and AESGCM iv). The KBS will use this data to unwrap the encrypted data and decrypt it.
+
+`GET /kbs/v0/id-key/{base64-wrapped-encrypted-data}?ecdh-pubkey={base64-client-ecdh-pubkey-sec1}&iv={base64-aesgcm-iv}`
+
+```                                            
+              ┌───────────────┐             
+              │      GET      │             
+              ├───────────────┤             
+    Client ──►│   Encrypted   │ ──► KBS     
+              │   Data        │             
+      ▲       │ (ECDH wrapped)│      │      
+      │       └───────────────┘      │      
+      │                              │      
+      │      ┌─────────────────┐     │      
+      │      │   Decrypted     │     │      
+      └───── │   Data          │ ◄───┘      
+             │  (TEE public    │            
+             │   key wrapped)  │            
+             └─────────────────┘            
+```
+
+As the decrypted secret is sensitive and will be passing through an untrusted host network, the secret must be wrapped by some data only known to the CVM. The KBS re-uses the TEE public key presented at attestation for this purpose. In this sense, a client reading the decrypted secret from the KBS is much like reading a resource from the KBS. A KBS `Response` wrapping the secret in the TEE public key will be returned to the CVM. The CVM will use the `Response` to unwrap the secret.

--- a/kbs/src/plugins/implementations/id_key.rs
+++ b/kbs/src/plugins/implementations/id_key.rs
@@ -1,0 +1,201 @@
+// Copyright (c) 2025 by Red Hat.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::plugin_manager::ClientPlugin;
+use actix_web::http::Method;
+use aes_gcm::{aead::Aead, Aes256Gcm, Key, KeyInit};
+use anyhow::{anyhow, bail, Context, Result};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use generic_array::GenericArray;
+use openssl::{
+    pkey::Private,
+    rsa::{Padding, Rsa},
+};
+use p384::{ecdh, PublicKey, SecretKey};
+use serde::Deserialize;
+use sha2::Sha256;
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct IdKeyConfig;
+
+pub struct IdKey {
+    idkey_non_hsm: Rsa<Private>,
+    ecdh_secret: SecretKey,
+}
+
+impl TryFrom<IdKeyConfig> for IdKey {
+    type Error = anyhow::Error;
+
+    fn try_from(_value: IdKeyConfig) -> anyhow::Result<Self> {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl ClientPlugin for IdKey {
+    async fn handle(
+        &self,
+        _body: &[u8],
+        query: &str,
+        path: &str,
+        method: &Method,
+    ) -> Result<Vec<u8>> {
+        let path = path
+            .strip_prefix('/')
+            .context("accessed path is illegal, should start with '/'")?;
+
+        match *method {
+            Method::POST => {
+                let plain = URL_SAFE_NO_PAD
+                    .decode(path)
+                    .context("invalid id-key path")?;
+
+                self.encrypt(plain)
+            }
+            Method::GET => match path {
+                "ecdh-pub-sec1" => Ok(self.ecdh_pubkey_sec1()),
+                _ => {
+                    let (public_key, iv) = ecdh_iv(query.to_string())?;
+
+                    let wrapped = URL_SAFE_NO_PAD.decode(path).context("invalid path")?;
+                    let encrypted = self.ecdh_unwrap(wrapped, public_key, iv)?;
+                    let decrypted = self.decrypt(encrypted)?;
+
+                    Ok(decrypted)
+                }
+            },
+            _ => bail!("Illegal HTTP method. Only supports `GET` and `POST`"),
+        }
+    }
+
+    async fn validate_auth(
+        &self,
+        _body: &[u8],
+        _query: &str,
+        _path: &str,
+        method: &Method,
+    ) -> Result<bool> {
+        match method {
+            &Method::POST => Ok(true),
+            _ => Ok(false),
+        }
+    }
+
+    async fn encrypted(
+        &self,
+        _body: &[u8],
+        _query: &str,
+        _path: &str,
+        method: &Method,
+    ) -> Result<bool> {
+        match *method {
+            Method::GET => Ok(true),
+            _ => Ok(false),
+        }
+    }
+}
+
+impl IdKey {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            idkey_non_hsm: Rsa::generate(2048).context("unable to create ID key")?,
+            ecdh_secret: SecretKey::random(&mut rand::thread_rng()),
+        })
+    }
+
+    fn encrypt(&self, bytes: Vec<u8>) -> Result<Vec<u8>> {
+        let encrypted = {
+            let mut d = [0u8; 256];
+            let sz = self
+                .idkey_non_hsm
+                .public_encrypt(&bytes, &mut d, Padding::PKCS1)
+                .context("unable to decrypt key")?;
+
+            Vec::from(&d[..sz])
+        };
+
+        Ok(URL_SAFE_NO_PAD.encode(encrypted).into())
+    }
+
+    fn ecdh_pubkey_sec1(&self) -> Vec<u8> {
+        self.ecdh_secret.public_key().to_sec1_bytes().to_vec()
+    }
+
+    fn ecdh_unwrap(
+        &self,
+        wrapped: Vec<u8>,
+        ec_public_key: PublicKey,
+        iv: Vec<u8>,
+    ) -> Result<Vec<u8>> {
+        let shared = ecdh::diffie_hellman(
+            self.ecdh_secret.to_nonzero_scalar(),
+            ec_public_key.as_affine(),
+        );
+        let mut sha_bytes = [0u8; 32];
+
+        let hkdf = shared.extract::<Sha256>(None);
+        if hkdf.expand(&[], &mut sha_bytes).is_err() {
+            return Err(anyhow!("unable to get ECDH shared SHA hash"));
+        }
+
+        let key = Key::<Aes256Gcm>::from_slice(&sha_bytes);
+        let aes = Aes256Gcm::new(key);
+
+        let encrypted = match aes.decrypt(GenericArray::from_slice(iv.as_slice()), wrapped.as_ref())
+        {
+            Ok(e) => e,
+            Err(_) => {
+                return Err(anyhow!(
+                    "unable to unwrap encrypted secret with shared AES-GCM key"
+                ))
+            }
+        };
+
+        Ok(encrypted)
+    }
+
+    fn decrypt(&self, encrypted: Vec<u8>) -> Result<Vec<u8>> {
+        let mut d = [0u8; 256];
+        let sz = self
+            .idkey_non_hsm
+            .private_decrypt(&encrypted, &mut d, Padding::PKCS1)
+            .context("unable to decrypt key")?;
+
+        Ok(Vec::from(&d[..sz]))
+    }
+}
+
+fn ecdh_iv(query: String) -> Result<(PublicKey, Vec<u8>)> {
+    let subs: Vec<&str> = query.split('&').collect();
+    if subs.len() != 2 {
+        bail!("invalid query");
+    }
+
+    let public_key = {
+        let bytes = parse_val("ecdh-pubkey", &subs)?;
+        PublicKey::from_sec1_bytes(&bytes)
+            .context("public key cannot be derived from SEC1 bytes")?
+    };
+
+    let iv = parse_val("iv", &subs)?;
+
+    Ok((public_key, iv))
+}
+
+fn parse_val(key: &str, subs: &Vec<&str>) -> Result<Vec<u8>> {
+    for substr in subs {
+        let kv: Vec<&str> = substr.split('=').collect();
+        if kv.len() != 2 {
+            bail!("invalid query");
+        }
+
+        if kv[0] == key {
+            let bytes = URL_SAFE_NO_PAD.decode(kv[1]).context("invalid query")?;
+
+            return Ok(bytes);
+        }
+    }
+
+    Err(anyhow!("invalid query"))
+}

--- a/kbs/src/plugins/implementations/mod.rs
+++ b/kbs/src/plugins/implementations/mod.rs
@@ -5,5 +5,8 @@
 pub mod resource;
 pub mod sample;
 
+pub mod id_key;
+
+pub use id_key::{IdKey, IdKeyConfig};
 pub use resource::{RepositoryConfig, ResourceStorage};
 pub use sample::{Sample, SampleConfig};

--- a/kbs/src/plugins/plugin_manager.rs
+++ b/kbs/src/plugins/plugin_manager.rs
@@ -8,7 +8,7 @@ use actix_web::http::Method;
 use anyhow::{Context, Error, Result};
 use serde::Deserialize;
 
-use super::{sample, RepositoryConfig, ResourceStorage};
+use super::{sample, IdKey, IdKeyConfig, RepositoryConfig, ResourceStorage};
 
 type ClientPluginInstance = Arc<dyn ClientPlugin>;
 
@@ -59,6 +59,9 @@ pub enum PluginsConfig {
 
     #[serde(alias = "resource")]
     ResourceStorage(RepositoryConfig),
+
+    #[serde(alias = "id-key")]
+    IdKey(IdKeyConfig),
 }
 
 impl Display for PluginsConfig {
@@ -66,6 +69,7 @@ impl Display for PluginsConfig {
         match self {
             PluginsConfig::Sample(_) => f.write_str("sample"),
             PluginsConfig::ResourceStorage(_) => f.write_str("resource"),
+            PluginsConfig::IdKey(_) => f.write_str("id-key"),
         }
     }
 }
@@ -84,6 +88,10 @@ impl TryInto<ClientPluginInstance> for PluginsConfig {
                 let resource_storage = ResourceStorage::try_from(repository_config)
                     .context("Initialize 'Resource' plugin failed")?;
                 Arc::new(resource_storage) as _
+            }
+            PluginsConfig::IdKey(cfg) => {
+                let id_key = IdKey::try_from(cfg).context("Initialize 'ID_KEY' plugin failed")?;
+                Arc::new(id_key) as _
             }
         };
 


### PR DESCRIPTION
The ID_KEY resource backend creates a new key tied to a Trustee server instance and mostly pertains to workloads that want a key unwrapping as a result of a successful attestation.

Admins can POST to the repository giving a base64 encoded byte vector as the resource tag. This resource tag will then be encrypted with the key and returned to the admin. Upon successful attestation, attestation clients can then send the encrypted data that was provisioned by the admin to the backend via a GET request. The resource tag in this case must be a base64 encoding of the encrypted data's bytes. The data will then be decrypted and sent back to the attestation client.

I will likely provide another PR in the near future allowing the server's encryption key to be derived from an HSM module for security purposes. While it won't be required, it will be preferred.

---

### Client use-case

SVSM will require attestation to establish trust and unlock persistent vTPM state to run CVMs. Virtual disks are made available to accommodate this and bootstrap persistent vTPMs. A block device will include:

- OS rootfs sealed with vTPM
- vTPM NVDATA (required for unsealing) encrypted with an "NVDATA Encryption Key" (NEK).
- NEK wrapped by a key on an attestation server.

```
┌────────────────────────────┐
│                            │
│  ┌──────────────────────┐  │
│  │vTPM-sealed rootfs    │  │
│  └──────────────────────┘  │
│  ┌──────────────────────┐  │
│  │Encrypted vTPM NVDATA │  │
│  │(wrapped by NEK)      │  │
│  └──────────────────────┘  │
│  ┌──────────────────────┐  │
│  │NEK (wrapped by key on│  │
│  │attestation server)   │  │
│  └──────────────────────┘  │
│                            │
│                Virtual disk│
└────────────────────────────┘
```

A simple unlocking and boot would be as follows:

- SVSM attests, gives encrypted NEK to attestation server, server unwraps it with ID-key.

- SVSM uses unwrapped NEK to decrypt vTPM NVDATA, sets up vTPM.

- SVSM boots OS with vTPM.

- OS initrd (systemd-cryptenroll) unseals and mounts rootfs.

With this chain, **an OS will not be able to boot without SVSM first attesting itself**.

### Admin set-up

Initializing and setup of the virtual disks should be done from the guest owner themselves. They should also be the ones in control (with admin privileges/credentials) of the Trustee server in which their CVMs will attest with. As such, the admin will:

- Initialize a "fresh" vTPM 
- Seal their OS's rootfs to the newly-created vTPM
- Create a new symmetric NEK
- Encrypt the vTPM's NVDATA with the newly-created NEK
- **Wrap the NEK with a key on an attestation server**

Once completed, the guest owner can supply this virtual disk to untrusted parties for running CVMs.

The highlighted portion pertains to this PR. Because the NEK (and corresponding key stored on attestation server that wraps it) is sensitive, only the KBS admin must be able to wrap NEKs that the KBS generates. I also plan to add support for deriving the wrap key from an HSM at some point, so an admin could just configure any KBS to use a key stored on the HSM as the wrap key.

### Using the existing resource backends

Recall how the virtual disks were presented to CVMs:

```
┌────────────────────────────┐
│                            │
│  ┌──────────────────────┐  │
│  │vTPM-sealed rootfs    │  │
│  └──────────────────────┘  │
│  ┌──────────────────────┐  │
│  │Encrypted vTPM NVDATA │  │
│  │(wrapped by NEK)      │  │
│  └──────────────────────┘  │
│  ┌──────────────────────┐  │
│  │NEK (wrapped by key on│  │
│  │attestation server)   │  │
│  └──────────────────────┘  │
│                            │
│                Virtual disk│
└────────────────────────────┘
```
As an alternative, we **could** store the NEK on the KBS as a retrievable resource. We could then provide the resource ID of the NEK so that the client would know which KBS resource to fetch once an attestation complete. The virtual disk would then look like this:

```
┌────────────────────────────┐
│                            │
│  ┌──────────────────────┐  │
│  │vTPM-sealed rootfs    │  │
│  └──────────────────────┘  │
│  ┌──────────────────────┐  │
│  │Encrypted vTPM NVDATA │  │
│  │(wrapped by NEK)      │  │
│  └──────────────────────┘  │
│  ┌──────────────────────┐  │
│  │KBS resource ID of NEK│  │
│  │                      │  │
│  └──────────────────────┘  │
│                            │
│                Virtual disk│
└────────────────────────────┘
```

With this, we could use the existing resource backends in Trustee to complete our attestation. However, there is a few principles that prevent us from doing this:

- Although the resource ID would be given in the virtual disk, there is nothing preventing a motivated bad actor from resources that pertain to other VMs, such as their NEKs. With some inside knowledge, an attacker could steal other VM NEKs and impersonate other VMs with their vTPM endorsement keys simply by knowing which resource ID corresponds to another VMs NEK.

- As we cannot guarantee that all clients using persistent vTPMs in this manner will use Trustee to attest, **the virtual disk format cannot tie itself to any Trustee-specific mechanism (like giving a resource ID tag of the NEK). The virtual disk format must be server-agnostic**. This applies for all attestation protocols, for that matter.

- As the virtual disk must be server-agnostic, **the result of an attestation should only be the unwrapping of the NEK**. No other information is supplied to the virtual disk.

### ID-key Plugin

Recall the point made above: **the result of an attestation should only be the unwrapping of the NEK**. That is exactly what this plugin provides.

- A way for admins to provision and encrypt NEKs
- An endpoint where CVMs can POST their NEKs for decryption

It allows for Trustee to be used for vTPM NVDATA encryption in a way it wasn't able to be used with the normal resource backend mechanisms. It still requires that an attested client present its attestation token when decrypting an NEK (much like when fetching a resource), but also allows the POSTing of plaintext NEK data.

### Preventing replay attacks

To prevent replay attacks (a third party snooping on the encrypted NEK in order to replay and get it decrypted), the ECDH mechanism for wrapping the encrypted NEK before sending it to the plugin is implemented. With this, every time an encrypted NEK is sent to the KBS, it is wrapped with an ephemeral EC key such that no third party can derive the original encrypted NEK and replay it.