### PR TITLE
ci: set up native build for arm64 and kbs-client-image

### DIFF
--- a/.github/workflows/build-as-image.yml
+++ b/.github/workflows/build-as-image.yml
@@ -45,8 +45,8 @@ jobs:
           verifier: se-verifier
         - target_arch: aarch64
           target_platform: linux/arm64
-          build_platform: linux/amd64
-          instance: ubuntu-22.04
+          build_platform: linux/arm64
+          instance: ubuntu-24.04-arm
           verifier: cca-verifier
     runs-on: ${{ matrix.instance }}
 

--- a/.github/workflows/build-kbs-client-image.yml
+++ b/.github/workflows/build-kbs-client-image.yml
@@ -1,0 +1,45 @@
+name: Build KBS Client Image
+
+on:
+  workflow_call:
+    inputs:
+      build_option:
+        description: 'Build option for the image'
+        type: string
+        required: false
+
+jobs:
+  build_kbs_client_image:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            instance: ubuntu-24.04
+          - arch: s390x
+            instance: s390x
+          - arch: aarch64
+            instance: ubuntu-24.04-arm
+    runs-on: ${{ matrix.instance }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GHCR Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build Container Image KBS-Client (${{ matrix.arch }})
+      run: |
+        commit_sha=${{ github.sha }}
+        docker buildx build --provenance false ${{ inputs.build_option }} \
+          -f kbs/docker/kbs-client-image/Dockerfile \
+          -t "ghcr.io/confidential-containers/staged-images/kbs-client-image:${commit_sha}-${{ matrix.arch }}" \
+          -t "ghcr.io/confidential-containers/staged-images/kbs-client-image:latest-${{ matrix.arch }}" .

--- a/.github/workflows/build-kbs-image.yml
+++ b/.github/workflows/build-kbs-image.yml
@@ -56,23 +56,14 @@ jobs:
             instance: s390x
           - target_arch: aarch64
             target_platform: linux/arm64
-            build_platform: linux/amd64
-            instance: ubuntu-22.04
+            build_platform: linux/arm64
+            instance: ubuntu-24.04-arm
 
     runs-on: ${{ matrix.instance }}
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-
-    # TODO: remove this when https://github.com/actions/runner-images/issues/11471
-    # is fully resolved
-    - name: Set up QEMU v8 for Arm
-      if: matrix.target_arch == 'aarch64'
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: linux/arm64
-        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/push-kbs-client-image-to-ghcr.yml
+++ b/.github/workflows/push-kbs-client-image-to-ghcr.yml
@@ -1,0 +1,45 @@
+name: Build and Push KBS-Client Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_and_push_kbs_client_image:
+    permissions:
+      packages: write
+    uses: ./.github/workflows/build-kbs-client-image.yml
+    with:
+      build_option: --push
+    secrets: inherit
+
+  publish_multi_arch_image:
+    needs: build_and_push_kbs_client_image
+    strategy:
+      fail-fast: false
+    permissions:
+      packages: write
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Login to GHCR Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Publish Multi-Arch kbs-client-image
+      run: |
+        commit_sha=${{ github.sha }}
+        docker manifest create "ghcr.io/confidential-containers/staged-images/kbs-client-image:${commit_sha}" \
+          --amend "ghcr.io/confidential-containers/staged-images/kbs-client-image:${commit_sha}-x86_64" \
+          --amend "ghcr.io/confidential-containers/staged-images/kbs-client-image:${commit_sha}-aarch64" \
+          --amend "ghcr.io/confidential-containers/staged-images/kbs-client-image:${commit_sha}-s390x"
+        docker manifest push "ghcr.io/confidential-containers/staged-images/kbs-client-image:${commit_sha}"
+        docker manifest create "ghcr.io/confidential-containers/staged-images/kbs-client-image:latest" \
+          --amend "ghcr.io/confidential-containers/staged-images/kbs-client-image:latest-x86_64" \
+          --amend "ghcr.io/confidential-containers/staged-images/kbs-client-image:latest-aarch64" \
+          --amend "ghcr.io/confidential-containers/staged-images/kbs-client-image:latest-s390x"
+        docker manifest push "ghcr.io/confidential-containers/staged-images/kbs-client-image:latest"

--- a/.github/workflows/push-kbs-client-to-ghcr.yml
+++ b/.github/workflows/push-kbs-client-to-ghcr.yml
@@ -10,11 +10,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - x86_64
-          - s390x
-          - aarch64
-    runs-on: ${{ matrix.arch == 's390x' && 's390x' || 'ubuntu-24.04' }}
+        include:
+          - arch: x86_64
+            instance: ubuntu-24.04
+          - arch: s390x
+            instance: s390x
+          - arch: aarch64
+            instance: ubuntu-24.04-arm
+    runs-on: ${{ matrix.instance }}
     permissions:
       contents: read
       packages: write

--- a/kbs/docker/kbs-client-image/Dockerfile
+++ b/kbs/docker/kbs-client-image/Dockerfile
@@ -1,0 +1,14 @@
+FROM docker.io/library/rust:1.80.0 AS builder
+
+WORKDIR /usr/src/kbs
+COPY . .
+
+RUN apt-get update && apt-get install -y pkg-config libssl-dev git sudo
+
+# Build KBS Client
+RUN cd kbs && make cli-static-linux && \
+    cp ../target/$(uname -m)-unknown-linux-gnu/release/kbs-client /
+
+FROM ubuntu:22.04
+
+COPY --from=builder /kbs-client /usr/local/bin/kbs-client


### PR DESCRIPTION
* Use native build for arm64 and remove the workaround for cross build
  * the workaround PR: https://github.com/confidential-containers/trustee/pull/716
* Build and push kbs-client-image to ghcr to use it for trustee-operator's kuttl integration tests
  * kuttl integration tests: https://github.com/confidential-containers/trustee-operator/blob/main/.github/workflows/kuttl-int-tests.yaml
  * [KBS_IMAGE_NAME](https://github.com/confidential-containers/trustee-operator/blob/118b525474b744939f1387cc7be439e0e04e0bd2/Makefile#L178) and [CLIENT_IMAGE_NAME](https://github.com/confidential-containers/trustee-operator/blob/118b525474b744939f1387cc7be439e0e04e0bd2/Makefile#L179C1-L179C18) will be changed to `ghcr.io/confidential-containers/staged-images/kbs:latest` and `ghcr.io/confidential-containers/staged-images/kbs-client-image:latest` respectively