### PR TITLE
Update kbs image version

### DIFF
--- a/kbs/config/kubernetes/base/kustomization.yaml
+++ b/kbs/config/kubernetes/base/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: coco-tenant
 images:
 - name: kbs-container-image
   newName: ghcr.io/confidential-containers/key-broker-service
-  newTag: built-in-as-v0.11.0
+  newTag: built-in-as-v0.12.0
 
 resources:
 - namespace.yaml

--- a/kbs/config/kubernetes/ita/kustomization.yaml
+++ b/kbs/config/kubernetes/ita/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 namespace: coco-tenant
 
 images:
-- name: ghcr.io/confidential-containers/key-broker-service:built-in-as-v0.10.1
-  newTag: ita-as-v0.10.1
+- name: ghcr.io/confidential-containers/key-broker-service:built-in-as-v0.12.0
+  newTag: ita-as-v0.12.0
 
 resources:
 - ../nodeport/


### PR DESCRIPTION
Trustee/kbs v0.12.0 should use by default image built-in-as-v0.12.0 otherwise it is incompliant with coco operator 0.13.0

Fixes: #758 