### PR TITLE
bump rust toolchain to 1.85.1

### DIFF
--- a/.github/workflows/as-e2e.yml
+++ b/.github/workflows/as-e2e.yml
@@ -28,16 +28,14 @@ jobs:
     name: TEE=${{ matrix.restful_tee_enum }} Generate Evidence Dynamically=${{ matrix.generate_evidence }}
     runs-on: ${{ matrix.runner }}
     env:
-      RUSTC_VERSION: 1.80.0
       GRPC_TEE_ENUM: ${{ matrix.grpc_tee_enum }}
       RESTFUL_TEE_ENUM: ${{ matrix.restful_tee_enum }}
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install Rust toolchain (${{ env.RUSTC_VERSION }})
+    - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: ${{ env.RUSTC_VERSION }}
         components: rustfmt, clippy
 
     - uses: actions/setup-go@v5

--- a/.github/workflows/as-rust.yml
+++ b/.github/workflows/as-rust.yml
@@ -23,8 +23,6 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     name: Check
     runs-on: ubuntu-24.04
-    env:
-      RUSTC_VERSION: 1.80.0
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
@@ -59,10 +57,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsgx-dcap-quote-verify-dev libsgx-dcap-default-qpl
 
-      - name: Install Rust toolchain (${{ env.RUSTC_VERSION }})
+      - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: ${{ env.RUSTC_VERSION }}
           components: rustfmt, clippy
 
       - name: Build

--- a/.github/workflows/kbs-docker-e2e.yml
+++ b/.github/workflows/kbs-docker-e2e.yml
@@ -26,16 +26,13 @@ jobs:
             target_arch: aarch64
             verifier: cca-verifier
     runs-on: ${{ matrix.instance }}
-    env:
-      RUSTC_VERSION: 1.80.0
     steps:
     - name: Checkout KBS
       uses: actions/checkout@v4
 
-    - name: Install Rust ${{ env.RUSTC_VERSION }} (for client)
+    - name: Install Rust (for client)
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: ${{ env.RUSTC_VERSION }}
         components: rustfmt, clippy
 
     - name: Build client

--- a/.github/workflows/kbs-e2e.yml
+++ b/.github/workflows/kbs-e2e.yml
@@ -32,7 +32,6 @@ jobs:
   build-binaries:
     runs-on: ${{ fromJSON(inputs.runs-on-build) }}
     env:
-      RUSTC_VERSION: 1.80.0
       OS_VERSION: ubuntu-22.04
     steps:
     - name: Download artifacts
@@ -41,10 +40,9 @@ jobs:
     - name: Extract tarball
       run: tar xzf ./artifact/${{ inputs.tarball }}
 
-    - name: Install Rust toolchain (${{ env.RUSTC_VERSION }})
+    - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: ${{ env.RUSTC_VERSION }}
         components: rustfmt, clippy
         rustflags: ""
         cache: false

--- a/.github/workflows/kbs-rust.yml
+++ b/.github/workflows/kbs-rust.yml
@@ -28,18 +28,15 @@ jobs:
           test_features: ""
         - instance: ubuntu-24.04-arm
           test_features: "coco-as-builtin,coco-as-grpc,intel-trust-authority-as,sample_only,cca-attester"
-    env:
-      RUSTC_VERSION: 1.80.0
     runs-on: ${{ matrix.instance }}
 
     steps:
     - name: Code checkout
       uses: actions/checkout@v4
 
-    - name: Install Rust toolchain (${{ env.RUSTC_VERSION }})
+    - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: ${{ env.RUSTC_VERSION }}
         components: rustfmt, clippy
 
     - name: Building dependencies installation

--- a/kbs/docker/kbs-client-image/Dockerfile
+++ b/kbs/docker/kbs-client-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.80.0 AS builder
+FROM docker.io/library/rust:1.85.1 AS builder
 
 WORKDIR /usr/src/kbs
 COPY . .

--- a/kbs/docker/kbs-client/Dockerfile
+++ b/kbs/docker/kbs-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.80.0 AS builder
+FROM docker.io/library/rust:1.85.1 AS builder
 ARG ARCH=x86_64
 
 WORKDIR /usr/src/kbs

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.85.1"


### PR DESCRIPTION
pin 1.85.1 toolchain version for the repository. Also, drop RUSTC_VERSION definition from CI workflow files as they are mostly redundant.

The actions README states:
"If a toolchain file (i.e., rust-toolchain or rust-toolchain.toml) is found in the root of the repository and no toolchain value is provided, all items specified in the toolchain file will be installed."

Trustee CI checks Rust builds against one version only so we can control CI through rust-toolchain.toml.

NB: Rust MSRV is unchanged: 1.80.x.