### PR TITLE
Fix Rust toolchain 1.85.1 to Dockerfiles

### DIFF
--- a/.github/workflows/build-as-image.yml
+++ b/.github/workflows/build-as-image.yml
@@ -49,6 +49,8 @@ jobs:
           instance: ubuntu-24.04-arm
           verifier: cca-verifier
     runs-on: ${{ matrix.instance }}
+    env:
+      RUST_TOOLCHAIN_VERSION: 1.85.1
 
     steps:
     - name: Checkout code
@@ -72,5 +74,6 @@ jobs:
           --build-arg BUILDPLATFORM="${{ matrix.build_platform }}" \
           --build-arg ARCH="${{ matrix.target_arch }}" \
           --build-arg VERIFIER="${{ matrix.verifier }}" \
+          --build-arg RUST_TOOLCHAIN_VERSION="${{ env.RUST_TOOLCHAIN_VERSION }}" \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${{ matrix.target_arch }}" \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${{ matrix.target_arch }}" .

--- a/.github/workflows/build-kbs-client-image.yml
+++ b/.github/workflows/build-kbs-client-image.yml
@@ -21,6 +21,8 @@ jobs:
           - arch: aarch64
             instance: ubuntu-24.04-arm
     runs-on: ${{ matrix.instance }}
+    env:
+      RUST_TOOLCHAIN_VERSION: 1.85.1
 
     steps:
     - name: Checkout code
@@ -41,5 +43,6 @@ jobs:
         commit_sha=${{ github.sha }}
         docker buildx build --provenance false ${{ inputs.build_option }} \
           -f kbs/docker/kbs-client-image/Dockerfile \
+          --build-arg RUST_TOOLCHAIN_VERSION="${{ env.RUST_TOOLCHAIN_VERSION }}" \
           -t "ghcr.io/confidential-containers/staged-images/kbs-client-image:${commit_sha}-${{ matrix.arch }}" \
           -t "ghcr.io/confidential-containers/staged-images/kbs-client-image:latest-${{ matrix.arch }}" .

--- a/.github/workflows/build-kbs-image.yml
+++ b/.github/workflows/build-kbs-image.yml
@@ -60,6 +60,8 @@ jobs:
             instance: ubuntu-24.04-arm
 
     runs-on: ${{ matrix.instance }}
+    env:
+      RUST_TOOLCHAIN_VERSION: 1.85.1
 
     steps:
     - name: Checkout code
@@ -82,5 +84,6 @@ jobs:
           -f "${{ matrix.docker_file }}" ${{ inputs.build_option }} \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${{ matrix.target_arch }}" \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${{ matrix.target_arch }}" \
+          --build-arg RUST_TOOLCHAIN_VERSION="${{ env.RUST_TOOLCHAIN_VERSION }}" \
           --build-arg BUILDPLATFORM="${{ matrix.build_platform }}" \
           --build-arg ARCH="${{ matrix.target_arch }}" .

--- a/.github/workflows/kbs-docker-e2e.yml
+++ b/.github/workflows/kbs-docker-e2e.yml
@@ -26,6 +26,8 @@ jobs:
             target_arch: aarch64
             verifier: cca-verifier
     runs-on: ${{ matrix.instance }}
+    env:
+      RUST_TOOLCHAIN_VERSION: 1.85.1
     steps:
     - name: Checkout KBS
       uses: actions/checkout@v4
@@ -45,7 +47,11 @@ jobs:
         openssl pkey -in kbs/config/private.key -pubout -out kbs/config/public.pub
 
     - name: Build KBS Cluster
-      run: docker compose build --build-arg BUILDPLATFORM=${{ matrix.build_platform }} --build-arg ARCH=${{ matrix.target_arch }} --build-arg VERIFIER=${{ matrix.verifier }}
+      run: |
+        docker compose build --build-arg BUILDPLATFORM=${{ matrix.build_platform }} \
+          --build-arg ARCH=${{ matrix.target_arch }} \
+          --build-arg RUST_TOOLCHAIN_VERSION="${{ env.RUST_TOOLCHAIN_VERSION }}" \
+          --build-arg VERIFIER=${{ matrix.verifier }}
 
     - name: Start KBS cluster
       run: docker compose up -d

--- a/.github/workflows/push-kbs-client-to-ghcr.yml
+++ b/.github/workflows/push-kbs-client-to-ghcr.yml
@@ -18,6 +18,8 @@ jobs:
           - arch: aarch64
             instance: ubuntu-24.04-arm
     runs-on: ${{ matrix.instance }}
+    env:
+      RUST_TOOLCHAIN_VERSION: 1.85.1
     permissions:
       contents: read
       packages: write
@@ -44,6 +46,7 @@ jobs:
     - name: Build a statically linked kbs-client for ${{ matrix.arch }} linux
       run: |
         docker buildx build -f kbs/docker/kbs-client/Dockerfile \
+          --build-arg RUST_TOOLCHAIN_VERSION="${{ env.RUST_TOOLCHAIN_VERSION }}" \
           --build-arg ARCH="${{ matrix.arch }}" --output ./ .
 
     - name: Push to ghcr.io

--- a/attestation-service/docker/as-grpc/Dockerfile
+++ b/attestation-service/docker/as-grpc/Dockerfile
@@ -2,7 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=$BUILDPLATFORM docker.io/library/rust:latest AS builder
+ARG RUST_TOOLCHAIN_VERSION=1.85.1
+
+FROM --platform=$BUILDPLATFORM docker.io/library/rust:${RUST_TOOLCHAIN_VERSION} AS builder
 ARG BUILDPLATFORM=linux/amd64
 ARG ARCH=x86_64
 ARG VERIFIER=all-verifier

--- a/attestation-service/docker/as-restful/Dockerfile
+++ b/attestation-service/docker/as-restful/Dockerfile
@@ -2,7 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=$BUILDPLATFORM docker.io/library/rust:latest AS builder
+ARG RUST_TOOLCHAIN_VERSION=1.85.1
+
+FROM --platform=$BUILDPLATFORM docker.io/library/rust:${RUST_TOOLCHAIN_VERSION} AS builder
 ARG BUILDPLATFORM=linux/amd64
 ARG ARCH=x86_64
 ARG VERIFIER=all-verifier

--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM --platform=$BUILDPLATFORM docker.io/library/rust:slim AS builder
+ARG RUST_TOOLCHAIN_VERSION=1.85.1
+
+FROM --platform=$BUILDPLATFORM docker.io/library/rust:${RUST_TOOLCHAIN_VERSION}-slim AS builder
 ARG BUILDPLATFORM=linux/amd64
 ARG ARCH=x86_64
 ARG ALIYUN=false

--- a/kbs/docker/coco-as-grpc/Dockerfile
+++ b/kbs/docker/coco-as-grpc/Dockerfile
@@ -1,4 +1,6 @@
-FROM --platform=$BUILDPLATFORM docker.io/library/rust:latest AS builder
+ARG RUST_TOOLCHAIN_VERSION=1.85.1
+
+FROM --platform=$BUILDPLATFORM docker.io/library/rust:${RUST_TOOLCHAIN_VERSION} AS builder
 ARG BUILDPLATFORM=linux/amd64
 ARG ARCH=x86_64
 ARG ALIYUN=false
@@ -24,8 +26,8 @@ RUN cd kbs && make AS_FEATURE=coco-as-grpc ALIYUN=${ALIYUN} ARCH=${ARCH} NEBULA_
 
 # Download and install Nebula
 RUN if [ "${NEBULA_CA_PLUGIN}" = "true" ]; then \
-       curl -fSLO https://github.com/slackhq/nebula/releases/download/${NEBULA_VERSION}/nebula-$(echo ${BUILDPLATFORM} | sed 's/\//-/').tar.gz && \
-       tar -C /usr/local/bin -xzf nebula-$(echo "${BUILDPLATFORM}" | sed 's/\//-/').tar.gz; \
+    curl -fSLO https://github.com/slackhq/nebula/releases/download/${NEBULA_VERSION}/nebula-$(echo ${BUILDPLATFORM} | sed 's/\//-/').tar.gz && \
+    tar -C /usr/local/bin -xzf nebula-$(echo "${BUILDPLATFORM}" | sed 's/\//-/').tar.gz; \
     fi
 
 FROM ubuntu:22.04

--- a/kbs/docker/intel-trust-authority/Dockerfile
+++ b/kbs/docker/intel-trust-authority/Dockerfile
@@ -1,4 +1,6 @@
-FROM docker.io/library/rust:latest AS builder
+ARG RUST_TOOLCHAIN_VERSION=1.85.1
+
+FROM --platform=$BUILDPLATFORM docker.io/library/rust:${RUST_TOOLCHAIN_VERSION} AS builder
 ARG ALIYUN=false
 
 WORKDIR /usr/src/kbs

--- a/kbs/docker/kbs-client-image/Dockerfile
+++ b/kbs/docker/kbs-client-image/Dockerfile
@@ -1,4 +1,6 @@
-FROM docker.io/library/rust:1.85.1 AS builder
+ARG RUST_TOOLCHAIN_VERSION=1.85.1
+
+FROM docker.io/library/rust:${RUST_TOOLCHAIN_VERSION} AS builder
 
 WORKDIR /usr/src/kbs
 COPY . .

--- a/kbs/docker/kbs-client/Dockerfile
+++ b/kbs/docker/kbs-client/Dockerfile
@@ -1,4 +1,6 @@
-FROM docker.io/library/rust:1.85.1 AS builder
+ARG RUST_TOOLCHAIN_VERSION=1.85.1
+
+FROM docker.io/library/rust:${RUST_TOOLCHAIN_VERSION} AS builder
 ARG ARCH=x86_64
 
 WORKDIR /usr/src/kbs

--- a/rvps/docker/Dockerfile
+++ b/rvps/docker/Dockerfile
@@ -2,7 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=$BUILDPLATFORM docker.io/library/rust:latest AS builder
+ARG RUST_TOOLCHAIN_VERSION=1.85.1
+
+FROM --platform=$BUILDPLATFORM docker.io/library/rust:${RUST_TOOLCHAIN_VERSION} AS builder
 ARG BUILDPLATFORM=linux/amd64
 ARG ARCH=x86_64
 


### PR DESCRIPTION
This PR fixes the rust version of the dockerfile to 1.85.1. The original version used to be the latest one. Please see the specific commit message