### PR TITLE
KBS: Fix deployment of resources policy on k8s + misc changes

### DIFF
--- a/kbs/config/kubernetes/README.md
+++ b/kbs/config/kubernetes/README.md
@@ -32,6 +32,14 @@ If you have more than one secret, copy them over to the `config/kubernetes/overl
 
 With the default configuration the keys will be stored in `reponame/workload_key/`. If you wish to define a different repository make necessary changes to the `overlays/patch.yaml` file.
 
+## Optional: Changing default policies
+
+The default deployed resources policy file is `base/policy.rego`. If you wish to change the default then edit that file. For example, suppose that you want to have the "allow all" policy applied, do:
+
+```bash
+cp ../../sample_policies/allow_all.rego base/policy.rego
+```
+
 ## Optional: Expose KBS using Ingress
 
 If you would like to expose KBS using Ingress, then run the following commands:

--- a/kbs/config/kubernetes/base/deployment.yaml
+++ b/kbs/config/kubernetes/base/deployment.yaml
@@ -16,14 +16,14 @@ spec:
       - command:
         - sh
         - -c
-        - cp -r /config/$(dirname $(readlink /config/policy.rego))/* /opa/confidential-containers/kbs/
+        - cp -r /config/$(dirname $(readlink /config/policy.rego))/* /opt/confidential-containers/kbs/
         image: quay.io/prometheus/busybox:latest
         imagePullPolicy: Always
         name: copy-config
         volumeMounts:
         - mountPath: /config
           name: config-volume
-        - mountPath: /opa/confidential-containers/kbs
+        - mountPath: /opt/confidential-containers/kbs
           name: policy-volume
       containers:
       - name: kbs
@@ -41,7 +41,7 @@ spec:
         - name: kbs-config
           mountPath: /etc/kbs/
         - name: policy-volume
-          mountPath: /opa/confidential-containers/kbs/
+          mountPath: /opt/confidential-containers/kbs/
       volumes:
       - name: kbs-auth-public-key
         secret:

--- a/kbs/config/kubernetes/base/kustomization.yaml
+++ b/kbs/config/kubernetes/base/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: coco-tenant
 images:
 - name: kbs-container-image
   newName: ghcr.io/confidential-containers/key-broker-service
-  newTag: built-in-as-v0.10.1
+  newTag: built-in-as-v0.11.0
 
 resources:
 - namespace.yaml


### PR DESCRIPTION
Main focus of this PR is to fix #702.

While in here, updated the docs so users know how to change the default policy. Also bumped the kbs image version to use latest released (v0.11.0).

----
I wanted to bump the image version from the ita overlay (kbs/config/kubernetes/ita) but I realized kustomization is not replacing the base image correctly:
```
$ kustomize build | grep image:
        image: ghcr.io/confidential-containers/key-broker-service:built-in-as-v0.11.0
        image: quay.io/prometheus/busybox:latest
```
The `built-in-as-v0.11.0` tag above is not correct. I tried to fix it but failed miserably and now I have to switch to other stuffs....