### PR TITLE
Allow RVPS configuration via KBS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,7 +3007,6 @@ dependencies = [
  "jwt-simple",
  "kbs_protocol",
  "log",
- "reference-value-provider-service",
  "reqwest",
  "serde",
  "serde_json",

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = [ "restful-bin", "rvps-grpc" ]
+default = [ "grpc-bin", "rvps-grpc" ]
 all-verifier = [ "verifier/all-verifier" ]
 tdx-verifier = [ "verifier/tdx-verifier" ]
 sgx-verifier = [ "verifier/sgx-verifier" ]

--- a/attestation-service/src/bin/grpc/mod.rs
+++ b/attestation-service/src/bin/grpc/mod.rs
@@ -16,17 +16,9 @@ use tonic::{Request, Response, Status};
 
 use crate::as_api::attestation_service_server::{AttestationService, AttestationServiceServer};
 use crate::as_api::{
-    AttestationRequest, AttestationResponse, ChallengeRequest, ChallengeResponse, SetPolicyRequest,
-    SetPolicyResponse,
-};
-
-use crate::rvps_api::reference_value_provider_service_server::{
-    ReferenceValueProviderService, ReferenceValueProviderServiceServer,
-};
-
-use crate::rvps_api::{
+    AttestationRequest, AttestationResponse, ChallengeRequest, ChallengeResponse,
     ReferenceValueQueryRequest, ReferenceValueQueryResponse, ReferenceValueRegisterRequest,
-    ReferenceValueRegisterResponse,
+    ReferenceValueRegisterResponse, SetPolicyRequest, SetPolicyResponse,
 };
 
 fn to_kbs_tee(tee: &str) -> anyhow::Result<Tee> {
@@ -115,9 +107,9 @@ impl AttestationService for Arc<RwLock<AttestationServer>> {
         let runtime_data = match request.runtime_data {
             Some(runtime_data) => match runtime_data {
                 crate::as_api::attestation_request::RuntimeData::RawRuntimeData(raw) => {
-                    let raw_runtime = URL_SAFE_NO_PAD
-                        .decode(raw)
-                        .map_err(|e| Status::aborted(format!("Failed to decode base64 runtime data: {e}")))?;
+                    let raw_runtime = URL_SAFE_NO_PAD.decode(raw).map_err(|e| {
+                        Status::aborted(format!("Failed to decode base64 runtime data: {e}"))
+                    })?;
                     Some(attestation_service::Data::Raw(raw_runtime))
                 }
                 crate::as_api::attestation_request::RuntimeData::StructuredRuntimeData(
@@ -135,14 +127,15 @@ impl AttestationService for Arc<RwLock<AttestationServer>> {
         let init_data = match request.init_data {
             Some(init_data) => match init_data {
                 crate::as_api::attestation_request::InitData::RawInitData(raw) => {
-                    let raw_init = URL_SAFE_NO_PAD
-                        .decode(raw)
-                        .map_err(|e| Status::aborted(format!("Failed to decode base64 init data: {e}")))?;
+                    let raw_init = URL_SAFE_NO_PAD.decode(raw).map_err(|e| {
+                        Status::aborted(format!("Failed to decode base64 init data: {e}"))
+                    })?;
                     Some(attestation_service::Data::Raw(raw_init))
                 }
                 crate::as_api::attestation_request::InitData::StructuredInitData(structured) => {
-                    let structured = serde_json::from_str(&structured)
-                        .map_err(|e| Status::aborted(format!("Failed to parse structured init data: {e}")))?;
+                    let structured = serde_json::from_str(&structured).map_err(|e| {
+                        Status::aborted(format!("Failed to parse structured init data: {e}"))
+                    })?;
                     Some(attestation_service::Data::Structured(structured))
                 }
             },
@@ -232,10 +225,7 @@ impl AttestationService for Arc<RwLock<AttestationServer>> {
         };
         Ok(Response::new(res))
     }
-}
 
-#[tonic::async_trait]
-impl ReferenceValueProviderService for Arc<RwLock<AttestationServer>> {
     async fn query_reference_value(
         &self,
         _request: Request<ReferenceValueQueryRequest>,
@@ -265,12 +255,10 @@ impl ReferenceValueProviderService for Arc<RwLock<AttestationServer>> {
         info!("RegisterReferenceValue API called.");
         debug!("registering reference value: {}", request.message);
 
-        let message = serde_json::from_str(&request.message)
-            .map_err(|e| Status::aborted(format!("Failed to parse message: {e}")))?;
         self.write()
             .await
             .attestation_service
-            .register_reference_value(message)
+            .register_reference_value(&request.message)
             .await
             .map_err(|e| Status::aborted(format!("Register reference value: {e}")))?;
 
@@ -280,13 +268,15 @@ impl ReferenceValueProviderService for Arc<RwLock<AttestationServer>> {
 }
 
 pub async fn start(socket: SocketAddr, config_path: Option<String>) -> Result<(), GrpcError> {
-    info!("Starting gRPC Attestation Service. Listenening on socket: {}", &socket);
+    info!(
+        "Starting gRPC Attestation Service. Listenening on socket: {}",
+        &socket
+    );
 
     let attestation_server = Arc::new(RwLock::new(AttestationServer::new(config_path).await?));
 
     Server::builder()
         .add_service(AttestationServiceServer::new(attestation_server.clone()))
-        .add_service(ReferenceValueProviderServiceServer::new(attestation_server))
         .serve(socket)
         .await?;
     Ok(())

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -210,12 +210,20 @@ impl AttestationService {
         Ok(attestation_results_token)
     }
 
-    /// Registry a new reference value
+    /// Register a new reference value
     pub async fn register_reference_value(&mut self, message: &str) -> Result<()> {
         self.rvps
             .verify_and_extract(message)
             .await
             .context("register reference value")
+    }
+
+    /// Query Reference Values
+    pub async fn query_reference_values(&self) -> Result<HashMap<String, Vec<String>>> {
+        self.rvps
+            .get_digests()
+            .await
+            .context("query reference values")
     }
 
     pub async fn generate_supplemental_challenge(

--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -179,6 +179,42 @@ pub(crate) async fn api(
 
             Ok(HttpResponse::Ok().finish())
         }
+        #[cfg(feature = "as")]
+        "reference-value" if request.method() == Method::GET => {
+            core.admin_auth.validate_auth(&request)?;
+            let reference_values = serde_json::to_string(
+                &core
+                    .attestation_service
+                    .query_reference_values()
+                    .await
+                    .map_err(|e| Error::RvpsError {
+                        message: format!("Failed to get reference_values: {e}").to_string(),
+                    })?,
+            )?;
+
+            Ok(HttpResponse::Ok()
+                .content_type("text/xml")
+                .body(reference_values))
+        }
+        #[cfg(feature = "as")]
+        "reference-value" if request.method() == Method::POST => {
+            core.admin_auth.validate_auth(&request)?;
+            let message = std::str::from_utf8(&body).map_err(|_| Error::RvpsError {
+                message: "Failed to parse reference value message".to_string(),
+            })?;
+            serde_json::to_string(
+                &core
+                    .attestation_service
+                    .register_reference_value(message)
+                    .await
+                    .map_err(|e| Error::RvpsError {
+                        message: format!("Failed to register reference value: {e}").to_string(),
+                    })?,
+            )?;
+
+            Ok(HttpResponse::Ok().content_type("text/xml").finish())
+        }
+
         // TODO: consider to rename the api name for it is not only for
         // resource retrievement but for all plugins.
         "resource-policy" if request.method() == Method::POST => {

--- a/kbs/src/attestation/backend.rs
+++ b/kbs/src/attestation/backend.rs
@@ -15,6 +15,7 @@ use rand::{thread_rng, Rng};
 use semver::{BuildMetadata, Prerelease, Version, VersionReq};
 use serde::Deserialize;
 use serde_json::json;
+use std::collections::HashMap;
 
 use crate::attestation::session::KBS_SESSION_ID;
 
@@ -89,6 +90,20 @@ pub trait Attest: Send + Sync {
         tee_parameters: serde_json::Value,
     ) -> anyhow::Result<Challenge> {
         generic_generate_challenge(tee, tee_parameters).await
+    }
+
+    /// Add reference values to the RVPS, if the AS supports it
+    async fn register_reference_value(&self, _message: &str) -> anyhow::Result<()> {
+        Err(anyhow!(
+            "Attestation Service does not support reference value configuration."
+        ))
+    }
+
+    /// Get reference values from the RVPS, if the AS supports it
+    async fn query_reference_values(&self) -> anyhow::Result<HashMap<String, Vec<String>>> {
+        Err(anyhow!(
+            "Attestation Service does not support reference value configuration."
+        ))
     }
 }
 

--- a/kbs/src/attestation/backend.rs
+++ b/kbs/src/attestation/backend.rs
@@ -332,6 +332,18 @@ impl AttestationService {
 
         Ok(token.to_owned())
     }
+
+    pub async fn register_reference_value(&self, message: &str) -> anyhow::Result<()> {
+        self.inner.register_reference_value(message).await?;
+
+        Ok(())
+    }
+
+    pub async fn query_reference_values(&self) -> anyhow::Result<HashMap<String, Vec<String>>> {
+        let values = self.inner.query_reference_values().await?;
+
+        Ok(values)
+    }
 }
 
 #[cfg(test)]

--- a/kbs/src/attestation/coco/builtin.rs
+++ b/kbs/src/attestation/coco/builtin.rs
@@ -72,7 +72,11 @@ impl Attest for BuiltInCoCoAs {
     }
 
     async fn register_reference_value(&self, message: &str) -> anyhow::Result<()> {
-        self.inner.write().await.register_reference_value(message).await
+        self.inner
+            .write()
+            .await
+            .register_reference_value(message)
+            .await
     }
 
     async fn query_reference_values(&self) -> anyhow::Result<HashMap<String, Vec<String>>> {

--- a/kbs/src/attestation/coco/builtin.rs
+++ b/kbs/src/attestation/coco/builtin.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use attestation_service::{config::Config as AsConfig, AttestationService, Data, HashAlgorithm};
 use kbs_types::{Attestation, Challenge, Tee};
 use serde_json::json;
+use std::collections::HashMap;
 use tokio::sync::RwLock;
 
 use crate::attestation::backend::{make_nonce, Attest};
@@ -68,6 +69,14 @@ impl Attest for BuiltInCoCoAs {
         };
 
         Ok(challenge)
+    }
+
+    async fn register_reference_value(&self, message: &str) -> anyhow::Result<()> {
+        self.inner.write().await.register_reference_value(message).await
+    }
+
+    async fn query_reference_values(&self) -> anyhow::Result<HashMap<String, Vec<String>>> {
+        self.inner.read().await.query_reference_values().await
     }
 }
 

--- a/kbs/src/error.rs
+++ b/kbs/src/error.rs
@@ -67,6 +67,9 @@ pub enum Error {
     #[error("Policy engine error")]
     PolicyEngine(#[from] crate::policy_engine::KbsPolicyEngineError),
 
+    #[error("RVPS configuration failed: {message}")]
+    RvpsError { message: String },
+
     #[error("Serialize/Deserialize failed")]
     SerdeError(#[from] serde_json::Error),
 

--- a/protos/attestation.proto
+++ b/protos/attestation.proto
@@ -86,9 +86,24 @@ message ChallengeResponse {
     string attestation_challenge = 1;
 }
 
+// The attestation service can also proxy requests
+// to an RVPS if supported.
+message ReferenceValueQueryRequest {}
+
+message ReferenceValueQueryResponse {
+    string reference_value_results = 1;
+}
+
+message ReferenceValueRegisterRequest {
+    string message = 1;
+}
+
+message ReferenceValueRegisterResponse {}
+
 service AttestationService {
     rpc AttestationEvaluate(AttestationRequest) returns (AttestationResponse) {};
     rpc SetAttestationPolicy(SetPolicyRequest) returns (SetPolicyResponse) {};
     rpc GetAttestationChallenge(ChallengeRequest) returns (ChallengeResponse) {};
-    // Get the GetPolicyRequest.user and GetPolicyRequest.tee specified Policy(.rego)
+    rpc QueryReferenceValue(ReferenceValueQueryRequest) returns (ReferenceValueQueryResponse) {};
+    rpc RegisterReferenceValue(ReferenceValueRegisterRequest) returns (ReferenceValueRegisterResponse) {};
 }

--- a/tools/kbs-client/Cargo.toml
+++ b/tools/kbs-client/Cargo.toml
@@ -21,7 +21,6 @@ jwt-simple.workspace = true
 kbs_protocol = { workspace = true, default-features = false }
 log.workspace = true
 reqwest = { workspace = true, default-features = false, features = ["cookies", "json"] }
-reference-value-provider-service.path = "../../rvps"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio.workspace = true

--- a/tools/kbs-client/src/main.rs
+++ b/tools/kbs-client/src/main.rs
@@ -66,16 +66,6 @@ enum Commands {
         #[clap(long, value_parser)]
         tee_key_file: Option<PathBuf>,
     },
-
-    /// List reference values registered with RVPS
-    GetReferenceValues,
-
-    /// Add a sample reference value to the RVPS.
-    /// The RVPS must enable the sample extractor
-    /// or the reference value will not be registered.
-    /// The sample extractor should only be used in scenarios
-    /// where the RVPS endpoint is not exposed to untrusted users.
-    SetSampleReferenceValue { name: String, value: String },
 }
 
 #[derive(Args)]
@@ -139,6 +129,16 @@ enum ConfigCommands {
         #[clap(long, value_parser)]
         resource_file: PathBuf,
     },
+
+    /// List reference values registered with RVPS
+    GetReferenceValues,
+
+    /// Add a sample reference value to the RVPS.
+    /// The RVPS must enable the sample extractor
+    /// or the reference value will not be registered.
+    /// The sample extractor should only be used in scenarios
+    /// where the RVPS endpoint is not exposed to untrusted users.
+    SetSampleReferenceValue { name: String, value: String },
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -270,15 +270,23 @@ async fn main() -> Result<()> {
                         STANDARD.encode(resource_bytes)
                     );
                 }
+                ConfigCommands::SetSampleReferenceValue { name, value } => {
+                    kbs_client::set_sample_rv(
+                        cli.url,
+                        name,
+                        value,
+                        auth_key.clone(),
+                        kbs_cert.clone(),
+                    )
+                    .await?;
+                    println!("Reference Values Updated");
+                }
+                ConfigCommands::GetReferenceValues => {
+                    let values =
+                        kbs_client::get_rvs(cli.url, auth_key.clone(), kbs_cert.clone()).await?;
+                    println!("{:?}", values);
+                }
             }
-        }
-        Commands::SetSampleReferenceValue { name, value } => {
-            kbs_client::set_sample_rv(cli.url, name, value).await?;
-            println!("Reference Values Updated");
-        }
-        Commands::GetReferenceValues => {
-            let values = kbs_client::get_rvs(cli.url).await?;
-            println!("{:?}", values);
         }
     }
 


### PR DESCRIPTION
This PR allows clients to configure the RVPS by communicating with the KBS, which will proxy the request via the AS, to the KBS. The significance of this might not be immediately obvious, but I think it does some nice things. It helps address https://github.com/confidential-containers/trustee/issues/761 and is a follow-up on https://github.com/confidential-containers/trustee/pull/757

We have a couple of problems with the RVPS API. First, you can't use the RVPS API when the RVPS is in built-in mode. This is a bit of an oversight. This PR fixes that, by allowing configuration of the RVPS via the KBS whether it is in built-in mode or not.

Second, the RVPS API isn't totally secure since the sample extractor is always enabled and can be used to overwrite any reference value. Thus, it shouldn't be exposed to the outside world. If it isn't, how do you configure the RVPS? Well, now you can use the kbs-client via the config command, which requires you to be authorized.

I kept the commits pretty small for this PR and wrote a lot more info in the commit messages.

