### PR TITLE
fix(cli): update argument short flags for HTTPS certificate options in restful-as (signed-off)

### DIFF
--- a/attestation-service/src/bin/restful-as.rs
+++ b/attestation-service/src/bin/restful-as.rs
@@ -31,12 +31,12 @@ pub struct Cli {
 
     /// Path to the public key cert for HTTPS. Both public key cert and
     /// private key are provided then HTTPS will be enabled.
-    #[arg(short, long)]
+    #[arg(short = 'u', long)]
     pub https_pubkey_cert: Option<String>,
 
     /// Path to the private key for HTTPS. Both public key cert and
     /// private key are provided then HTTPS will be enabled.
-    #[arg(short, long)]
+    #[arg(short = 'r', long)]
     pub https_prikey: Option<String>,
 }
 


### PR DESCRIPTION
Issue:
Running the executable target `restful-as` panics with the following error:
```
$  cargo build --bin restful-as $(release) --features restful-bin
$  ./target/release/restful-as
Short option names must be unique for each argument, but "-h" is in use by both "https_pubkey_cert" and "https_prikey"
```

This fix ensures that the executable target `restful-as` doesn't panic at runtime because the command has by default conflicting short arguments.