### PR TITLE
ci: fix the kbs e2e test failure on azure vtpm

### DIFF
--- a/.github/workflows/kbs-e2e-azure-vtpm.yml
+++ b/.github/workflows/kbs-e2e-azure-vtpm.yml
@@ -60,7 +60,7 @@ jobs:
     - checkout-and-rebase
     uses: ./.github/workflows/kbs-e2e.yml
     with:
-      runs-on: '["self-hosted","azure-cvm-tdx"]'
+      runs-on-test: '["self-hosted","azure-cvm-tdx"]'
       tee: aztdxvtpm
       tarball: kbs.tar.gz
 
@@ -70,6 +70,6 @@ jobs:
     - checkout-and-rebase
     uses: ./.github/workflows/kbs-e2e.yml
     with:
-      runs-on: '["self-hosted","azure-cvm"]'
+      runs-on-test: '["self-hosted","azure-cvm"]'
       tee: azsnpvtpm
       tarball: kbs.tar.gz

--- a/.github/workflows/kbs-e2e-sample.yml
+++ b/.github/workflows/kbs-e2e-sample.yml
@@ -22,7 +22,6 @@ jobs:
     uses: ./.github/workflows/kbs-e2e.yml
     with:
       tee: sample
-      runs-on: '["ubuntu-22.04"]'
       tarball: kbs.tar.gz
 
   e2e-test-arm64:
@@ -30,6 +29,7 @@ jobs:
     uses: ./.github/workflows/kbs-e2e.yml
     with:
       tee: sample
-      runs-on: '["ubuntu-22.04-arm"]'
+      runs-on-build: '["ubuntu-22.04-arm"]'
+      runs-on-test: '["ubuntu-22.04-arm"]'
       tarball: kbs.tar.gz
       kbs-client-features: "sample_only,cca-attester"

--- a/.github/workflows/kbs-e2e.yml
+++ b/.github/workflows/kbs-e2e.yml
@@ -6,10 +6,14 @@ on:
       tee:
         type: string
         required: true
-      runs-on:
+      runs-on-build:
         type: string
         default: '["ubuntu-22.04"]'
-        description: JSON representation of runner labels
+        description: JSON representation of runner labels for build
+      runs-on-test:
+        type: string
+        default: '["ubuntu-22.04"]'
+        description: JSON representation of runner labels for test
       tarball:
         type: string
         description: Artifact containing checked out source from a prior job
@@ -26,7 +30,7 @@ defaults:
 
 jobs:
   build-binaries:
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ fromJSON(inputs.runs-on-build) }}
     env:
       RUSTC_VERSION: 1.80.0
       OS_VERSION: ubuntu-22.04
@@ -72,7 +76,7 @@ jobs:
 
   e2e-test:
     needs: build-binaries
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    runs-on: ${{ fromJSON(inputs.runs-on-test) }}
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v4


### PR DESCRIPTION
this makes `build-binaries` run on `ubuntu-22.04` for azure vtpm.
this fixes [this issue](https://github.com/confidential-containers/trustee/pull/774#issuecomment-2825512688).

tests from the forked repo.:
* sample tee: https://github.com/seungukshin/trustee/actions/runs/14637695169
* azure vtpm: https://github.com/seungukshin/trustee/actions/runs/14637695154
  * `build-binaries` passes, but `e2e-test` is not executed because of lack of self-hosted runners.