### PR TITLE
fix(as): make EAR TV names into acceptable OPA variable names

### DIFF
--- a/attestation-service/src/policy_engine/mod.rs
+++ b/attestation-service/src/policy_engine/mod.rs
@@ -72,6 +72,7 @@ impl PolicyEngineType {
 
 type PolicyDigest = String;
 
+#[derive(Debug)]
 pub struct EvaluationResult {
     pub rules_result: HashMap<String, Value>,
     pub policy_hash: String,

--- a/attestation-service/src/policy_engine/opa/mod.rs
+++ b/attestation-service/src/policy_engine/opa/mod.rs
@@ -241,7 +241,7 @@ mod tests {
 
         let ear_rules = TrustVector::new()
             .into_iter()
-            .map(|c| c.tag().to_string())
+            .map(|c| c.tag().to_string().replace("-", "_"))
             .collect();
 
         let output = opa

--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -236,12 +236,14 @@ impl AttestationTokenBroker for EarAttestationTokenBroker {
 
         let rules = TrustVector::new()
             .into_iter()
-            .map(|c| c.tag().to_string())
+            .map(|c| c.tag().to_string().replace("-", "_"))
             .collect();
         let policy_results = self
             .policy_engine
             .evaluate(&reference_data, &tcb_claims_json, &policy_ids[0], rules)
             .await?;
+
+        debug!("policy results: {:#?}", policy_results);
 
         let mut appraisal = Appraisal::new();
 


### PR DESCRIPTION
EAR TV names are kebab-case, which is not acceptable for OPA variables.
This results in TV names with `-` to be ignored.

This fix transforms kebabs into snakes to make OPA happy.