### PR TITLE
ci: fix permissions for nested workflows

### DIFF
--- a/.github/workflows/as-docker-build.yml
+++ b/.github/workflows/as-docker-build.yml
@@ -13,4 +13,7 @@ permissions: {}
 jobs:
   check_as_image_build:
     uses: ./.github/workflows/build-as-image.yml
+    permissions:
+      contents: read
+      packages: write
     secrets: inherit

--- a/.github/workflows/kbs-docker-build.yml
+++ b/.github/workflows/kbs-docker-build.yml
@@ -7,5 +7,8 @@ permissions: {}
 
 jobs:
   check_kbs_image_build:
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/build-kbs-image.yml
     secrets: inherit

--- a/.github/workflows/kbs-e2e-azure-vtpm.yml
+++ b/.github/workflows/kbs-e2e-azure-vtpm.yml
@@ -29,6 +29,8 @@ jobs:
     needs:
     - checkout
     uses: ./.github/workflows/kbs-e2e.yml
+    permissions:
+      packages: write
     with:
       runs-on-test: '["self-hosted","azure-cvm-tdx"]'
       tee: aztdxvtpm
@@ -38,6 +40,8 @@ jobs:
     needs:
     - checkout
     uses: ./.github/workflows/kbs-e2e.yml
+    permissions:
+      packages: write
     with:
       runs-on-test: '["self-hosted","azure-cvm"]'
       tee: azsnpvtpm

--- a/.github/workflows/push-as-image-to-ghcr.yml
+++ b/.github/workflows/push-as-image-to-ghcr.yml
@@ -11,6 +11,7 @@ jobs:
   build_and_push_as_image:
     permissions:
       packages: write
+      contents: read
     uses: ./.github/workflows/build-as-image.yml
     with:
       build_option: --push

--- a/.github/workflows/push-kbs-client-image-to-ghcr.yml
+++ b/.github/workflows/push-kbs-client-image-to-ghcr.yml
@@ -11,6 +11,7 @@ jobs:
   build_and_push_kbs_client_image:
     permissions:
       packages: write
+      contents: read
     uses: ./.github/workflows/build-kbs-client-image.yml
     with:
       build_option: --push

--- a/.github/workflows/push-kbs-image-to-ghcr.yml
+++ b/.github/workflows/push-kbs-image-to-ghcr.yml
@@ -11,6 +11,7 @@ jobs:
   build_and_push_kbs_image:
     permissions:
       packages: write
+      contents: read
     uses: ./.github/workflows/build-kbs-image.yml
     with:
       build_option: --push


### PR DESCRIPTION
Some necessary permissions weren't passed down to nested workflows when they are being invoked.