### PR TITLE
KBS: refactor in prometheus, active connections metric

### DIFF
--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -17,8 +17,8 @@ use crate::{
     plugins::PluginManager,
     policy_engine::PolicyEngine,
     prometheus::{
-        KBS_POLICY_APPROVALS, KBS_POLICY_ERRORS, KBS_POLICY_EVALS, KBS_POLICY_VIOLATIONS,
-        REQUEST_DURATION, REQUEST_SIZES, REQUEST_TOTAL,
+        ACTIVE_CONNECTIONS, KBS_POLICY_APPROVALS, KBS_POLICY_ERRORS, KBS_POLICY_EVALS,
+        KBS_POLICY_VIOLATIONS, REQUEST_DURATION, REQUEST_SIZES, REQUEST_TOTAL,
     },
     token::TokenVerifier,
     Error, Result,
@@ -344,6 +344,7 @@ async fn prometheus_metrics_middleware(
     // arguably are not very interesting either to a user of KBS metrics.
     let is_kbs_req = req.request().path().starts_with("/kbs");
     if is_kbs_req {
+        ACTIVE_CONNECTIONS.inc();
         REQUEST_TOTAL.inc();
 
         // Consider requests lacking a "content-length" header to be of zero
@@ -368,6 +369,8 @@ async fn prometheus_metrics_middleware(
         if let actix_web::body::BodySize::Sized(len) = res.response().body().size() {
             REQUEST_SIZES.observe(len as f64);
         }
+
+        ACTIVE_CONNECTIONS.dec();
     }
 
     Ok(res)

--- a/kbs/src/prometheus/mod.rs
+++ b/kbs/src/prometheus/mod.rs
@@ -6,154 +6,131 @@
 use lazy_static::lazy_static;
 use prometheus::{Counter, CounterVec, Histogram, HistogramOpts, Opts, Registry, TextEncoder};
 
+macro_rules! make_counter {
+    ($name:literal , $help:literal $(,)?) => {{
+        let opts = Opts::new($name, $help);
+        Counter::with_opts(opts).unwrap()
+    }};
+}
+
+macro_rules! make_counter_vec {
+    ($name:literal, $help:literal, $labels:expr $(,)?) => {{
+        let opts = Opts::new($name, $help);
+        CounterVec::new(opts, &$labels).unwrap()
+    }};
+}
+
+macro_rules! make_histogram {
+    ($name:literal, $help:literal, $buckets:expr $(,)?) => {{
+        let opts = HistogramOpts::new($name, $help).buckets($buckets);
+        Histogram::with_opts(opts).unwrap()
+    }};
+}
+
 lazy_static! {
     /// Resource Path Read Metrics
-    pub(crate) static ref RESOURCE_READS_TOTAL: CounterVec = {
-        let reads_opts = Opts::new("resource_reads_total", "KBS resource read count");
-        CounterVec::new(reads_opts, &["resource_path"]).unwrap()
+    pub(crate) static ref RESOURCE_READS_TOTAL: CounterVec = make_counter_vec!{
+        "resource_reads_total", "KBS resource read count", ["resource_path"]
     };
 
     /// Resource Path Write Metrics
-    pub(crate) static ref RESOURCE_WRITES_TOTAL: CounterVec = {
-        let writes_opts = Opts::new("resource_writes_total", "KBS resource write count");
-        CounterVec::new(writes_opts, &["resource_path"]).unwrap()
+    pub(crate) static ref RESOURCE_WRITES_TOTAL: CounterVec = make_counter_vec!{
+        "resource_writes_total", "KBS resource write count", ["resource_path"]
     };
 
     /// KBS Web Server Requests Metrics
-    pub(crate) static ref REQUEST_TOTAL: Counter = {
-        let requests_opts = Opts::new(
-            "http_requests_total",
-            "Total HTTP requests count",
-        );
-        Counter::with_opts(requests_opts).unwrap()
+    pub(crate) static ref REQUEST_TOTAL: Counter = make_counter!{
+        "http_requests_total",
+        "Total HTTP requests count",
     };
 
     /// KBS Web Server Requests Metrics
-    pub(crate) static ref REQUEST_DURATION: Histogram = {
-        let requests_duration_opts = HistogramOpts::new(
-                "http_request_duration_seconds",
-                "Distribution of request handling duration",
-        ).buckets(vec![0.0005, 0.001, 0.005, 0.01, 0.05, 0.5, 1.0]);
-        Histogram::with_opts(requests_duration_opts).unwrap()
+    pub(crate) static ref REQUEST_DURATION: Histogram = make_histogram!{
+        "http_request_duration_seconds",
+        "Distribution of request handling duration",
+        vec![0.0005, 0.001, 0.005, 0.01, 0.05, 0.5, 1.0],
     };
 
     /// KBS Web Server Request Sizes
-    pub(crate) static ref REQUEST_SIZES: Histogram = {
-        let request_sizes_opts = HistogramOpts::new(
-                "http_request_size_bytes",
-                "Distribution of request body sizes",
-            )
-            .buckets(prometheus::exponential_buckets(32.0, 4.0, 5).unwrap());
-        Histogram::with_opts(request_sizes_opts).unwrap()
+    pub(crate) static ref REQUEST_SIZES: Histogram = make_histogram!{
+        "http_request_size_bytes",
+        "Distribution of request body sizes",
+        prometheus::exponential_buckets(32.0, 4.0, 5).unwrap(),
     };
 
     /// KBS Web Server Response Sizes
-    pub(crate) static ref RESPONSE_SIZES: Histogram = {
-        let response_sizes_opts = HistogramOpts::new(
-                "http_response_size_bytes",
-                "Distribution of response body sizes",
-            )
-            .buckets(prometheus::exponential_buckets(32.0, 4.0, 5).unwrap());
-        Histogram::with_opts(response_sizes_opts).unwrap()
+    pub(crate) static ref RESPONSE_SIZES: Histogram = make_histogram!{
+        "http_response_size_bytes",
+        "Distribution of response body sizes",
+        prometheus::exponential_buckets(32.0, 4.0, 5).unwrap(),
     };
 
     /// KBS Policy Evaluations Total
-    pub(crate) static ref KBS_POLICY_EVALS: Counter = {
-        let opts = Opts::new(
-            "kbs_policy_evaluations_total",
-            "Total count of KBS policy evaluations",
-        );
-        Counter::with_opts(opts).unwrap()
+    pub(crate) static ref KBS_POLICY_EVALS: Counter = make_counter!{
+        "kbs_policy_evaluations_total",
+        "Total count of KBS policy evaluations",
     };
 
     /// KBS Policy Approvals Total
-    pub(crate) static ref KBS_POLICY_APPROVALS: Counter = {
-        let opts = Opts::new(
-            "kbs_policy_approvals_total",
-            "Total count of requests approved by KBS policy",
-        );
-        Counter::with_opts(opts).unwrap()
+    pub(crate) static ref KBS_POLICY_APPROVALS: Counter = make_counter!{
+        "kbs_policy_approvals_total",
+        "Total count of requests approved by KBS policy",
     };
 
     /// KBS Policy Violations Total
-    pub(crate) static ref KBS_POLICY_VIOLATIONS: Counter = {
-        let opts = Opts::new(
-            "kbs_policy_violations_total",
-            "Total count of requests denied by KBS policy",
-        );
-        Counter::with_opts(opts).unwrap()
+    pub(crate) static ref KBS_POLICY_VIOLATIONS: Counter = make_counter!{
+        "kbs_policy_violations_total",
+        "Total count of requests denied by KBS policy",
     };
 
     /// KBS Policy Errors Total
-    pub(crate) static ref KBS_POLICY_ERRORS: Counter = {
-        let opts = Opts::new(
-            "kbs_policy_errors_total",
-            "Total count of errors during KBS evaluation",
-        );
-        Counter::with_opts(opts).unwrap()
+    pub(crate) static ref KBS_POLICY_ERRORS: Counter = make_counter!{
+        "kbs_policy_errors_total",
+        "Total count of errors during KBS evaluation",
     };
 
     /// KBS Attestation Requests Total
-    pub(crate) static ref ATTESTATION_REQUESTS: Counter = {
-        let opts = Opts::new(
-            "attestation_requests_total",
-            "Total count of attestation requests",
-        );
-        Counter::with_opts(opts).unwrap()
+    pub(crate) static ref ATTESTATION_REQUESTS: Counter = make_counter!{
+        "attestation_requests_total",
+        "Total count of attestation requests",
     };
 
     /// KBS Attestation Successes Total
-    pub(crate) static ref ATTESTATION_SUCCESSES: CounterVec = {
-        let opts = Opts::new(
-            "attestation_successes_total",
-            "Total count of attestation successes",
-        );
-        CounterVec::new(opts, &["tee_type"]).unwrap()
+    pub(crate) static ref ATTESTATION_SUCCESSES: CounterVec = make_counter_vec!{
+        "attestation_successes_total",
+        "Total count of attestation successes",
+        ["tee_type"],
     };
 
     /// KBS Attestation Failures Total
-    pub(crate) static ref ATTESTATION_FAILURES: CounterVec = {
-        let opts = Opts::new(
-            "attestation_failures_total",
-            "Total count of attestation failures",
-        );
-        CounterVec::new(opts, &["tee_type"]).unwrap()
+    pub(crate) static ref ATTESTATION_FAILURES: CounterVec = make_counter_vec!{
+        "attestation_failures_total",
+        "Total count of attestation failures",
+        ["tee_type"],
     };
 
     /// KBS Attestation Errors Total
-    pub(crate) static ref ATTESTATION_ERRORS: Counter = {
-        let opts = Opts::new(
-            "attestation_errors_total",
-            "Total count of errors during attestation processing",
-        );
-        Counter::with_opts(opts).unwrap()
+    pub(crate) static ref ATTESTATION_ERRORS: Counter = make_counter!{
+        "attestation_errors_total",
+        "Total count of errors during attestation processing",
     };
 
     /// KBS Auth Requests Total
-    pub(crate) static ref AUTH_REQUESTS: Counter = {
-        let opts = Opts::new(
-            "auth_requests_total",
-            "Total count of auth requests",
-        );
-        Counter::with_opts(opts).unwrap()
+    pub(crate) static ref AUTH_REQUESTS: Counter = make_counter!{
+        "auth_requests_total",
+        "Total count of auth requests",
     };
 
     /// KBS Auth Successes Total
-    pub(crate) static ref AUTH_SUCCESSES: Counter = {
-        let opts = Opts::new(
-            "auth_successes_total",
-            "Total count of successfully authenticated requests",
-        );
-        Counter::with_opts(opts).unwrap()
+    pub(crate) static ref AUTH_SUCCESSES: Counter = make_counter!{
+        "auth_successes_total",
+        "Total count of successfully authenticated requests",
     };
 
     /// KBS Auth Errors Total
-    pub(crate) static ref AUTH_ERRORS: Counter = {
-        let opts = Opts::new(
-            "auth_errors_total",
-            "Total count of errors during auth processing",
-        );
-        Counter::with_opts(opts).unwrap()
+    pub(crate) static ref AUTH_ERRORS: Counter = make_counter!{
+        "auth_errors_total",
+        "Total count of errors during auth processing",
     };
 
     /// Prometheus instance to get the metrics

--- a/kbs/src/prometheus/mod.rs
+++ b/kbs/src/prometheus/mod.rs
@@ -4,7 +4,9 @@
 //
 
 use lazy_static::lazy_static;
-use prometheus::{Counter, CounterVec, Histogram, HistogramOpts, Opts, Registry, TextEncoder};
+use prometheus::{
+    Counter, CounterVec, Gauge, Histogram, HistogramOpts, Opts, Registry, TextEncoder,
+};
 
 macro_rules! make_counter {
     ($name:literal , $help:literal $(,)?) => {{
@@ -133,6 +135,15 @@ lazy_static! {
         "Total count of errors during auth processing",
     };
 
+    /// KBS Web Server Active Connections
+    pub(crate) static ref ACTIVE_CONNECTIONS: Gauge = {
+        let opts = Opts::new(
+            "http_active_connections",
+            "Count of HTTP connections being processed at the moment",
+        );
+        Gauge::with_opts(opts).unwrap()
+    };
+
     /// Prometheus instance to get the metrics
     static ref INSTANCE: Registry = {
         let registry = Registry::default();
@@ -157,6 +168,7 @@ lazy_static! {
         registry.register(Box::new(AUTH_REQUESTS.clone())).unwrap();
         registry.register(Box::new(AUTH_SUCCESSES.clone())).unwrap();
         registry.register(Box::new(AUTH_ERRORS.clone())).unwrap();
+        registry.register(Box::new(ACTIVE_CONNECTIONS.clone())).unwrap();
 
         registry
     };


### PR DESCRIPTION
More gradual progress on KBS's Prometheus endpoint:
- capture Prometheus metric objects' repeated/boilerplate initialisation code in macros [as suggested earlier](https://github.com/confidential-containers/trustee/pull/816#discussion_r2139146420)
-  add the active connections metric [as proposed](https://github.com/confidential-containers/trustee/issues/543#issuecomment-2916097383).