### PR TITLE
verifiers: update eventlog crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,14 +1882,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "eventlog-rs"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f63e89ae20606137075d874615efe9b6c1beb82c5b86d438e0bf2bb11b60519"
+checksum = "8032cb35e23e548f50306064c37de06e04eb51378bce8ad99f0a7f119b30204e"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -3149,7 +3149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4125,7 +4125,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4562,7 +4562,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5281,7 +5281,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6115,7 +6115,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/deps/verifier/src/tdx/eventlog.rs
+++ b/deps/verifier/src/tdx/eventlog.rs
@@ -71,7 +71,7 @@ impl CcEventLog {
     }
 
     fn rebuild_rtmr(&self) -> Result<Rtmr> {
-        let mr_map = self.cc_events.replay_measurement_regiestry();
+        let mr_map = self.cc_events.replay_measurement_registry();
 
         let mr = Rtmr {
             rtmr0: mr_map.get(&1).unwrap_or(&Vec::from([0u8; 48]))[0..48].try_into()?,


### PR DESCRIPTION
There were some typo fixes upstream in the eventlog crate and a new release was cut. Let's bump our lockfile to pickup the changes and use the new function name.