### PR TITLE
kbs: Add support for two-way encryption

### DIFF
--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -237,7 +237,7 @@ pub(crate) async fn api(
                     .await
                     .map_err(|e| Error::PluginInternalError { source: e })?;
                 if plugin
-                    .encrypted(&body, query, additional_path, request.method())
+                    .response_encrypted(&body, query, additional_path, request.method())
                     .await
                     .map_err(|e| Error::PluginInternalError { source: e })?
                 {

--- a/kbs/src/attestation/backend.rs
+++ b/kbs/src/attestation/backend.rs
@@ -275,12 +275,15 @@ impl AttestationService {
             .ok_or(anyhow!("session not found"))?;
         let session = session.get_mut();
 
+        session.attest(&token)?;
+
+        let public_key = session.public_key()?;
+
         let body = serde_json::to_string(&json!({
             "token": token,
+            "public_key": public_key
         }))
         .context("Serialize token failed")?;
-
-        session.attest(token);
 
         Ok(HttpResponse::Ok()
             .cookie(session.cookie())

--- a/kbs/src/plugins/implementations/nebula_ca.rs
+++ b/kbs/src/plugins/implementations/nebula_ca.rs
@@ -448,6 +448,16 @@ impl ClientPlugin for NebulaCaPlugin {
     ) -> Result<bool> {
         Ok(true)
     }
+
+    async fn request_encrypted(
+        &self,
+        _body: &[u8],
+        _query: &str,
+        _path: &str,
+        _method: &Method,
+    ) -> Result<bool> {
+        Ok(false)
+    }
 }
 
 #[cfg(test)]

--- a/kbs/src/plugins/implementations/nebula_ca.rs
+++ b/kbs/src/plugins/implementations/nebula_ca.rs
@@ -439,7 +439,7 @@ impl ClientPlugin for NebulaCaPlugin {
         Ok(false)
     }
 
-    async fn encrypted(
+    async fn response_encrypted(
         &self,
         _body: &[u8],
         _query: &str,

--- a/kbs/src/plugins/implementations/pkcs11.rs
+++ b/kbs/src/plugins/implementations/pkcs11.rs
@@ -117,6 +117,20 @@ impl ClientPlugin for Pkcs11Backend {
     ) -> Result<bool> {
         Ok(true)
     }
+
+    async fn request_encrypted(
+        &self,
+        _body: &[u8],
+        _query: &str,
+        path: &str,
+        method: &Method,
+    ) -> Result<bool> {
+        if path.contains("wrap-key") && *method == Method::GET {
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
 }
 
 #[async_trait::async_trait]

--- a/kbs/src/plugins/implementations/pkcs11.rs
+++ b/kbs/src/plugins/implementations/pkcs11.rs
@@ -108,7 +108,7 @@ impl ClientPlugin for Pkcs11Backend {
         }
     }
 
-    async fn encrypted(
+    async fn response_encrypted(
         &self,
         _body: &[u8],
         _query: &str,

--- a/kbs/src/plugins/implementations/resource/mod.rs
+++ b/kbs/src/plugins/implementations/resource/mod.rs
@@ -57,7 +57,7 @@ impl ClientPlugin for ResourceStorage {
         Ok(false)
     }
 
-    async fn encrypted(
+    async fn response_encrypted(
         &self,
         _body: &[u8],
         _query: &str,

--- a/kbs/src/plugins/implementations/resource/mod.rs
+++ b/kbs/src/plugins/implementations/resource/mod.rs
@@ -70,4 +70,14 @@ impl ClientPlugin for ResourceStorage {
 
         Ok(false)
     }
+
+    async fn request_encrypted(
+        &self,
+        _body: &[u8],
+        _query: &str,
+        _path: &str,
+        _method: &Method,
+    ) -> Result<bool> {
+        Ok(false)
+    }
 }

--- a/kbs/src/plugins/implementations/sample.rs
+++ b/kbs/src/plugins/implementations/sample.rs
@@ -61,4 +61,14 @@ impl ClientPlugin for Sample {
     ) -> Result<bool> {
         Ok(false)
     }
+
+    async fn request_encrypted(
+        &self,
+        _body: &[u8],
+        _query: &str,
+        _path: &str,
+        _method: &Method,
+    ) -> Result<bool> {
+        Ok(false)
+    }
 }

--- a/kbs/src/plugins/implementations/sample.rs
+++ b/kbs/src/plugins/implementations/sample.rs
@@ -52,7 +52,7 @@ impl ClientPlugin for Sample {
     /// Whether the body needs to be encrypted via TEE key pair.
     /// If returns `Ok(true)`, the KBS server will encrypt the whole body
     /// with TEE key pair and use KBS protocol's Response format.
-    async fn encrypted(
+    async fn response_encrypted(
         &self,
         _body: &[u8],
         _query: &str,

--- a/kbs/src/plugins/plugin_manager.rs
+++ b/kbs/src/plugins/plugin_manager.rs
@@ -55,6 +55,17 @@ pub trait ClientPlugin: Send + Sync {
         path: &str,
         method: &Method,
     ) -> Result<bool>;
+
+    /// Whether the request body needs to be encrypted via server's TEE key pair.
+    /// If returns `Ok(true)`, the KBS server will decrypt the request's body
+    /// with the TEE key pair generated for the session upon successful attestation.
+    async fn request_encrypted(
+        &self,
+        body: &[u8],
+        query: &str,
+        path: &str,
+        method: &Method,
+    ) -> Result<bool>;
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq)]

--- a/kbs/src/plugins/plugin_manager.rs
+++ b/kbs/src/plugins/plugin_manager.rs
@@ -45,10 +45,10 @@ pub trait ClientPlugin: Send + Sync {
         method: &Method,
     ) -> Result<bool>;
 
-    /// Whether the body needs to be encrypted via TEE key pair.
-    /// If returns `Ok(true)`, the KBS server will encrypt the whole body
-    /// with TEE key pair and use KBS protocol's Response format.
-    async fn encrypted(
+    /// Whether the response body needs to be encrypted via TEE key pair.
+    /// If returns `Ok(true)`, the KBS server will encrypt the response's body
+    /// with the TEE key pair and use KBS protocol's Response format.
+    async fn response_encrypted(
         &self,
         body: &[u8],
         query: &str,


### PR DESCRIPTION
KBS offers a mechanism for plugin responses (such as resources) to be encrypted with the client's TEE public key. However, there is no mechanism to specify that requests' bodies themselves to be encrypted, which would be useful (for example, to prevent replay attacks in key unwrapping).

Plugins that would like to use two-way encryption need a public key from the KBS to encrypt the data being sent. Upon successful attestation, a RSA public/private key pair is created and public key is returned with the attestation token. For plugins that do not use two-way encryption, clients can ignore the key.

For plugins that would like to use two-way encryption, they can use the public key to encrypt their request bodies and protect data in transit.

Each plugin has the option to enable two-way encryption. As no plugin currently uses two-way encryption, all existing plugins disable the feature.