### PR TITLE
ci: dependabot: check direct cargo dependencies only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     open-pull-requests-limit: 1
     allow:
       - dependency-type: direct
-      - dependency-type: indirect
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Per dependabot docs, dependabot should prioritize direct dependencies but it does not seem to be the case.

As of today, we have a backlog of 148 "update candidates" (according to the update job logs) and the repo is configured to have one open PR at a time so it will be an endless effort to get things up-to-date.

For now, make dependabot to check direct dependencies only so that we get those updated.

Per discussion in https://github.com/confidential-containers/trustee/pull/797#issuecomment-2896873687