### PR TITLE
Add built-in affirming policy to KBS client

### DIFF
--- a/kbs/sample_policies/README.md
+++ b/kbs/sample_policies/README.md
@@ -7,3 +7,4 @@ There are also several example policies used [for testing](../test/data).
 | ---  | ---         |
 |[allow_all.rego](./allow_all.rego)|Equivalent to turning off the policy engine. Release resources unconditionally|
 |[deny_all.rego](./deny_all.rego)|Deny all resources release|
+|[affirming.rego](./affirming.rego)|Only release resources if the AS provides an affirming EAR token|

--- a/kbs/sample_policies/affirming.rego
+++ b/kbs/sample_policies/affirming.rego
@@ -1,0 +1,8 @@
+package policy
+import rego.v1
+
+default allow = false
+
+allow if {
+    input["submods"]["cpu"]["ear.status"] == "affirming"
+}

--- a/tools/kbs-client/src/main.rs
+++ b/tools/kbs-client/src/main.rs
@@ -122,6 +122,11 @@ enum ConfigCommands {
         #[clap(long, action, group = "resource_policy")]
         deny_all: bool,
 
+        /// Use built-in policy that only releases resources if the attestation
+        /// token is affirming (i.e. the attestation policy is met)
+        #[clap(long, action, group = "resource_policy")]
+        affirming: bool,
+
         /// Use built-in default policy that allows access to all policies
         /// unless the sample evidence is provided
         #[clap(long, action, group = "resource_policy")]
@@ -226,6 +231,7 @@ async fn main() -> Result<()> {
                     policy_file,
                     allow_all,
                     deny_all,
+                    affirming,
                     default,
                 } => {
                     let policy_bytes: Vec<u8> = if let Some(file) = policy_file {
@@ -234,6 +240,8 @@ async fn main() -> Result<()> {
                         include_bytes!("../../../kbs/sample_policies/allow_all.rego").into()
                     } else if deny_all {
                         include_bytes!("../../../kbs/sample_policies/deny_all.rego").into()
+                    } else if affirming {
+                        include_bytes!("../../../kbs/sample_policies/affirming.rego").into()
                     } else if default {
                         include_bytes!("../../../kbs/src/policy_engine/opa/default_policy.rego")
                             .into()


### PR DESCRIPTION
Recently I added a couple built-in policies to the KBS Client. These simplify the workflow for admins who are setting basic policies. Unfortunately, I didn't think to add the policy that is probably most important; the affirming policy, which basically makes sure that the attestation policy passed.