### PR TITLE
ci: enable kbs integration / e2e sample tests on arm64

### DIFF
--- a/.github/workflows/kbs-docker-e2e.yml
+++ b/.github/workflows/kbs-docker-e2e.yml
@@ -11,7 +11,21 @@ env:
 
 jobs:
   e2e-test:
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        instance:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+        include:
+          - instance: ubuntu-24.04
+            build_platform: linux/amd64
+            target_arch: x86_64
+            verifier: all-verifier
+          - instance: ubuntu-24.04-arm
+            build_platform: linux/arm64
+            target_arch: aarch64
+            verifier: cca-verifier
+    runs-on: ${{ matrix.instance }}
     env:
       RUSTC_VERSION: 1.80.0
     steps:
@@ -34,7 +48,7 @@ jobs:
         openssl pkey -in kbs/config/private.key -pubout -out kbs/config/public.pub
 
     - name: Build KBS Cluster
-      run: docker compose build
+      run: docker compose build --build-arg BUILDPLATFORM=${{ matrix.build_platform }} --build-arg ARCH=${{ matrix.target_arch }} --build-arg VERIFIER=${{ matrix.verifier }}
 
     - name: Start KBS cluster
       run: docker compose up -d

--- a/.github/workflows/kbs-e2e-sample.yml
+++ b/.github/workflows/kbs-e2e-sample.yml
@@ -17,9 +17,19 @@ jobs:
       with:
         path: ./kbs.tar.gz
 
-  e2e-test:
+  e2e-test-amd64:
     needs: checkout
     uses: ./.github/workflows/kbs-e2e.yml
     with:
       tee: sample
+      runs-on: '["ubuntu-22.04"]'
       tarball: kbs.tar.gz
+
+  e2e-test-arm64:
+    needs: checkout
+    uses: ./.github/workflows/kbs-e2e.yml
+    with:
+      tee: sample
+      runs-on: '["ubuntu-22.04-arm"]'
+      tarball: kbs.tar.gz
+      kbs-client-features: "sample_only,cca-attester"

--- a/.github/workflows/kbs-e2e.yml
+++ b/.github/workflows/kbs-e2e.yml
@@ -14,6 +14,10 @@ on:
         type: string
         description: Artifact containing checked out source from a prior job
         required: true
+      kbs-client-features:
+        type: string
+        default: ""
+        description: features for kbs-client
 
 # Self-hosted runners do not set -o pipefail otherwise
 defaults:
@@ -22,7 +26,7 @@ defaults:
 
 jobs:
   build-binaries:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     env:
       RUSTC_VERSION: 1.80.0
       OS_VERSION: ubuntu-22.04
@@ -55,7 +59,7 @@ jobs:
       working-directory: kbs/test
       run: |
         make install-dev-dependencies
-        make bins
+        make bins TEST_FEATURES=${{ inputs.kbs-client-features }}
 
     - name: Archive test folder
       run: tar czf test.tar.gz kbs/test

--- a/.github/workflows/kbs-rust.yml
+++ b/.github/workflows/kbs-rust.yml
@@ -22,9 +22,15 @@ jobs:
     name: Check
     strategy:
       fail-fast: false
+      matrix:
+        include:
+        - instance: ubuntu-24.04
+          test_features: ""
+        - instance: ubuntu-24.04-arm
+          test_features: "coco-as-builtin,coco-as-grpc,intel-trust-authority-as,sample_only,cca-attester"
     env:
       RUSTC_VERSION: 1.80.0
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.instance }}
 
     steps:
     - name: Code checkout
@@ -46,6 +52,7 @@ jobs:
         sudo apt-get install -y libtss2-dev
 
     - name: Install TDX dependencies
+      if: ${{ matrix.instance == 'ubuntu-24.04' }}
       run: |
         curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
         echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu noble main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
@@ -66,7 +73,7 @@ jobs:
 
     - name: Lint
       working-directory: kbs
-      run: make lint
+      run: make lint TEST_FEATURES=${{ matrix.test_features }}
 
     - name: Format
       working-directory: kbs
@@ -74,4 +81,4 @@ jobs:
 
     - name: Test
       working-directory: kbs
-      run: make check
+      run: make check TEST_FEATURES=${{ matrix.test_features }}

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -8,8 +8,6 @@ edition.workspace = true
 
 [dependencies] 
 kbs = { path = "../kbs" }
-attestation-service = { path = "../attestation-service" }
-kbs-client = { path = "../tools/kbs-client" }
 reference-value-provider-service = { path = "../rvps" }
 
 actix-web.workspace = true
@@ -25,3 +23,15 @@ serial_test.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tonic.workspace = true
+
+[target.'cfg(not(any(target_arch = "s390x", target_arch = "aarch64")))'.dependencies]
+attestation-service = { path = "../attestation-service"  }
+kbs-client = { path = "../tools/kbs-client"  }
+
+[target.'cfg(target_arch = "s390x")'.dependencies]
+attestation-service = { path = "../attestation-service", default-features = false, features = [ "se-verifier", ] }
+kbs-client = { path = "../tools/kbs-client", default-features = false, features = [ "se-attester", ] }
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+attestation-service = { path = "../attestation-service", default-features = false, features = [ "cca-verifier", ] }
+kbs-client = { path = "../tools/kbs-client", default-features = false, features = [ "cca-attester", ] }

--- a/kbs/Makefile
+++ b/kbs/Makefile
@@ -34,6 +34,8 @@ endif
 CLI_FEATURES ?=
 ATTESTER ?=
 FEATURES ?=
+TEST_FEATURES ?=
+TEST_ARGUMENTS ?=
 
 COCO_AS_INTEGRATION_TYPE ?= builtin
 
@@ -59,6 +61,10 @@ ifndef CLI_FEATURES
   else
     CLI_FEATURES += "sample_only,all-attesters"
   endif
+endif
+
+ifneq ($(TEST_FEATURES),)
+  TEST_ARGUMENTS = --no-default-features --features $(TEST_FEATURES)
 endif
 
 build: background-check-kbs
@@ -109,10 +115,10 @@ uninstall:
 	rm -rf $(INSTALL_DESTDIR)/kbs $(INSTALL_DESTDIR)/kbs-client $(INSTALL_DESTDIR)/issuer-kbs $(INSTALL_DESTDIR)/resource-kbs
 
 check:
-	cargo test -p kbs -p kbs-client -p integration-tests
+	cargo test -p kbs -p kbs-client -p integration-tests $(TEST_ARGUMENTS)
 
 lint:
-	cargo clippy -p kbs -p kbs-client -- -D warnings
+	cargo clippy -p kbs -p kbs-client $(TEST_ARGUMENTS) -- -D warnings
 
 format:
 	cargo fmt -p kbs -p kbs-client -- --check --config format_code_in_doc_comments=true

--- a/kbs/test/Makefile
+++ b/kbs/test/Makefile
@@ -1,3 +1,4 @@
+ARCH := $(shell uname -m)
 OS := $(shell lsb_release -si)
 RELEASE := $(shell lsb_release -sr)
 CODENAME := $(shell lsb_release -sc)
@@ -32,6 +33,9 @@ HTTPS_KEY := $(WORK_DIR)/https.key
 HTTPS_CERT := $(WORK_DIR)/https.crt
 KBS_POLICY := $(WORK_DIR)/kbs-policy.rego
 
+TEST_FEATURES ?=
+TEST_ARGUMENTS ?=
+
 SHELL := bash
 ifneq ($(OS),Ubuntu)
     $(error "This Makefile requires Ubuntu")
@@ -48,20 +52,27 @@ allow {
 endef
 export TEE_POLICY_REGO
 
+ifneq ($(TEST_FEATURES),)
+  TEST_ARGUMENTS = --no-default-features --features $(TEST_FEATURES)
+endif
+
 .PHONY: install-dev-dependencies
 install-dev-dependencies: install-dependencies
 	sudo apt-get update && \
 	sudo apt-get install -y \
 		build-essential \
 		clang \
-		libsgx-dcap-quote-verify-dev \
 		libssl-dev \
 		libtss2-dev \
 		pkg-config \
-		protobuf-compiler
+		protobuf-compiler && \
+	if [ "${ARCH}" = "x86_64" ]; then \
+	sudo apt-get install -y \
+		libsgx-dcap-quote-verify-dev; fi
 
 .PHONY: install-dependencies
 install-dependencies:
+	if [ "${ARCH}" = "x86_64" ]; then \
 	curl -L "$(SGX_REPO_URL)/intel-sgx-deb.key" | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
 	echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] $(SGX_REPO_URL) $(CODENAME) main" \
 		| sudo tee /etc/apt/sources.list.d/intel-sgx.list && \
@@ -73,7 +84,7 @@ install-dependencies:
 		libtss2-esys-3.0.2-0 \
 		libtss2-tctildr0 \
 		openssl && \
-	echo '{"collateral_service": "$(SGX_COLLATERAL_URL)"}' | sudo tee $(SGX_QCNL_CONFIG)
+	echo '{"collateral_service": "$(SGX_COLLATERAL_URL)"}' | sudo tee $(SGX_QCNL_CONFIG); fi
 
 kbs:
 	cd $(PROJECT_DIR) && \
@@ -87,7 +98,7 @@ resource-kbs:
 
 client:
 	cd $(PROJECT_DIR) && \
-	cargo build -p kbs-client --release && \
+	cargo build -p kbs-client --release $(TEST_ARGUMENTS) && \
 	install -D --compare $(PROJECT_DIR)/../target/release/kbs-client $(CURDIR)/client
 
 .PHONY: bins


### PR DESCRIPTION
Enable kbs integration / e2e sample tests on arm64
* kbs integration test: https://github.com/confidential-containers/trustee/blob/main/.github/workflows/kbs-rust.yml
* kbs e2e sample test: https://github.com/confidential-containers/trustee/blob/main/.github/workflows/kbs-e2e-sample.yml
* kbs docker e2e test: https://github.com/confidential-containers/trustee/blob/main/.github/workflows/kbs-docker-e2e.yml

Test results on the fork:
* kbs integration test: https://github.com/seungukshin/trustee/actions/runs/14595864727
* kbs e2e sample test: https://github.com/seungukshin/trustee/actions/runs/14595864726
* kbs docker e2e test: https://github.com/seungukshin/trustee/actions/runs/14595864719
