### PR TITLE
kbs-client: show file name when cannot read it

### DIFF
--- a/tools/kbs-client/src/main.rs
+++ b/tools/kbs-client/src/main.rs
@@ -153,14 +153,14 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let kbs_cert = match cli.cert_file {
-        Some(p) => vec![std::fs::read_to_string(p)?],
+        Some(ref p) => vec![std::fs::read_to_string(p).inspect_err(|_|eprintln!("Failed to read:{}",p.display()))?],
         None => vec![],
     };
 
     match cli.command {
         Commands::Attest { tee_key_file } => {
             let tee_key = match tee_key_file {
-                Some(f) => Some(std::fs::read_to_string(f)?),
+                Some(ref f) => Some(std::fs::read_to_string(f).inspect_err(|_|eprintln!("Failed to read:{}",f.display()))?),
                 None => None,
             };
             let token = kbs_client::attestation(&cli.url, tee_key, kbs_cert.clone()).await?;
@@ -172,11 +172,11 @@ async fn main() -> Result<()> {
             attestation_token,
         } => {
             let tee_key = match tee_key_file {
-                Some(f) => Some(std::fs::read_to_string(f)?),
+                Some(ref f) => Some(std::fs::read_to_string(f).inspect_err(|_|eprintln!("Failed to read:{}",f.display()))?),
                 None => None,
             };
             let token = match attestation_token {
-                Some(t) => Some(std::fs::read_to_string(t)?.trim().to_string()),
+                Some(ref t) => Some(std::fs::read_to_string(t).inspect_err(|_|eprintln!("Failed to read:{}",t.display()))?.trim().to_string()),
                 None => None,
             };
 
@@ -205,7 +205,8 @@ async fn main() -> Result<()> {
             }
         }
         Commands::Config(config) => {
-            let auth_key = std::fs::read_to_string(config.auth_private_key)?;
+            let auth_private_key_path = &config.auth_private_key;
+            let auth_key = std::fs::read_to_string(auth_private_key_path).inspect_err(|_|eprintln!("Failed to read:{}",auth_private_key_path.display()))?;
             match config.command {
                 ConfigCommands::SetAttestationPolicy {
                     r#type,


### PR DESCRIPTION
It's not clear to know which file is not found while passing more file path parameters like tee-key-file, cert-file, attestation-token.

With this patch:
$ kbs-client --url https://trusteeserver:8080 --cert-file trustee_keys/srv_host.crt get-resource --tee-key-file trustee_keys/tee_key.pem --attestation-token /tmp/attestation_token_x --path default/test/model_encrypt_key 
Failed to read:/tmp/attestation_token_x
Error: No such file or directory (os error 2)

Without this patch:
$ kbs-client --url https://trusteeserver:8080 --cert-file trustee_keys/srv_host.crt get-resource --tee-key-file trustee_keys/tee_key.pem --attestation-token /tmp/attestation_token_x --path default/test/model_encrypt_key 
Error: No such file or directory (os error 2)