### PR TITLE
kbs-client: make set-resource verify resource path

### DIFF
--- a/tools/kbs-client/src/lib.rs
+++ b/tools/kbs-client/src/lib.rs
@@ -12,6 +12,7 @@ use kbs_protocol::evidence_provider::NativeEvidenceProvider;
 use kbs_protocol::token_provider::TestTokenProvider;
 use kbs_protocol::KbsClientBuilder;
 use kbs_protocol::KbsClientCapabilities;
+use kbs_protocol::ResourceUri;
 use serde::Serialize;
 
 const KBS_URL_PREFIX: &str = "kbs/v0";
@@ -216,6 +217,10 @@ pub async fn set_resource(
     let token = auth_private_key.sign(claims)?;
 
     let http_client = build_http_client(kbs_root_certs_pem)?;
+
+    // verify 'path'
+    let resource_kbs_uri = format!("kbs:///{path}");
+    serde_json::from_str::<ResourceUri>(&format!("\"{resource_kbs_uri}\""))?;
 
     let resource_url = format!("{}/{KBS_URL_PREFIX}/resource/{}", url, path);
     let res = http_client


### PR DESCRIPTION
set-resource allowed resources to be created at invalid paths since there has been no validation of path so far.  Such a resource can't even be retrieved since get-resource does validate resource path.

This commit changes that by introducing the same path check into set-resource that is called from get-resource.  If path validation fails on set-resource kbs-client now aborts with the same error message as on get-resource.