### PR TITLE
config: fix insecure_key parameter

### DIFF
--- a/kbs/config/kbs-config.toml
+++ b/kbs/config/kbs-config.toml
@@ -2,7 +2,7 @@
 insecure_http = true
 
 [attestation_token]
-insecure_api = true
+insecure_key = true
 
 [attestation_service]
 type = "coco_as_builtin"


### PR DESCRIPTION
`insecure_api` is a parameter of the admin config whereas `insecure_key` is part of the attestation token config. We use the wrong field in one of our config files.