### PR TITLE
ci: fix rust version of kbs-client release dockerfile to 1.80.0

### DIFF
--- a/kbs/docker/kbs-client/Dockerfile
+++ b/kbs/docker/kbs-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.78.0 AS builder
+FROM docker.io/library/rust:1.80.0 AS builder
 ARG ARCH=x86_64
 
 WORKDIR /usr/src/kbs


### PR DESCRIPTION
This is a following up for #725

Fix the CI error like https://github.com/confidential-containers/trustee/actions/runs/13757985713