### PR TITLE
kbs: make repository part of resource path mandatory

### DIFF
--- a/kbs/docs/kbs.yaml
+++ b/kbs/docs/kbs.yaml
@@ -109,10 +109,10 @@ paths:
           required: false
         - name: repository
           in: path
-          description: A parent path of resource, can be empty to use the default repository.
+          description: A parent path of resource.
           schema:
             type: string
-          required: false
+          required: true
         - name: type
           in: path
           description: Resource type name

--- a/kbs/docs/kbs_attestation_protocol.md
+++ b/kbs/docs/kbs_attestation_protocol.md
@@ -454,7 +454,6 @@ Where the URL path parameters are:
 - `<repository>`: This is similar to the concept of container image repository (`docker.io/{repository}/{image_name}:{tag}`), 
 which is used to facilitate users to manage different resource groups.
 Its name should be completely set by users.
-This parameter can be empty to use the default repository of KBS.
 - `<type>`: To distinguish different resource types.
 - `<tag>`: To distinguish different resource instances.
 

--- a/kbs/src/plugins/implementations/resource/backend.rs
+++ b/kbs/src/plugins/implementations/resource/backend.rs
@@ -38,7 +38,7 @@ impl TryFrom<&str> for ResourceDesc {
     fn try_from(value: &str) -> Result<Self> {
         let regex = CELL.get_or_init(|| {
             Regex::new(
-                r"^((?<repo>[a-zA-Z0-9_\-]+[a-zA-Z0-9_\-\.]*)\/)?(?<type>[a-zA-Z0-9_\-]+[a-zA-Z0-9_\-\.]*)\/(?<tag>[a-zA-Z0-9_\-]+[a-zA-Z0-9_\-\.]*)$",
+                r"^(?<repo>[a-zA-Z0-9_\-]+[a-zA-Z0-9_\-\.]*)\/(?<type>[a-zA-Z0-9_\-]+[a-zA-Z0-9_\-\.]*)\/(?<tag>[a-zA-Z0-9_\-]+[a-zA-Z0-9_\-\.]*)$",
             )
             .unwrap()
         });
@@ -47,11 +47,7 @@ impl TryFrom<&str> for ResourceDesc {
         };
 
         Ok(Self {
-            repository_name: captures
-                .name("repo")
-                .map(|s| s.into())
-                .unwrap_or("default")
-                .into(),
+            repository_name: captures["repo"].into(),
             resource_type: captures["type"].into(),
             resource_tag: captures["tag"].into(),
         })
@@ -158,11 +154,7 @@ mod tests {
         resource_type: "type".into(),
         resource_tag: "tag".into(),
     }))]
-    #[case("1/2", Some(ResourceDesc {
-        repository_name: "default".into(),
-        resource_type: "1".into(),
-        resource_tag: "2".into(),
-    }))]
+    #[case("1/2", None)]
     #[case("123--_default/1Abff-_/___-afds44BC", Some(ResourceDesc {
         repository_name: "123--_default".into(),
         resource_type: "1Abff-_".into(),


### PR DESCRIPTION
The original cause of this change was a confusing asymetry in kbs-client where the client's set-resource command accepted resource paths without a repository part however a corresponding get-resource did not.  This was because on set-repository, the code being changed by this commit filled in a "default" repository value while ResourceUri::try_from(url::Url) called on get-resource bails out unless a path has all three components.

As agreed in Trustee Development call, the solution is to remove the kbs-protocol's provisiion for an optional repository part of resource path and make the repository path mandatory, similar to the rest of resource path parts.