### PR TITLE
Fix a tiny typo in kbs document

### DIFF
--- a/kbs/docs/self-signed-https.md
+++ b/kbs/docs/self-signed-https.md
@@ -82,7 +82,7 @@ type = "coco_as_builtin"
 work_dir = "/opt/confidential-containers/attestation-service"
 policy_engine = "opa"
 
-    [attestation_serivce.attestation_token_broker]
+    [attestation_service.attestation_token_broker]
     type = "Ear"
     duration_min = 5
 


### PR DESCRIPTION
The typo is inside document and not code-related.  However, during setting up the KBS with HTTPS by following the document, it caused small issues.

This PR won't affect any executable files.