### PR TITLE
Use complex reference value types

### DIFF
--- a/attestation-service/src/policy_engine/opa/mod.rs
+++ b/attestation-service/src/policy_engine/opa/mod.rs
@@ -208,7 +208,9 @@ mod tests {
         json!({
             "reference": {
                 "svn": [svn.to_string()],
-                "launch_digest": [launch_digest]
+                "launch_digest": [launch_digest],
+                "major_version": 1,
+                "minimum_minor_version": 1
             }
         })
         .to_string()
@@ -218,7 +220,11 @@ mod tests {
         json!({
             "sample": {
                 "svn": svn.to_string(),
-                "launch_digest": launch_digest
+                "launch_digest": launch_digest,
+                "platform_version": {
+                    "major": 1,
+                    "minor": 4
+                }
             }
         })
         .to_string()

--- a/attestation-service/src/token/ear_default_policy_cpu.rego
+++ b/attestation-service/src/token/ear_default_policy_cpu.rego
@@ -43,6 +43,8 @@ executables := 3 if {
 #  supported.
 hardware := 2 if {
 	input.sample.svn in data.reference.svn
+	input.sample.platform_version.major == data.reference.major_version
+	input.sample.platform_version.minor >= data.reference.minimum_minor_version
 }
 
 ##### SNP

--- a/attestation-service/src/token/ear_default_policy_cpu.rego
+++ b/attestation-service/src/token/ear_default_policy_cpu.rego
@@ -66,14 +66,14 @@ hardware := 2 if {
 #
 # For this, we compare all the configuration fields.
 configuration := 2 if {
-	input.snp.policy_debug_allowed == "0"
-	input.snp.policy_migrate_ma == "0"
-	input.snp.platform_smt_enabled in data.reference.snp_smt_enabled
-	input.snp.platform_tsme_enabled in data.reference.snp_tsme_enabled
-	input.snp.policy_abi_major in data.reference.snp_guest_abi_major
-	input.snp.policy_abi_minor in data.reference.snp_guest_abi_minor
-	input.snp.policy_single_socket in data.reference.snp_single_socket
-	input.snp.policy_smt_allowed in data.reference.snp_smt_allowed
+	input.snp.policy_debug_allowed == false
+	input.snp.policy_migrate_ma == false
+	input.snp.platform_smt_enabled == data.reference.snp_smt_enabled
+	input.snp.platform_tsme_enabled == data.reference.snp_tsme_enabled
+	input.snp.policy_abi_major == data.reference.snp_guest_abi_major
+	input.snp.policy_abi_minor == data.reference.snp_guest_abi_minor
+	input.snp.policy_single_socket == data.reference.snp_single_socket
+	input.snp.policy_smt_allowed == data.reference.snp_smt_allowed
 }
 
 # For the `configuration` trust claim 3 stands for
@@ -84,8 +84,8 @@ configuration := 2 if {
 # configuration value, but we make sure that some key
 # configurations (like debug_allowed) are set correctly.
 else := 3 if {
-	input.snp.policy_debug_allowed == "0"
-	input.snp.policy_migrate_ma == "0"
+	input.snp.policy_debug_allowed == false
+	input.snp.policy_migrate_ma == false
 }
 
 ##### TDX

--- a/deps/verifier/src/sample/mod.rs
+++ b/deps/verifier/src/sample/mod.rs
@@ -84,6 +84,12 @@ fn parse_tee_evidence(quote: &SampleTeeEvidence) -> Result<TeeEvidenceParsedClai
 
         // Generally TCB claims should originate from the attester.
         "launch_digest": "abcde",
+
+        // TCB Claims can be any type supported by serde_json
+        "platform_version": {
+            "major": 1,
+            "minor": 4,
+        },
     });
 
     Ok(claims_map as TeeEvidenceParsedClaim)

--- a/deps/verifier/src/snp/mod.rs
+++ b/deps/verifier/src/snp/mod.rs
@@ -381,27 +381,27 @@ pub(crate) fn verify_report_tcb(
 pub(crate) fn parse_tee_evidence(report: &AttestationReport) -> TeeEvidenceParsedClaim {
     let claims_map = json!({
         // policy fields
-        "policy_abi_major": format!("{}",report.policy.abi_major()),
-        "policy_abi_minor": format!("{}", report.policy.abi_minor()),
-        "policy_smt_allowed": format!("{}", report.policy.smt_allowed()),
-        "policy_migrate_ma": format!("{}", report.policy.migrate_ma_allowed()),
-        "policy_debug_allowed": format!("{}", report.policy.debug_allowed()),
-        "policy_single_socket": format!("{}", report.policy.single_socket_required()),
+        "policy_abi_major": report.policy.abi_major(),
+        "policy_abi_minor": report.policy.abi_minor(),
+        "policy_smt_allowed": report.policy.smt_allowed(),
+        "policy_migrate_ma": report.policy.migrate_ma_allowed(),
+        "policy_debug_allowed": report.policy.debug_allowed(),
+        "policy_single_socket": report.policy.single_socket_required(),
 
         // versioning info
-        "reported_tcb_bootloader": format!("{}", report.reported_tcb.bootloader),
-        "reported_tcb_tee": format!("{}", report.reported_tcb.tee),
-        "reported_tcb_snp": format!("{}", report.reported_tcb.snp),
-        "reported_tcb_microcode": format!("{}", report.reported_tcb.microcode),
+        "reported_tcb_bootloader": report.reported_tcb.bootloader,
+        "reported_tcb_tee": report.reported_tcb.tee,
+        "reported_tcb_snp": report.reported_tcb.snp,
+        "reported_tcb_microcode": report.reported_tcb.microcode,
 
         // platform info
-        "platform_tsme_enabled": format!("{}", report.plat_info.tsme_enabled()),
-        "platform_smt_enabled": format!("{}", report.plat_info.smt_enabled()),
+        "platform_tsme_enabled": report.plat_info.tsme_enabled(),
+        "platform_smt_enabled": report.plat_info.smt_enabled(),
 
         // measurements
-        "measurement": format!("{}", STANDARD.encode(report.measurement)),
-        "report_data": format!("{}", STANDARD.encode(report.report_data)),
-        "init_data": format!("{}", STANDARD.encode(report.host_data)),
+        "measurement": STANDARD.encode(report.measurement),
+        "report_data": STANDARD.encode(report.report_data),
+        "init_data": STANDARD.encode(report.host_data),
     });
 
     claims_map as TeeEvidenceParsedClaim

--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -272,8 +272,8 @@ impl TestHarness {
         tokio::time::sleep(duration).await;
     }
 
-    pub async fn set_reference_value(&self, key: String, value: String) -> Result<()> {
-        let provenance = json!({key: [value]}).to_string();
+    pub async fn set_reference_value(&self, key: String, value: serde_json::Value) -> Result<()> {
+        let provenance = json!({key: value}).to_string();
         let provenance = STANDARD.encode(provenance);
 
         let message = json!({

--- a/integration-tests/tests/get_resource.rs
+++ b/integration-tests/tests/get_resource.rs
@@ -5,6 +5,7 @@
 use anyhow::{bail, Result};
 use log::info;
 use rstest::rstest;
+use serde_json::json;
 use serial_test::serial;
 
 extern crate integration_tests;
@@ -124,10 +125,16 @@ async fn get_secret_not_contraindicated(harness: &TestHarness) -> Result<()> {
 
     // so this test will fail if run in an enclave.
     harness
-        .set_reference_value("svn".to_string(), "1".to_string())
+        .set_reference_value("svn".to_string(), json!(["1"]))
         .await?;
     harness
-        .set_reference_value("launch_digest".to_string(), "abcde".to_string())
+        .set_reference_value("launch_digest".to_string(), json!(["abcde"]))
+        .await?;
+    harness
+        .set_reference_value("major_version".to_string(), 1.into())
+        .await?;
+    harness
+        .set_reference_value("minimum_minor_version".to_string(), 1.into())
         .await?;
 
     let secret = harness.get_secret(SECRET_PATH.to_string()).await?;
@@ -184,15 +191,21 @@ async fn get_secret_not_contraindicated_device(harness: &TestHarness) -> Result<
 
     // cpu reference values
     harness
-        .set_reference_value("svn".to_string(), "1".to_string())
+        .set_reference_value("svn".to_string(), json!(["1"]))
         .await?;
     harness
-        .set_reference_value("launch_digest".to_string(), "abcde".to_string())
+        .set_reference_value("launch_digest".to_string(), json!(["abcde"]))
+        .await?;
+    harness
+        .set_reference_value("major_version".to_string(), 1.into())
+        .await?;
+    harness
+        .set_reference_value("minimum_minor_version".to_string(), 1.into())
         .await?;
 
     // device reference values
     harness
-        .set_reference_value("device_svn".to_string(), "2".to_string())
+        .set_reference_value("device_svn".to_string(), json!(["2"]))
         .await?;
 
     let secret = harness.get_secret(SECRET_PATH.to_string()).await?;
@@ -226,15 +239,21 @@ async fn get_secret_contraindicated_device(harness: &TestHarness) -> Result<()> 
 
     // cpu reference values
     harness
-        .set_reference_value("svn".to_string(), "1".to_string())
+        .set_reference_value("svn".to_string(), json!(["1"]))
         .await?;
     harness
-        .set_reference_value("launch_digest".to_string(), "abcde".to_string())
+        .set_reference_value("launch_digest".to_string(), json!(["abcde"]))
+        .await?;
+    harness
+        .set_reference_value("major_version".to_string(), 1.into())
+        .await?;
+    harness
+        .set_reference_value("minimum_minor_version".to_string(), 1.into())
         .await?;
 
     // device reference values (wrong ones)
     harness
-        .set_reference_value("device_svn".to_string(), "3".to_string())
+        .set_reference_value("device_svn".to_string(), json!(["3"]))
         .await?;
 
     let secret = harness.get_secret(SECRET_PATH.to_string()).await;

--- a/tools/kbs-client/src/lib.rs
+++ b/tools/kbs-client/src/lib.rs
@@ -240,7 +240,7 @@ pub async fn set_resource(
 pub async fn set_sample_rv(
     url: String,
     key: String,
-    value: String,
+    value: serde_json::Value,
     auth_key: String,
     kbs_root_certs_pem: Vec<String>,
 ) -> Result<()> {
@@ -252,7 +252,7 @@ pub async fn set_sample_rv(
 
     let reference_value_url = format!("{}/{KBS_URL_PREFIX}/reference-value", url);
 
-    let provenance = json!({key: [value]}).to_string();
+    let provenance = json!({key: value}).to_string();
     let provenance = STANDARD.encode(provenance);
 
     let message = json!({

--- a/tools/kbs-client/src/main.rs
+++ b/tools/kbs-client/src/main.rs
@@ -8,6 +8,7 @@ use anyhow::{bail, Result};
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use clap::{Args, Parser, Subcommand};
+use serde_json::json;
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -139,11 +140,28 @@ enum ConfigCommands {
     GetReferenceValues,
 
     /// Add a sample reference value to the RVPS.
+    /// The request will be proxied through the KBS
     /// The RVPS must enable the sample extractor
     /// or the reference value will not be registered.
-    /// The sample extractor should only be used in scenarios
-    /// where the RVPS endpoint is not exposed to untrusted users.
-    SetSampleReferenceValue { name: String, value: String },
+    SetSampleReferenceValue {
+        /// The name of the reference value.
+        name: String,
+        /// The reference value itself. This will be
+        /// treated as an integer by default.
+        value: String,
+        /// If set, the value will be parsed as an integer.
+        #[clap(long, action, group = "resource_type")]
+        as_integer: bool,
+        /// If set, the value will be parsed as a bool.
+        #[clap(long, action, group = "resource_type")]
+        as_bool: bool,
+        /// By default the reference value will be a single
+        /// member in a list.
+        /// If this argument is set, the reference value
+        /// will be a single value.
+        #[clap(long, action)]
+        as_single_value: bool,
+    },
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -278,11 +296,30 @@ async fn main() -> Result<()> {
                         STANDARD.encode(resource_bytes)
                     );
                 }
-                ConfigCommands::SetSampleReferenceValue { name, value } => {
+                ConfigCommands::SetSampleReferenceValue {
+                    name,
+                    value,
+                    as_integer,
+                    as_bool,
+                    as_single_value,
+                } => {
+                    let parsed_value: serde_json::Value = if as_integer {
+                        value.parse::<i32>()?.into()
+                    } else if as_bool {
+                        value.parse::<bool>()?.into()
+                    } else {
+                        serde_json::Value::String(value)
+                    };
+
+                    let rv = match as_single_value {
+                        true => parsed_value,
+                        false => json!([parsed_value]),
+                    };
+
                     kbs_client::set_sample_rv(
                         cli.url,
                         name,
-                        value,
+                        rv,
                         auth_key.clone(),
                         kbs_cert.clone(),
                     )


### PR DESCRIPTION
Now that we have support for complex reference value types, let's use them.

Specifically, let's update the `kbs-client` so that we can specify integer and boolean reference values, as well as RVs that are single values (rather than a list of values).

Then, let's add some integer tcb claims to the sample verifier to show how this works.

Then, update the SNP verifier to return boolean and integer claims where it makes sense. @bpradipt @DGonzalezVillal @ryansavino might want to check this part. This will change what users need to do to provision reference values.

We may want to do something similar for other platforms. 

See commit messages for more information.