### PR TITLE
Trustee unified CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5696,6 +5696,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustee"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "env_logger 0.10.2",
+ "log",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5703,6 +5703,7 @@ dependencies = [
  "clap",
  "env_logger 0.10.2",
  "log",
+ "openssl",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5702,8 +5702,10 @@ dependencies = [
  "anyhow",
  "clap",
  "env_logger 0.10.2",
+ "kbs",
  "log",
  "openssl",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "tools/kbs-client",
     "deps/verifier",
     "integration-tests",
+    "trustee",
 ]
 resolver = "2"
 

--- a/trustee/Cargo.toml
+++ b/trustee/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "trustee"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+edition.workspace = true
+
+[features]
+default = ["aliases", "plugins"]
+aliases = []
+plugins = []
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+env_logger.workspace = true
+log.workspace = true

--- a/trustee/Cargo.toml
+++ b/trustee/Cargo.toml
@@ -15,5 +15,7 @@ plugins = []
 anyhow.workspace = true
 clap.workspace = true
 env_logger.workspace = true
+kbs = { version = "0.1.0", path = "../kbs" }
 log.workspace = true
 openssl.workspace = true
+tokio.workspace = true

--- a/trustee/Cargo.toml
+++ b/trustee/Cargo.toml
@@ -16,3 +16,4 @@ anyhow.workspace = true
 clap.workspace = true
 env_logger.workspace = true
 log.workspace = true
+openssl.workspace = true

--- a/trustee/src/aliases.rs
+++ b/trustee/src/aliases.rs
@@ -1,0 +1,21 @@
+use std::env;
+use std::path::Path;
+
+/// get_exe_basename returns the name the executable is running with.
+fn get_exe_basename() -> Option<String> {
+    let exe_name = env::args().next()?;
+    let exe_basename = Path::new(&exe_name).file_name()?.to_str()?;
+    Some(exe_basename.to_string())
+}
+
+/// match_alias selects and runs a cli according to the executable name.
+pub fn match_alias() -> Result<(), String> {
+    let alias = get_exe_basename().unwrap_or_default();
+
+    match alias.as_str() {
+        "true" => {}
+        alias => return Err(format!("not a known alias: {alias}")),
+    }
+
+    Ok(())
+}

--- a/trustee/src/cli.rs
+++ b/trustee/src/cli.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use clap::{error::Error, Parser};
+
+/// Enum to represent different subcommands.
+#[derive(Debug, Parser)]
+enum Commands {}
+
+#[derive(Debug, Parser)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+pub fn cli_default() -> Result<(), Error> {
+    let cli = Cli::try_parse()?;
+
+    Ok(())
+}

--- a/trustee/src/cli.rs
+++ b/trustee/src/cli.rs
@@ -1,6 +1,11 @@
+use std::path::Path;
+
 use anyhow::Result;
 use clap::{error::Error, Parser};
 use openssl::pkey::PKey;
+use tokio;
+
+use kbs::{ApiServer, KbsConfig};
 
 fn trustee_keygen(path: Option<String>) -> Result<()> {
     let private = PKey::generate_ed25519()?;
@@ -15,7 +20,15 @@ fn trustee_keygen(path: Option<String>) -> Result<()> {
     Ok(())
 }
 
-/// Enum to represent different subcommands.
+async fn trustee_run(config_file: &str) -> Result<()> {
+    let kbs_config = KbsConfig::try_from(Path::new(config_file))?;
+    let api_server = ApiServer::new(kbs_config).await?;
+    // TODO initialize the components separately
+    // and spawn each one within try_join
+    tokio::try_join!(api_server.server()?)?;
+    Ok(())
+}
+
 #[derive(Debug, Parser)]
 enum Commands {
     /// Generate a new key pair
@@ -23,6 +36,12 @@ enum Commands {
         /// Output file for the private key
         #[arg(long = "out")]
         out: Option<String>,
+    },
+    /// Launch Trustee
+    Run {
+        /// Configuration file
+        #[arg(long = "config")]
+        config_file: String,
     },
 }
 
@@ -33,11 +52,12 @@ struct Cli {
     command: Commands,
 }
 
-pub fn cli_default() -> Result<(), Error> {
+pub async fn cli_default() -> Result<(), Error> {
     let cli = Cli::try_parse()?;
 
     match cli.command {
         Commands::Keygen { out } => trustee_keygen(out).unwrap(),
+        Commands::Run { config_file } => trustee_run(&config_file).await.unwrap(),
     };
 
     Ok(())

--- a/trustee/src/cli.rs
+++ b/trustee/src/cli.rs
@@ -1,9 +1,30 @@
 use anyhow::Result;
 use clap::{error::Error, Parser};
+use openssl::pkey::PKey;
+
+fn trustee_keygen(path: Option<String>) -> Result<()> {
+    let private = PKey::generate_ed25519()?;
+    let public = private.public_key_to_pem()?;
+
+    if let Some(path) = path {
+        std::fs::write(&path, private.private_key_to_pem_pkcs8()?)?;
+        let public_path = format!("{path}.pub");
+        std::fs::write(&public_path, public)?;
+    }
+
+    Ok(())
+}
 
 /// Enum to represent different subcommands.
 #[derive(Debug, Parser)]
-enum Commands {}
+enum Commands {
+    /// Generate a new key pair
+    Keygen {
+        /// Output file for the private key
+        #[arg(long = "out")]
+        out: Option<String>,
+    },
+}
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
@@ -14,6 +35,10 @@ struct Cli {
 
 pub fn cli_default() -> Result<(), Error> {
     let cli = Cli::try_parse()?;
+
+    match cli.command {
+        Commands::Keygen { out } => trustee_keygen(out).unwrap(),
+    };
 
     Ok(())
 }

--- a/trustee/src/main.rs
+++ b/trustee/src/main.rs
@@ -10,7 +10,8 @@ mod aliases;
 #[cfg(feature = "plugins")]
 mod plugins;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
 
     #[cfg(feature = "aliases")]
@@ -21,7 +22,7 @@ fn main() {
         }
     }
 
-    let cli_error = match cli::cli_default() {
+    let cli_error = match cli::cli_default().await {
         Ok(_) => return,
         Err(e) => e,
     };

--- a/trustee/src/main.rs
+++ b/trustee/src/main.rs
@@ -1,0 +1,35 @@
+use std::env;
+
+use log::debug;
+
+mod cli;
+
+#[cfg(feature = "aliases")]
+mod aliases;
+
+#[cfg(feature = "plugins")]
+mod plugins;
+
+fn main() {
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+
+    #[cfg(feature = "aliases")]
+    match aliases::match_alias() {
+        Ok(_) => return,
+        Err(e) => {
+            debug!("matching alias failed: {}", e)
+        }
+    }
+
+    let cli_error = match cli::cli_default() {
+        Ok(_) => return,
+        Err(e) => e,
+    };
+
+    #[cfg(feature = "plugins")]
+    if env::args().count() > 1 {
+        plugins::exec();
+    }
+
+    cli_error.exit()
+}

--- a/trustee/src/plugins.rs
+++ b/trustee/src/plugins.rs
@@ -1,0 +1,42 @@
+use std::env;
+use std::io::ErrorKind::{NotFound, PermissionDenied};
+use std::process::{exit, Command};
+
+use log::{debug, error};
+
+const PLUGIN_PREFIX: &str = "trustee";
+
+/// Spawns the plugin command and exits.
+///
+/// Returns only if the plugin is not found or it's not executable,
+/// to allow to continue the CLI flow.
+pub fn exec() {
+    let mut args_iter = env::args();
+    // skip arg0
+    args_iter.next();
+    let command = args_iter.next().expect("missing plugin command");
+    let plugin_command = format!("{}-{}", PLUGIN_PREFIX, command);
+
+    let command_result = Command::new(&plugin_command).args(args_iter).status();
+
+    match command_result {
+        Ok(status) => {
+            let exit_code = status.code().unwrap_or(1);
+            exit(exit_code)
+        }
+        Err(err) => {
+            let kind = err.kind();
+            let message = format!(
+                "can't run plugin: {}: {}",
+                &plugin_command,
+                kind.to_string()
+            );
+            if kind == NotFound || kind == PermissionDenied {
+                debug!("{}", &message);
+            } else {
+                error!("{}", &message);
+                exit(1)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hey! I've been trying to address #529 and bootstrap a CLI for Trustee.

### Aliases and plugins
I'm supporting aliases and plugins.
Aliases are when you link to the same executable with different names (à la busybox).
Plugins allow third parties to create a `trustee-something` executable and run it with
```
trustee something do-my-third-party-thing
```

### Structure / design
The design direction I took is to unify all the command lines in a single one.
I'm opening this pull as a draft while it's in early stages. Below there is a graphic of the structure I'm thinking about.

![trustee-new-architecture drawio](https://github.com/user-attachments/assets/32f82786-fcc5-4532-9240-1290e215e456)

### Next steps

I'll be updating this pull in the next days. This is what I have in mind right now:

- Implement more commands.
- Make the `run` command spawn all the components separately.
- Allow to `run` without a config file, using defaults + CLI arguments.
- Use functions that already exist in the codebase for the `keygen` command.

Harsh feedback is welcome 😁
