### PR TITLE
KBS: more prometheus metrics

### DIFF
--- a/kbs/src/prometheus/mod.rs
+++ b/kbs/src/prometheus/mod.rs
@@ -93,6 +93,42 @@ lazy_static! {
         Counter::with_opts(opts).unwrap()
     };
 
+    /// KBS Attestation Requests Total
+    pub(crate) static ref ATTESTATION_REQUESTS: Counter = {
+        let opts = Opts::new(
+            "attestation_requests_total",
+            "Total count of attestation requests",
+        );
+        Counter::with_opts(opts).unwrap()
+    };
+
+    /// KBS Attestation Successes Total
+    pub(crate) static ref ATTESTATION_SUCCESSES: CounterVec = {
+        let opts = Opts::new(
+            "attestation_successes_total",
+            "Total count of attestation successes",
+        );
+        CounterVec::new(opts, &["tee_type"]).unwrap()
+    };
+
+    /// KBS Attestation Failures Total
+    pub(crate) static ref ATTESTATION_FAILURES: CounterVec = {
+        let opts = Opts::new(
+            "attestation_failures_total",
+            "Total count of attestation failures",
+        );
+        CounterVec::new(opts, &["tee_type"]).unwrap()
+    };
+
+    /// KBS Attestation Errors Total
+    pub(crate) static ref ATTESTATION_ERRORS: Counter = {
+        let opts = Opts::new(
+            "attestation_errors_total",
+            "Total count of errors during attestation processing",
+        );
+        Counter::with_opts(opts).unwrap()
+    };
+
     /// Prometheus instance to get the metrics
     static ref INSTANCE: Registry = {
         let registry = Registry::default();
@@ -110,6 +146,10 @@ lazy_static! {
         registry.register(Box::new(KBS_POLICY_APPROVALS.clone())).unwrap();
         registry.register(Box::new(KBS_POLICY_VIOLATIONS.clone())).unwrap();
         registry.register(Box::new(KBS_POLICY_ERRORS.clone())).unwrap();
+        registry.register(Box::new(ATTESTATION_REQUESTS.clone())).unwrap();
+        registry.register(Box::new(ATTESTATION_SUCCESSES.clone())).unwrap();
+        registry.register(Box::new(ATTESTATION_FAILURES.clone())).unwrap();
+        registry.register(Box::new(ATTESTATION_ERRORS.clone())).unwrap();
 
         registry
     };

--- a/kbs/src/prometheus/mod.rs
+++ b/kbs/src/prometheus/mod.rs
@@ -57,6 +57,42 @@ lazy_static! {
         Histogram::with_opts(response_sizes_opts).unwrap()
     };
 
+    /// KBS Policy Evaluations Total
+    pub(crate) static ref KBS_POLICY_EVALS: Counter = {
+        let opts = Opts::new(
+            "kbs_policy_evaluations_total",
+            "Total count of KBS policy evaluations",
+        );
+        Counter::with_opts(opts).unwrap()
+    };
+
+    /// KBS Policy Approvals Total
+    pub(crate) static ref KBS_POLICY_APPROVALS: Counter = {
+        let opts = Opts::new(
+            "kbs_policy_approvals_total",
+            "Total count of requests approved by KBS policy",
+        );
+        Counter::with_opts(opts).unwrap()
+    };
+
+    /// KBS Policy Violations Total
+    pub(crate) static ref KBS_POLICY_VIOLATIONS: Counter = {
+        let opts = Opts::new(
+            "kbs_policy_violations_total",
+            "Total count of requests denied by KBS policy",
+        );
+        Counter::with_opts(opts).unwrap()
+    };
+
+    /// KBS Policy Errors Total
+    pub(crate) static ref KBS_POLICY_ERRORS: Counter = {
+        let opts = Opts::new(
+            "kbs_policy_errors_total",
+            "Total count of errors during KBS evaluation",
+        );
+        Counter::with_opts(opts).unwrap()
+    };
+
     /// Prometheus instance to get the metrics
     static ref INSTANCE: Registry = {
         let registry = Registry::default();
@@ -70,6 +106,10 @@ lazy_static! {
         registry.register(Box::new(REQUEST_DURATION.clone())).unwrap();
         registry.register(Box::new(REQUEST_SIZES.clone())).unwrap();
         registry.register(Box::new(RESPONSE_SIZES.clone())).unwrap();
+        registry.register(Box::new(KBS_POLICY_EVALS.clone())).unwrap();
+        registry.register(Box::new(KBS_POLICY_APPROVALS.clone())).unwrap();
+        registry.register(Box::new(KBS_POLICY_VIOLATIONS.clone())).unwrap();
+        registry.register(Box::new(KBS_POLICY_ERRORS.clone())).unwrap();
 
         registry
     };

--- a/kbs/src/prometheus/mod.rs
+++ b/kbs/src/prometheus/mod.rs
@@ -129,6 +129,33 @@ lazy_static! {
         Counter::with_opts(opts).unwrap()
     };
 
+    /// KBS Auth Requests Total
+    pub(crate) static ref AUTH_REQUESTS: Counter = {
+        let opts = Opts::new(
+            "auth_requests_total",
+            "Total count of auth requests",
+        );
+        Counter::with_opts(opts).unwrap()
+    };
+
+    /// KBS Auth Successes Total
+    pub(crate) static ref AUTH_SUCCESSES: Counter = {
+        let opts = Opts::new(
+            "auth_successes_total",
+            "Total count of successfully authenticated requests",
+        );
+        Counter::with_opts(opts).unwrap()
+    };
+
+    /// KBS Auth Errors Total
+    pub(crate) static ref AUTH_ERRORS: Counter = {
+        let opts = Opts::new(
+            "auth_errors_total",
+            "Total count of errors during auth processing",
+        );
+        Counter::with_opts(opts).unwrap()
+    };
+
     /// Prometheus instance to get the metrics
     static ref INSTANCE: Registry = {
         let registry = Registry::default();
@@ -150,6 +177,9 @@ lazy_static! {
         registry.register(Box::new(ATTESTATION_SUCCESSES.clone())).unwrap();
         registry.register(Box::new(ATTESTATION_FAILURES.clone())).unwrap();
         registry.register(Box::new(ATTESTATION_ERRORS.clone())).unwrap();
+        registry.register(Box::new(AUTH_REQUESTS.clone())).unwrap();
+        registry.register(Box::new(AUTH_SUCCESSES.clone())).unwrap();
+        registry.register(Box::new(AUTH_ERRORS.clone())).unwrap();
 
         registry
     };


### PR DESCRIPTION
Add Prometheus metrics for authentication, attestation and policy evaluation as per discussion at issue #543.

The endpoint output after some successful resource accesses will be similar to
```
$ curl http://127.0.0.1:8080/metrics
# HELP attestation_errors_total Total count of errors during attestation processing
# TYPE attestation_errors_total counter
attestation_errors_total 0
# HELP attestation_requests_total Total count of attestation requests
# TYPE attestation_requests_total counter
attestation_requests_total 3
# HELP attestation_successes_total Total count of attestation successes
# TYPE attestation_successes_total counter
attestation_successes_total{tee_type="sample"} 3
# HELP auth_errors_total Total count of errors during auth processing
# TYPE auth_errors_total counter
auth_errors_total 0
# HELP auth_requests_total Total count of auth requests
# TYPE auth_requests_total counter
auth_requests_total 3
# HELP auth_successes_total Total count of successfully authenticated requests
# TYPE auth_successes_total counter
auth_successes_total 3
# HELP http_request_duration_seconds Distribution of request handling duration
# TYPE http_request_duration_seconds histogram
http_request_duration_seconds_bucket{le="0.0005"} 6
http_request_duration_seconds_bucket{le="0.001"} 7
http_request_duration_seconds_bucket{le="0.005"} 13
http_request_duration_seconds_bucket{le="0.01"} 13
http_request_duration_seconds_bucket{le="0.05"} 13
http_request_duration_seconds_bucket{le="0.5"} 13
http_request_duration_seconds_bucket{le="1"} 13
http_request_duration_seconds_bucket{le="+Inf"} 13
http_request_duration_seconds_sum 0.014657365
http_request_duration_seconds_count 13
# HELP http_request_size_bytes Distribution of request body sizes
# TYPE http_request_size_bytes histogram
http_request_size_bytes_bucket{le="32"} 8
http_request_size_bytes_bucket{le="128"} 17
http_request_size_bytes_bucket{le="512"} 23
http_request_size_bytes_bucket{le="2048"} 26
http_request_size_bytes_bucket{le="8192"} 26
http_request_size_bytes_bucket{le="+Inf"} 26
http_request_size_bytes_sum 7255
http_request_size_bytes_count 26
# HELP http_requests_total Total HTTP requests count
# TYPE http_requests_total counter
http_requests_total 13
# HELP http_response_size_bytes Distribution of response body sizes
# TYPE http_response_size_bytes histogram
http_response_size_bytes_bucket{le="32"} 0
http_response_size_bytes_bucket{le="128"} 0
http_response_size_bytes_bucket{le="512"} 0
http_response_size_bytes_bucket{le="2048"} 0
http_response_size_bytes_bucket{le="8192"} 0
http_response_size_bytes_bucket{le="+Inf"} 0
http_response_size_bytes_sum 0
http_response_size_bytes_count 0
# HELP kbs_policy_approvals_total Total count of requests approved by KBS policy
# TYPE kbs_policy_approvals_total counter
kbs_policy_approvals_total 3
# HELP kbs_policy_errors_total Total count of errors during KBS evaluation
# TYPE kbs_policy_errors_total counter
kbs_policy_errors_total 0
# HELP kbs_policy_evaluations_total Total count of KBS policy evaluations
# TYPE kbs_policy_evaluations_total counter
kbs_policy_evaluations_total 3
# HELP kbs_policy_violations_total Total count of requests denied by KBS policy
# TYPE kbs_policy_violations_total counter
kbs_policy_violations_total 0
# HELP resource_reads_total KBS resource read count
# TYPE resource_reads_total counter
resource_reads_total{resource_path="pvl/test/smazat"} 3
# HELP resource_writes_total KBS resource write count
# TYPE resource_writes_total counter
resource_writes_total{resource_path="pvl/test/smazat"} 1
```