### PR TITLE
Bumpin SEV library to 6.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "attestation-agent"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=069a6ea#069a6ea010f44b759478b5cdc191d50416cb7deb"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=33f908ff4e2a39d117fca510361b9a47722ccf48#33f908ff4e2a39d117fca510361b9a47722ccf48"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -619,7 +619,7 @@ dependencies = [
 [[package]]
 name = "attester"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=069a6ea#069a6ea010f44b759478b5cdc191d50416cb7deb"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=33f908ff4e2a39d117fca510361b9a47722ccf48#33f908ff4e2a39d117fca510361b9a47722ccf48"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -641,7 +641,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 3.12.0",
- "sev 6.1.0",
+ "sev 6.2.1",
  "sha2",
  "strum",
  "tempfile",
@@ -1445,7 +1445,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=069a6ea#069a6ea010f44b759478b5cdc191d50416cb7deb"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=33f908ff4e2a39d117fca510361b9a47722ccf48#33f908ff4e2a39d117fca510361b9a47722ccf48"
 dependencies = [
  "aes-gcm",
  "aes-kw",
@@ -3128,7 +3128,7 @@ dependencies = [
 [[package]]
 name = "kbs_protocol"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=069a6ea#069a6ea010f44b759478b5cdc191d50416cb7deb"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=33f908ff4e2a39d117fca510361b9a47722ccf48#33f908ff4e2a39d117fca510361b9a47722ccf48"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3152,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=069a6ea#069a6ea010f44b759478b5cdc191d50416cb7deb"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=33f908ff4e2a39d117fca510361b9a47722ccf48#33f908ff4e2a39d117fca510361b9a47722ccf48"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4497,7 +4497,7 @@ dependencies = [
 [[package]]
 name = "resource_uri"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=069a6ea#069a6ea010f44b759478b5cdc191d50416cb7deb"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=33f908ff4e2a39d117fca510361b9a47722ccf48#33f908ff4e2a39d117fca510361b9a47722ccf48"
 dependencies = [
  "anyhow",
  "serde",
@@ -5109,9 +5109,9 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492a7043c77be9a4997a62e2426ea084849c73660efd402f1a33fea0ee75ebb4"
+checksum = "1750ba11a6a6bba3c220da714caa0226aa34e417dce3975d2953062240717dea"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -6098,7 +6098,7 @@ dependencies = [
  "serde_json",
  "serde_with 1.14.0",
  "serial_test",
- "sev 6.1.0",
+ "sev 6.2.1",
  "sha2",
  "shadow-rs",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ hex = "0.4.3"
 jwt-simple = { version = "0.12", default-features = false, features = [
     "pure-rust",
 ] }
-kbs_protocol = { git = "https://github.com/confidential-containers/guest-components.git", rev = "069a6ea", default-features = false }
+kbs_protocol = { git = "https://github.com/confidential-containers/guest-components.git", rev = "33f908ff4e2a39d117fca510361b9a47722ccf48", default-features = false }
 kbs-types = "0.10.0"
-kms = { git = "https://github.com/confidential-containers/guest-components.git", rev = "069a6ea", default-features = false }
+kms = { git = "https://github.com/confidential-containers/guest-components.git", rev = "33f908ff4e2a39d117fca510361b9a47722ccf48", default-features = false }
 jsonwebtoken = { version = "9", default-features = false }
 log = "0.4.17"
 openssl = "0.10.72"

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -41,7 +41,7 @@ scroll = { version = "0.12.0", default-features = false, features = ["derive"], 
 serde.workspace = true
 serde_json.workspace = true
 serde_with = { workspace = true, optional = true }
-sev = { version = "6.1.0", default-features = false, features = ["openssl", "snp"], optional = true }
+sev = { version = "6.2.1", default-features = false, features = ["openssl", "snp"], optional = true }
 sha2.workspace = true 
 tokio = { workspace = true, optional = true }
 intel-tee-quote-verification-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", tag = "DCAP_1.22", optional = true }


### PR DESCRIPTION
Simply bumping the dependency to 6.2.1. There are some minor parsing bugs on 6.0.0 that get handled here and it would be good to include here to avoid complications later. No code changes required.

Should probably wait for https://github.com/confidential-containers/guest-components/pull/1012 to be merged first to also change the GC dependency in this PR.