### PR TITLE
kbs/config/kubernetes: update for deploying on AKS

### DIFF
--- a/kbs/config/kubernetes/README.md
+++ b/kbs/config/kubernetes/README.md
@@ -44,9 +44,6 @@ cp ../../sample_policies/allow_all.rego base/policy.rego
 
 If you would like to expose KBS using Ingress, then run the following commands:
 
-> [!NOTE]
-> If you are using AKS then set the `KBS_INGRESS_CLASS` to `addon-http-application-routing` and get the `CLUSTER_SPECIFIC_DNS_ZONE` by following the instructions [here](https://learn.microsoft.com/en-us/azure/aks/http-application-routing#enable-http-application-routing).
-
 ```bash
 export KBS_INGRESS_CLASS="REPLACE_ME"
 export CLUSTER_SPECIFIC_DNS_ZONE="REPLACE_ME"
@@ -57,6 +54,14 @@ envsubst <ingress.yaml >ingress.yaml.tmp && mv ingress.yaml.tmp ingress.yaml
 kustomize edit add resource ingress.yaml
 popd
 ```
+
+If you are using AKS then one option is to enable the **approuting** add-on in your cluster (more information [here](https://learn.microsoft.com/en-us/azure/aks/app-routing)) and set the above environment variables as:
+* `KBS_INGRESS_CLASS="webapprouting.kubernetes.azure.com"`
+* the **approuting** add-on doesn't create a managed cluster DNS zone, so you will need to create it yourself and attach to **approuting** (more information [here](https://learn.microsoft.com/en-us/azure/aks/app-routing-dns-ssl#create-a-public-azure-dns-zone)). Then set `CLUSTER_SPECIFIC_DNS_ZONE` to the created zone name
+* in case you don't want a cluster DNS zone, export `KBS_INGRESS_HOST="\"\""` and use the ingress public IP:
+  ```bash
+  kubectl get service -n app-routing-system nginx -o jsonpath="{.status.loadBalancer.ingress[0].ip}"
+  ```
 
 ## Optional: Use non-release images
 

--- a/kbs/config/kubernetes/overlays/ingress.yaml
+++ b/kbs/config/kubernetes/overlays/ingress.yaml
@@ -3,9 +3,8 @@ kind: Ingress
 metadata:
   name: kbs
   namespace: coco-tenant
-  annotations:
-    kubernetes.io/ingress.class: $KBS_INGRESS_CLASS
 spec:
+  ingressClassName: $KBS_INGRESS_CLASS
   rules:
   - host: $KBS_INGRESS_HOST
     http:


### PR DESCRIPTION
The Azure AKS addon-http-application-routing add-on is deprecated and cannot be enabled on new clusters. Azure suggests to replace it with approuting, so this changed the README.md accordingly.

Also passing the ingress class via annotation is deprecated as shown on the warning below. Changed the ingress manifest to pass the class name in the spec section:

```
Warning: annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
```