### PR TITLE
Update attestation service source link in dockerfile

### DIFF
--- a/attestation-service/docker/as-grpc/Dockerfile
+++ b/attestation-service/docker/as-grpc/Dockerfile
@@ -35,7 +35,7 @@ FROM ubuntu:22.04
 ARG ARCH=x86_64
 ARG VERIFIER=all-verifier
 
-LABEL org.opencontainers.image.source="https://github.com/confidential-containers/attestation-service"
+LABEL org.opencontainers.image.source="https://github.com/confidential-containers/trustee/tree/main/attestation-service"
 
 # Install Openssl Suites
 RUN apt-get update && apt-get install openssl -y && \

--- a/attestation-service/docker/as-restful/Dockerfile
+++ b/attestation-service/docker/as-restful/Dockerfile
@@ -34,7 +34,7 @@ FROM ubuntu:22.04
 ARG ARCH=x86_64
 ARG VERIFIER=all-verifier
 
-LABEL org.opencontainers.image.source="https://github.com/confidential-containers/attestation-service"
+LABEL org.opencontainers.image.source="https://github.com/confidential-containers/trustee/tree/main/attestation-service"
 
 # Install Openssl Suites
 RUN apt-get update && apt-get install openssl -y && \


### PR DESCRIPTION
The attestation service link is point to old link "https://github.com/confidential-containers/attestation-service".
New link should be "https://github.com/confidential-containers/trustee/tree/main/attestation-service"