### PR TITLE
kbs: added request payload size config option

### DIFF
--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -173,6 +173,7 @@ impl TestHarness {
                 private_key: None,
                 certificate: None,
                 insecure_http: true,
+                payload_request_size: 2,
             },
             admin: AdminConfig {
                 auth_public_key: None,

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -20,12 +20,13 @@ configuration file.
 
 The following properties can be set under the `[http_server]` section.
 
-| Property                 | Type         | Description                                                                                                | Required | Default              |
-|--------------------------|--------------|------------------------------------------------------------------------------------------------------------|----------|----------------------|
-| `sockets`                | String array | One or more sockets to listen on.                                                                          | No       | `["127.0.0.1:8080"]` |
-| `insecure_http`          | Boolean      | Don't use TLS for the KBS HTTP endpoint.                                                                   | No       | `false`              |
-| `private_key`            | String       | Path to a private key file to be used for HTTPS.                                                           | No       | None                 |
-| `certificate`            | String       | Path to a certificate file to be used for HTTPS.                                                           | No       | None                 |
+| Property                 | Type         | Description                                      | Required | Default              |
+|--------------------------|--------------|--------------------------------------------------|----------|----------------------|
+| `sockets`                | String array | One or more sockets to listen on.                | No       | `["127.0.0.1:8080"]` |
+| `insecure_http`          | Boolean      | Don't use TLS for the KBS HTTP endpoint.         | No       | `false`              |
+| `private_key`            | String       | Path to a private key file to be used for HTTPS. | No       | None                 |
+| `certificate`            | String       | Path to a certificate file to be used for HTTPS. | No       | None                 |
+| `payload_request_size`   | Integer      | Request payload size in mega bytes.              | No       | 2                    |
 
 ### Attestation Token Configuration
 
@@ -305,15 +306,15 @@ type = "coco_as_builtin"
 work_dir = "/opt/confidential-containers/attestation-service"
 policy_engine = "opa"
 
-    [attestation_service.attestation_token_broker]
-    type = "Ear"
-    duration_min = 5
+[attestation_service.attestation_token_broker]
+type = "Ear"
+duration_min = 5
 
-    [attestation_service.rvps_config]
-    type = "BuiltIn"
+[attestation_service.rvps_config]
+type = "BuiltIn"
 
-    [attestation_service.rvps_config.storage]
-    type = "LocalFs"
+[attestation_service.rvps_config.storage]
+type = "LocalFs"
 
 [[plugins]]
 name = "resource"
@@ -348,11 +349,10 @@ sockets = ["0.0.0.0:8080"]
 private_key = "/etc/kbs-private.key"
 certificate = "/etc/kbs-cert.pem"
 insecure_http = false
+payload_request_size = 2
 
 [attestation_token]
 trusted_jwk_sets = ["https://portal.trustauthority.intel.com"]
-
-[attestation_token]
 
 [attestation_service]
 type = "intel_ta"
@@ -391,15 +391,15 @@ type = "coco_as_builtin"
 work_dir = "/opt/confidential-containers/attestation-service"
 policy_engine = "opa"
 
-    [attestation_service.attestation_token_broker]
-    type = "Ear"
-    duration_min = 5
+[attestation_service.attestation_token_broker]
+type = "Ear"
+duration_min = 5
 
-    [attestation_service.rvps_config]
-    type = "BuiltIn"
+[attestation_service.rvps_config]
+type = "BuiltIn"
 
-    [attestation_service.rvps_config.storage]
-    type = "LocalFs"
+[attestation_service.rvps_config.storage]
+type = "LocalFs"
 
 [[plugins]]
 name = "resource"

--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -107,6 +107,9 @@ impl ApiServer {
                 App::new()
                     .wrap(middleware::Logger::default())
                     .app_data(web::Data::new(api_server))
+                    .app_data(web::PayloadConfig::new(
+                        (1024 * 1024 * http_config.payload_request_size) as usize,
+                    ))
                     .service(
                         web::resource([kbs_path!("{base_path}{additional_path:.*}")])
                             .route(web::get().to(api))

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 
 const DEFAULT_INSECURE_HTTP: bool = false;
 const DEFAULT_SOCKET: &str = "127.0.0.1:8080";
+const DEFAULT_PAYLOAD_REQUEST_SIZE: u32 = 2;
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct HttpServerConfig {
@@ -30,6 +31,9 @@ pub struct HttpServerConfig {
     /// Insecure HTTP.
     /// WARNING: Using this option makes the HTTP connection insecure.
     pub insecure_http: bool,
+
+    /// Request payload size in MB
+    pub payload_request_size: u32,
 }
 
 impl Default for HttpServerConfig {
@@ -39,6 +43,7 @@ impl Default for HttpServerConfig {
             private_key: None,
             certificate: None,
             insecure_http: DEFAULT_INSECURE_HTTP,
+            payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
         }
     }
 }
@@ -80,6 +85,10 @@ impl TryFrom<&Path> for KbsConfig {
             .set_default("admin.insecure_api", DEFAULT_INSECURE_API)?
             .set_default("http_server.insecure_http", DEFAULT_INSECURE_HTTP)?
             .set_default("http_server.sockets", vec![DEFAULT_SOCKET])?
+            .set_default(
+                "http_server.payload_request_size",
+                DEFAULT_PAYLOAD_REQUEST_SIZE,
+            )?
             .set_default("attestation_service.policy_ids", Vec::<&str>::new())?
             .add_source(File::with_name(config_path.to_str().unwrap()))
             .build()?;
@@ -105,7 +114,10 @@ mod tests {
 
     use crate::{
         admin::config::AdminConfig,
-        config::{HttpServerConfig, DEFAULT_INSECURE_API, DEFAULT_INSECURE_HTTP, DEFAULT_SOCKET},
+        config::{
+            HttpServerConfig, DEFAULT_INSECURE_API, DEFAULT_INSECURE_HTTP,
+            DEFAULT_PAYLOAD_REQUEST_SIZE, DEFAULT_SOCKET,
+        },
         plugins::{
             implementations::{
                 resource::local_fs::LocalFsRepoDesc, RepositoryConfig, SampleConfig,
@@ -152,6 +164,7 @@ mod tests {
             private_key: Some("/etc/kbs-private.key".into()),
             certificate: Some("/etc/kbs-cert.pem".into()),
             insecure_http: false,
+            payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
         },
         admin: AdminConfig {
             auth_public_key: Some(PathBuf::from("/etc/kbs-admin.pub")),
@@ -200,6 +213,7 @@ mod tests {
             private_key: None,
             certificate: None,
             insecure_http: DEFAULT_INSECURE_HTTP,
+            payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
         },
         admin: AdminConfig {
             auth_public_key: None,
@@ -236,6 +250,7 @@ mod tests {
             private_key: Some("/etc/kbs-private.key".into()),
             certificate: Some("/etc/kbs-cert.pem".into()),
             insecure_http: false,
+            payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
         },
         admin: AdminConfig {
             auth_public_key: Some(PathBuf::from("/etc/kbs-admin.pub")),
@@ -273,6 +288,7 @@ mod tests {
             private_key: None,
             certificate: None,
             insecure_http: true,
+            payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
         },
         admin: AdminConfig {
             auth_public_key: Some(PathBuf::from("/opt/confidential-containers/kbs/user-keys/public.pub")),
@@ -312,6 +328,7 @@ mod tests {
             private_key: None,
             certificate: None,
             insecure_http: true,
+            payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
         },
         admin: AdminConfig {
             auth_public_key: Some("/kbs/kbs.pem".into()),
@@ -346,6 +363,7 @@ mod tests {
             private_key: None,
             certificate: None,
             insecure_http: true,
+            payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
         },
         admin: AdminConfig {
             auth_public_key: Some("/kbs/kbs.pem".into()),


### PR DESCRIPTION
Parametrized request payload size which now can be configured by user by providing value in mb.

Fixes: #670