### PR TITLE
kbs/config/kubernetes: update image tags for the release

### DIFF
--- a/kbs/config/kubernetes/base/kustomization.yaml
+++ b/kbs/config/kubernetes/base/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: coco-tenant
 images:
 - name: kbs-container-image
   newName: ghcr.io/confidential-containers/key-broker-service
-  newTag: built-in-as-v0.12.0
+  newTag: built-in-as-v0.14.0
 
 resources:
 - namespace.yaml

--- a/kbs/config/kubernetes/ita/kustomization.yaml
+++ b/kbs/config/kubernetes/ita/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 namespace: coco-tenant
 
 images:
-- name: ghcr.io/confidential-containers/key-broker-service:built-in-as-v0.12.0
-  newTag: ita-as-v0.12.0
+- name: ghcr.io/confidential-containers/key-broker-service
+  newTag: ita-as-v0.14.0
 
 resources:
 - ../nodeport/


### PR DESCRIPTION
The new images must be updated in main before the release so that they are pulled when installing the from the release branch.