### PR TITLE
toolchain: add rust-toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.80.0"

--- a/rvps/docker/Dockerfile
+++ b/rvps/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN if [ "$(uname -m)" != "${ARCH}" ]; then \
     export RUSTFLAGS="${RUSTFLAGS_ARGS}"; \
     apt-get install -y ${GCC_PACKAGE}; \
     rustup target add ${RUSTC_TARGET}; fi; \
-    cargo install --bin rvps --path rvps ${TARGET_FLAG}
+    cargo install --bin rvps --path rvps ${TARGET_FLAG} --locked
 
 FROM debian
 


### PR DESCRIPTION
rust-toolchain file will help to record a specific rust toolchain version to build the project.
For more details, see
https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file

Close #772

cc @larrydewey 