### PR TITLE
policy: change expected SNP configuration values to Strings

### DIFF
--- a/attestation-service/src/token/ear_default_policy.rego
+++ b/attestation-service/src/token/ear_default_policy.rego
@@ -64,8 +64,8 @@ hardware := 2 if {
 #
 # For this, we compare all the configuration fields.
 configuration := 2 if {
-	input.snp.policy_debug_allowed == 0
-	input.snp.policy_migrate_ma == 0
+	input.snp.policy_debug_allowed == "0"
+	input.snp.policy_migrate_ma == "0"
 	input.snp.platform_smt_enabled in data.reference.snp_smt_enabled
 	input.snp.platform_tsme_enabled in data.reference.snp_tsme_enabled
 	input.snp.policy_abi_major in data.reference.snp_guest_abi_major
@@ -82,8 +82,8 @@ configuration := 2 if {
 # configuration value, but we make sure that some key
 # configurations (like debug_allowed) are set correctly.
 else := 3 if {
-	input.snp.policy_debug_allowed == 0
-	input.snp.policy_migrate_ma == 0
+	input.snp.policy_debug_allowed == "0"
+	input.snp.policy_migrate_ma == "0"
 }
 
 ##### TDX


### PR DESCRIPTION
The SNP verifier returns all of its TCB claims as strings, we could adjust this to return numeric types for certain claims, but the RVPS currently stores all reference values as strings.

In the future we should update the RVPS to work with numeric types as well, but for now let's change the policy to use strings.

Fix https://github.com/confidential-containers/trustee/issues/801