### PR TITLE
build: drop libtdx-attest

### DIFF
--- a/.github/workflows/kbs-rust.yml
+++ b/.github/workflows/kbs-rust.yml
@@ -50,7 +50,7 @@ jobs:
         curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
         echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu noble main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
         sudo apt-get update
-        sudo apt-get install -y libtdx-attest-dev libsgx-dcap-quote-verify-dev
+        sudo apt-get install -y libsgx-dcap-quote-verify-dev
 
     - name: KBS Build [Default/Built-in CoCo AS]
       working-directory: kbs

--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -33,8 +33,7 @@ RUN if [ "${ARCH}" = "x86_64" ]; then curl -fsSL https://download.01.org/intel-s
     cmake \
     libtss2-dev && \
     if [ "${ARCH}" = "x86_64" ]; then apt-get install -y --no-install-recommends \
-    libsgx-dcap-quote-verify-dev \
-    libtdx-attest-dev; fi
+    libsgx-dcap-quote-verify-dev; fi
 
 # Build and Install KBS
 WORKDIR /usr/src/trustee

--- a/kbs/quickstart.md
+++ b/kbs/quickstart.md
@@ -24,8 +24,6 @@ sudo apt-get install -y \
 	clang \
 	libsgx-dcap-quote-verify-dev \
 	libsgx-dcap-quote-verify \
-	libtdx-attest-dev \
-	libtdx-attest \
 	libtss2-dev \
 	openssl \
 	pkg-config \

--- a/kbs/test/Makefile
+++ b/kbs/test/Makefile
@@ -56,7 +56,6 @@ install-dev-dependencies: install-dependencies
 		clang \
 		libsgx-dcap-quote-verify-dev \
 		libssl-dev \
-		libtdx-attest-dev \
 		libtss2-dev \
 		pkg-config \
 		protobuf-compiler
@@ -71,7 +70,6 @@ install-dependencies:
 		libsgx-dcap-default-qpl \
 		libsgx-dcap-quote-verify \
 		libsgx-urts \
-		libtdx-attest \
 		libtss2-esys-3.0.2-0 \
 		libtss2-tctildr0 \
 		openssl && \


### PR DESCRIPTION
kbs-client w/ tdx-attester does not depend on libtdx-attest anymore so drop that install dependency.