### PR TITLE
tdx: change default qcnl configuration

### DIFF
--- a/kbs/config/sgx_default_qcnl.conf
+++ b/kbs/config/sgx_default_qcnl.conf
@@ -2,7 +2,7 @@
   // *** ATTENTION : This file is in JSON format so the keys are case sensitive. Don't change them.
   
   //PCCS server address
-  "pccs_url": "https://localhost:8081/sgx/certification/v4/"
+  //"pccs_url": "https://localhost:8081/sgx/certification/v4/"
 
   // To accept insecure HTTPS certificate, set this option to false
   ,"use_secure_cert": true
@@ -10,7 +10,7 @@
   // You can use the Intel PCS or another PCCS to get quote verification collateral.  Retrieval of PCK 
   // Certificates will always use the PCCS described in pccs_url.  When collateral_service is not defined, both 
   // PCK Certs and verification collateral will be retrieved using pccs_url  
-  //,"collateral_service": "https://api.trustedservices.intel.com/sgx/certification/v4/"
+  ,"collateral_service": "https://api.trustedservices.intel.com/sgx/certification/v4/"
 
   // If you use a PCCS service to get the quote verification collateral, you can specify which PCCS API version is to be used.
   // The legacy 3.0 API will return CRLs in HEX encoded DER format and the sgx_ql_qve_collateral_t.version will be set to 3.0, while


### PR DESCRIPTION
The current QCNL configuration has the collateral service commented out. This seems to cause problems for anyone who tries to use it.

Maybe there is some reason for this being set that i am not aware of, but this has been a big stumbling block for users.

@mythi