### PR TITLE
sample-polcy: fixup affirming policy

### DIFF
--- a/kbs/sample_policies/affirming.rego
+++ b/kbs/sample_policies/affirming.rego
@@ -4,5 +4,5 @@ import rego.v1
 default allow = false
 
 allow if {
-    input["submods"]["cpu"]["ear.status"] == "affirming"
+    input["submods"]["cpu0"]["ear.status"] == "affirming"
 }


### PR DESCRIPTION
With multi-device attestation, the EAR submods are accessed with the Tee class and the index of the device among all devices of the same class.

In other words "cpu" -> "cpu0"

We introduced the affirming policy while the multi-device PR was being developed and we missed updating the submod index.

Fixes: https://github.com/confidential-containers/trustee/issues/834