### PR TITLE
Add as-restful support for TDX-based Open-webui

### DIFF
--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -65,6 +65,7 @@ tokio.workspace = true
 tonic = { workspace = true, optional = true }
 uuid = { version = "1.1.2", features = ["v4"] }
 verifier = { path = "../deps/verifier", default-features = false }
+actix-cors = "0.7"
 
 [build-dependencies]
 shadow-rs.workspace = true

--- a/attestation-service/src/bin/restful-as.rs
+++ b/attestation-service/src/bin/restful-as.rs
@@ -1,6 +1,6 @@
 use std::{net::SocketAddr, path::Path, sync::Arc};
 
-use actix_web::{web, App, HttpServer};
+use actix_web::{web, App, HttpServer, http};
 use anyhow::Result;
 use attestation_service::{config::Config, config::ConfigError, AttestationService, ServiceError};
 use clap::{arg, command, Parser};
@@ -14,6 +14,7 @@ use thiserror::Error;
 use tokio::sync::RwLock;
 
 use crate::restful::{attestation, get_challenge, get_policies, set_policy};
+use actix_cors::Cors;
 
 mod restful;
 
@@ -96,7 +97,9 @@ async fn main() -> Result<(), RestfulError> {
 
     let attestation_service = web::Data::new(Arc::new(RwLock::new(attestation_service)));
     let server = HttpServer::new(move || {
+        let cors = Cors::permissive();
         App::new()
+            .wrap(cors)
             .service(web::resource(WebApi::Attestation.as_ref()).route(web::post().to(attestation)))
             .service(
                 web::resource(WebApi::Policy.as_ref())


### PR DESCRIPTION
[Background]:
We are working on a Confidential AI project(https://github.com/intel/confidential-computing-zoo/tree/main/cczoo/confidential_ai),which is built based-on TDX + Open-webui. We will leverage attestation service (restful api) in trustee to do the attestation related work. Open-webui(https://github.com/open-webui/open-webui) is an open-sourced project which provide a webui for AI services.

[Issue]
When Open-webui tries to access as via http, it will show below error message:
    Access to XMLHttpRequest at 'http://xxxx:8080/attestation' from origin 'http://xxxx:18080' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: It does not have HTTP ok status.

[Fix]
Add CORS policy to permit the access from open-webui request.