### PR TITLE
verifier: Bump Max Supported Version of Attestation Report to 5

### DIFF
--- a/deps/verifier/src/snp/mod.rs
+++ b/deps/verifier/src/snp/mod.rs
@@ -55,7 +55,7 @@ const KDS_VCEK: &str = "/vcek/v1";
 
 /// Attestation report versions supported
 const REPORT_VERSION_MIN: u32 = 3;
-const REPORT_VERSION_MAX: u32 = 4;
+const REPORT_VERSION_MAX: u32 = 5;
 
 pub(crate) static CERT_CHAINS: LazyLock<HashMap<ProcessorGeneration, VendorCertificates>> =
     LazyLock::new(|| {


### PR DESCRIPTION
In line with the upcoming changes in VirTEE, I'm enabling support for Attestation Reports with Versions up to 5.