### PR TITLE
policy: fix SNP policy

### DIFF
--- a/attestation-service/src/token/ear_default_policy.rego
+++ b/attestation-service/src/token/ear_default_policy.rego
@@ -48,7 +48,7 @@ hardware := 2 if {
 ##### SNP
 executables := 3 if {
 	# In the future, we might calculate this measurement here various components
-	input.snp.launch_measurement in data.reference.snp_launch_measurement
+	input.snp.measurement in data.reference.snp_launch_measurement
 }
 
 hardware := 2 if {


### PR DESCRIPTION
The SNP policy references a claim called `launch_measurement`, but the claim is actually just `measurement`.

cc @bpradipt @ryansavino 