### PR TITLE
Bump Maximum version of SNP Attestation Report.

### DIFF
--- a/deps/verifier/src/snp/mod.rs
+++ b/deps/verifier/src/snp/mod.rs
@@ -51,7 +51,7 @@ const KDS_VCEK: &str = "/vcek/v1";
 
 /// Attestation report versions supported
 const REPORT_VERSION_MIN: u32 = 2;
-const REPORT_VERSION_MAX: u32 = 3;
+const REPORT_VERSION_MAX: u32 = 4;
 
 #[derive(Debug)]
 pub struct Snp {


### PR DESCRIPTION
Version 4 of the attestation report has arrived into some people's machines, so we have to bump up the minimum version to allow them to continue to attest their coco environment.

Slack issue:
https://cloud-native.slack.com/archives/C039JSH0807/p1740776076921049