### PR TITLE
rvps: drop HashValue abstraction

### DIFF
--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -10,12 +10,13 @@ pub mod token;
 
 use crate::token::AttestationTokenBroker;
 
+pub use kbs_types::{Attestation, Tee};
+pub use serde_json::Value;
+
 use anyhow::{anyhow, bail, Context, Result};
 use config::Config;
-pub use kbs_types::{Attestation, Tee};
 use log::{debug, info};
 use rvps::{RvpsApi, RvpsError};
-use serde_json::Value;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use std::collections::HashMap;
 use strum::{AsRefStr, Display, EnumString};
@@ -257,7 +258,7 @@ impl AttestationService {
     }
 
     /// Query Reference Values
-    pub async fn query_reference_values(&self) -> Result<HashMap<String, Vec<String>>> {
+    pub async fn query_reference_values(&self) -> Result<HashMap<String, Value>> {
         self.rvps
             .get_digests()
             .await

--- a/attestation-service/src/rvps/builtin.rs
+++ b/attestation-service/src/rvps/builtin.rs
@@ -22,7 +22,7 @@ impl RvpsApi for BuiltinRvps {
         Ok(())
     }
 
-    async fn get_digests(&self) -> Result<HashMap<String, Vec<String>>> {
+    async fn get_digests(&self) -> Result<HashMap<String, serde_json::Value>> {
         let hashes = self.rvps.get_digests().await?;
 
         Ok(hashes)

--- a/attestation-service/src/rvps/grpc.rs
+++ b/attestation-service/src/rvps/grpc.rs
@@ -63,7 +63,7 @@ impl RvpsApi for Agent {
         Ok(())
     }
 
-    async fn get_digests(&self) -> Result<HashMap<String, Vec<String>>> {
+    async fn get_digests(&self) -> Result<HashMap<String, serde_json::Value>> {
         let req = tonic::Request::new(ReferenceValueQueryRequest {});
         let res = self
             .client

--- a/attestation-service/src/rvps/mod.rs
+++ b/attestation-service/src/rvps/mod.rs
@@ -43,7 +43,7 @@ pub trait RvpsApi {
     async fn verify_and_extract(&mut self, message: &str) -> Result<()>;
 
     /// Get the reference values / golden values / expected digests in hex.
-    async fn get_digests(&self) -> Result<HashMap<String, Vec<String>>>;
+    async fn get_digests(&self) -> Result<HashMap<String, serde_json::Value>>;
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq)]

--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -205,7 +205,7 @@ impl AttestationTokenBroker for EarAttestationTokenBroker {
         &self,
         all_tee_claims: Vec<TeeClaims>,
         policy_ids: Vec<String>,
-        reference_data_map: HashMap<String, Vec<String>>,
+        reference_data_map: HashMap<String, serde_json::Value>,
     ) -> Result<String> {
         debug!("all_tee_claims: {:#?}", all_tee_claims);
 

--- a/attestation-service/src/token/mod.rs
+++ b/attestation-service/src/token/mod.rs
@@ -28,7 +28,7 @@ pub trait AttestationTokenBroker: Send + Sync {
         &self,
         tee_claims: Vec<TeeClaims>,
         policy_ids: Vec<String>,
-        reference_data_map: HashMap<String, Vec<String>>,
+        reference_data_map: HashMap<String, serde_json::Value>,
     ) -> Result<String>;
 
     async fn set_policy(&self, _policy_id: String, _policy: String) -> Result<()> {

--- a/attestation-service/src/token/simple.rs
+++ b/attestation-service/src/token/simple.rs
@@ -207,7 +207,7 @@ impl AttestationTokenBroker for SimpleAttestationTokenBroker {
         &self,
         all_tee_claims: Vec<TeeClaims>,
         policy_ids: Vec<String>,
-        reference_data_map: HashMap<String, Vec<String>>,
+        reference_data_map: HashMap<String, serde_json::Value>,
     ) -> Result<String> {
         // Take claims from all verifiers, flatten them and add them to one map.
         let mut flattened_claims: Map<String, Value> = Map::new();

--- a/kbs/src/attestation/backend.rs
+++ b/kbs/src/attestation/backend.rs
@@ -121,7 +121,7 @@ pub trait Attest: Send + Sync {
     }
 
     /// Get reference values from the RVPS, if the AS supports it
-    async fn query_reference_values(&self) -> anyhow::Result<HashMap<String, Vec<String>>> {
+    async fn query_reference_values(&self) -> anyhow::Result<HashMap<String, serde_json::Value>> {
         Err(anyhow!(
             "Attestation Service does not support reference value configuration."
         ))
@@ -387,7 +387,9 @@ impl AttestationService {
         Ok(())
     }
 
-    pub async fn query_reference_values(&self) -> anyhow::Result<HashMap<String, Vec<String>>> {
+    pub async fn query_reference_values(
+        &self,
+    ) -> anyhow::Result<HashMap<String, serde_json::Value>> {
         let values = self.inner.query_reference_values().await?;
 
         Ok(values)

--- a/kbs/src/attestation/coco/builtin.rs
+++ b/kbs/src/attestation/coco/builtin.rs
@@ -81,7 +81,7 @@ impl Attest for BuiltInCoCoAs {
             .await
     }
 
-    async fn query_reference_values(&self) -> anyhow::Result<HashMap<String, Vec<String>>> {
+    async fn query_reference_values(&self) -> anyhow::Result<HashMap<String, serde_json::Value>> {
         self.inner.read().await.query_reference_values().await
     }
 }

--- a/kbs/src/attestation/coco/grpc.rs
+++ b/kbs/src/attestation/coco/grpc.rs
@@ -182,7 +182,7 @@ impl Attest for GrpcClientPool {
         Ok(())
     }
 
-    async fn query_reference_values(&self) -> anyhow::Result<HashMap<String, Vec<String>>> {
+    async fn query_reference_values(&self) -> anyhow::Result<HashMap<String, serde_json::Value>> {
         let req = tonic::Request::new(ReferenceValueQueryRequest {});
 
         let mut client = self.pool.get().await?;

--- a/rvps/src/extractors/extractor_modules/in_toto/mod.rs
+++ b/rvps/src/extractors/extractor_modules/in_toto/mod.rs
@@ -279,9 +279,9 @@ pub mod test {
         let rv = ReferenceValue::new()
             .expect("create ReferenceValue failed")
             .set_name("foo.tar.gz")
-            .set_expired(Utc.with_ymd_and_hms(2030, 11, 18, 16, 6, 36).unwrap())
+            .set_expiration(Utc.with_ymd_and_hms(2030, 11, 18, 16, 6, 36).unwrap())
             .set_version("0.1.0")
-            .add_hash_value("sha256".into(), sha256_for_in_toto_test_artifact());
+            .set_value(serde_json::Value::String(sha256_for_in_toto_test_artifact()));
         let rv = vec![rv];
         let provenance = generate_in_toto_provenance();
         let res = e

--- a/rvps/src/extractors/extractor_modules/sample/mod.rs
+++ b/rvps/src/extractors/extractor_modules/sample/mod.rs
@@ -9,31 +9,20 @@ use std::collections::HashMap;
 
 use anyhow::*;
 use base64::Engine;
-use chrono::{Months, Timelike, Utc};
-use log::warn;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    reference_value::{HashValuePair, REFERENCE_VALUE_VERSION},
-    ReferenceValue,
-};
+use crate::ReferenceValue;
 
 use super::Extractor;
 
 #[derive(Serialize, Deserialize)]
 pub struct Provenance {
     #[serde(flatten)]
-    rvs: HashMap<String, Vec<String>>,
+    rvs: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Default)]
 pub struct SampleExtractor;
-
-/// Default reference value hash algorithm
-const DEFAULT_ALG: &str = "sha384";
-
-/// The reference value will be expired in the default time (months)
-const MONTHS_BEFORE_EXPIRATION: u32 = 12;
 
 impl Extractor for SampleExtractor {
     fn verify_and_extract(&self, provenance_base64: &str) -> Result<Vec<ReferenceValue>> {
@@ -43,31 +32,16 @@ impl Extractor for SampleExtractor {
         let payload: Provenance =
             serde_json::from_slice(&provenance).context("deseralize sample provenance")?;
 
-        let res = payload
+        let res: Vec<ReferenceValue> = payload
             .rvs
             .iter()
-            .filter_map(|(name, rvalues)| {
-                let rvs = rvalues
-                    .iter()
-                    .map(|rv| HashValuePair::new(DEFAULT_ALG.into(), rv.to_string()))
-                    .collect();
-
-                let time = Utc::now()
-                    .with_nanosecond(0)
-                    .and_then(|t| t.checked_add_months(Months::new(MONTHS_BEFORE_EXPIRATION)));
-
-                match time {
-                    Some(expiration) => Some(ReferenceValue {
-                        version: REFERENCE_VALUE_VERSION.into(),
-                        name: name.to_string(),
-                        expiration,
-                        hash_value: rvs,
-                    }),
-                    None => {
-                        warn!("Expired time calculated overflowed for reference value of {name}.");
-                        None
-                    }
-                }
+            .filter_map(|(name, values)| {
+                Some(
+                    ReferenceValue::new()
+                        .ok()?
+                        .set_name(name)
+                        .set_value(values.clone()),
+                )
             })
             .collect();
 

--- a/rvps/src/lib.rs
+++ b/rvps/src/lib.rs
@@ -19,6 +19,8 @@ pub use storage::ReferenceValueStorage;
 use extractors::Extractors;
 use pre_processor::{PreProcessor, PreProcessorAPI};
 
+pub use serde_json::Value;
+
 use anyhow::{bail, Context, Result};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
@@ -100,7 +102,7 @@ impl Rvps {
         Ok(())
     }
 
-    pub async fn get_digests(&self) -> Result<HashMap<String, Vec<String>>> {
+    pub async fn get_digests(&self) -> Result<HashMap<String, Value>> {
         let mut rv_map = HashMap::new();
         let reference_values = self.storage.get_values().await?;
 
@@ -110,13 +112,7 @@ impl Rvps {
                 continue;
             }
 
-            let hash_values = rv
-                .hash_values()
-                .iter()
-                .map(|pair| pair.value().to_owned())
-                .collect();
-
-            rv_map.insert(rv.name().to_string(), hash_values);
+            rv_map.insert(rv.name().to_string(), rv.value());
         }
         Ok(rv_map)
     }


### PR DESCRIPTION
When we first made the RVPS, we assumed that most reference values would be hashes and we created a struct to keep track of this. It turns out that lots of reference values have other formats (integers, strings, etc) and even for value that are hashes, the RVPS only reports the value itself to the AS. As such, let's drop the HashValue struct and instead use a serde_json::Value to store the reference value.

One cool advantage of this is that reference values can take almost any format. For instance, one reference value can actually be a map of a bunch of values. As long as the AS policy knows how to use the value, everything should work out.

I also added a little hint about how we will support a pull model by supporting local and remote values. Support for remote values will be added in future PRs.

See https://github.com/confidential-containers/trustee/issues/768