### PR TITLE
docker-compose: automatically generate admin keys

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     command: [
         "/usr/local/bin/kbs",
         "--config-file",
-        "/etc/kbs-config.toml",
+        "/opt/confidential-containers/kbs/user-keys/docker-compose/kbs-config.toml",
       ]
     restart: always # keep the server running
     ports:
@@ -17,10 +17,12 @@ services:
     volumes:
       - ./kbs/data/kbs-storage:/opt/confidential-containers/kbs/repository:rw
       - ./kbs/data/nebula-ca:/opt/confidential-containers/kbs/nebula-ca:rw
-      - ./kbs/config/public.pub:/opt/confidential-containers/kbs/user-keys/public.pub
-      - ./kbs/config/docker-compose/kbs-config.toml:/etc/kbs-config.toml
+      - ./kbs/config:/opt/confidential-containers/kbs/user-keys
     depends_on:
-    - as
+      as:
+        condition: service_started
+      setup:
+        condition: service_completed_successfully
 
   as:
     build:
@@ -73,7 +75,7 @@ services:
     ports:
       - "50000:50000"
     volumes:
-      - ./kbs/config/private.key:/etc/private.key
+      - ./kbs/config:/opt/confidential-containers/kbs/user-keys
     command: [
       "coco_keyprovider",
       "--socket",
@@ -81,7 +83,24 @@ services:
       "--kbs",
       "http://kbs:8080",
       "--auth-private-key",
-      "/etc/private.key"
+      "/opt/confidential-containers/kbs/user-keys/private.key"
     ]
     depends_on:
-    - kbs
+      kbs:
+        condition: service_started
+      setup:
+        condition: service_completed_successfully
+
+  setup:
+    image: alpine/openssl
+    environment:
+      - RUST_LOG
+    entrypoint: /bin/ash
+    command: >
+        -c "
+          if [ ! -s /opt/confidential-containers/kbs/user-keys/private.key ]; then
+            /usr/bin/openssl genpkey -algorithm ed25519 > /opt/confidential-containers/kbs/user-keys/private.key &&
+            /usr/bin/openssl pkey -in /opt/confidential-containers/kbs/user-keys/private.key -pubout -out /opt/confidential-containers/kbs/user-keys/public.pub;
+          fi"
+    volumes:
+      - ./kbs/config:/opt/confidential-containers/kbs/user-keys


### PR DESCRIPTION
We expect the user to generate the admin keypair for the KBS (and keyprovider), but this really isn't necessary. This commit does maintain the existing workflow, so users can continue to setup their keys if they would like to and our existing guides are still valid.

We do have to make a few small tweaks to setup the keys from inside the KBS container. First, we have to install openssl inside the container. The staged container images don't have openssl in them yet (until after this PR), so let's hold off on updating the docs for now. I will make a second PR that tests out the staged images and updates the docs. For now, this will only work if you build the images yourself.

Next, we have to change how we mount the keys into the container. Currently, we mount the two key files individually. Docker compose will complain if they don't exist. To get around this we can mount the entire config directory. This does copy a few files into the container that we don't need, but if we want to keep the paths of the keys the same on the host (to not break the current flow), I don't think there's any way around this.