### PR TITLE
ci: harden gh action workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281 # v1.65.2
       with:
         fail_level: any 

--- a/.github/workflows/as-docker-build.yml
+++ b/.github/workflows/as-docker-build.yml
@@ -16,4 +16,5 @@ jobs:
     permissions:
       contents: read
       packages: write
-    secrets: inherit
+    secrets:
+      GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/as-e2e.yml
+++ b/.github/workflows/as-e2e.yml
@@ -35,6 +35,8 @@ jobs:
       RESTFUL_TEE_ENUM: ${{ matrix.restful_tee_enum }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1.13.0

--- a/.github/workflows/as-rust.yml
+++ b/.github/workflows/as-rust.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install OPA command line tool
         uses: open-policy-agent/setup-opa@34a30e8a924d1b03ce2cf7abe97250bbb1f332b5 # v2.2.0 # v2

--- a/.github/workflows/build-as-image.yml
+++ b/.github/workflows/build-as-image.yml
@@ -7,13 +7,18 @@ on:
         description: 'Build option for the image'
         type: string
         required: false
+    secrets:
+      GHCR_TOKEN:
+        description: 'GitHub token for GHCR'
+        required: true
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build_as_image:
+    permissions:
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -57,6 +62,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
@@ -66,15 +73,18 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build ${{ matrix.name }} Container Image
       run: |
         commit_sha=${{ github.sha }}
         docker buildx build --platform "${{ matrix.target_platform }}" --provenance false \
-          -f "${{ matrix.docker_file }}" ${{ inputs.build_option }} \
+          -f "${{ matrix.docker_file }}" \
+          ${INPUTS_BUILD_OPTION:+"$INPUTS_BUILD_OPTION"} \
           --build-arg BUILDPLATFORM="${{ matrix.build_platform }}" \
           --build-arg ARCH="${{ matrix.target_arch }}" \
           --build-arg VERIFIER="${{ matrix.verifier }}" \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${{ matrix.target_arch }}" \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${{ matrix.target_arch }}" .
+      env:
+        INPUTS_BUILD_OPTION: ${{ inputs.build_option }}

--- a/.github/workflows/build-kbs-client-image.yml
+++ b/.github/workflows/build-kbs-client-image.yml
@@ -7,13 +7,18 @@ on:
         description: 'Build option for the image'
         type: string
         required: false
+    secrets:
+      GHCR_TOKEN:
+        description: 'GitHub token for GHCR'
+        required: true
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build_kbs_client_image:
+    permissions:
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +34,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
@@ -38,12 +45,15 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build Container Image KBS-Client (${{ matrix.arch }})
       run: |
         commit_sha=${{ github.sha }}
-        docker buildx build --provenance false ${{ inputs.build_option }} \
+        docker buildx build --provenance false \
+          ${INPUTS_BUILD_OPTION:+"$INPUTS_BUILD_OPTION"} \
           -f kbs/docker/kbs-client-image/Dockerfile \
           -t "ghcr.io/confidential-containers/staged-images/kbs-client-image:${commit_sha}-${{ matrix.arch }}" \
           -t "ghcr.io/confidential-containers/staged-images/kbs-client-image:latest-${{ matrix.arch }}" .
+      env:
+        INPUTS_BUILD_OPTION: ${{ inputs.build_option }}

--- a/.github/workflows/build-kbs-image.yml
+++ b/.github/workflows/build-kbs-image.yml
@@ -7,13 +7,18 @@ on:
         description: 'Build option for the image'
         type: string
         required: false
+    secrets:
+      GHCR_TOKEN:
+        description: 'GitHub token for GHCR'
+        required: true
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build_kbs_image:
+    permissions:
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -68,6 +73,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
@@ -77,14 +84,17 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GHCR_TOKEN }}
 
     - name: Build Container Image KBS (${{ matrix.name }})
       run: |
         commit_sha=${{ github.sha }}
         docker buildx build --platform "${{ matrix.target_platform }}" --provenance false \
-          -f "${{ matrix.docker_file }}" ${{ inputs.build_option }} \
+          -f "${{ matrix.docker_file }}" \
+          ${INPUTS_BUILD_OPTION:+"$INPUTS_BUILD_OPTION"} \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha}-${{ matrix.target_arch }}" \
           -t "ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest-${{ matrix.target_arch }}" \
           --build-arg BUILDPLATFORM="${{ matrix.build_platform }}" \
           --build-arg ARCH="${{ matrix.target_arch }}" .
+      env:
+        INPUTS_BUILD_OPTION: ${{ inputs.build_option }}

--- a/.github/workflows/kbs-docker-build.yml
+++ b/.github/workflows/kbs-docker-build.yml
@@ -11,4 +11,5 @@ jobs:
       contents: read
       packages: write
     uses: ./.github/workflows/build-kbs-image.yml
-    secrets: inherit
+    secrets:
+      GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/kbs-docker-e2e.yml
+++ b/.github/workflows/kbs-docker-e2e.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
     - name: Checkout KBS
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - name: Install Rust (for client)
       uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1.13.0

--- a/.github/workflows/kbs-e2e-azure-vtpm.yml
+++ b/.github/workflows/kbs-e2e-azure-vtpm.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - name: Archive source
       run: git archive -o kbs.tar.gz HEAD

--- a/.github/workflows/kbs-e2e-sample.yml
+++ b/.github/workflows/kbs-e2e-sample.yml
@@ -6,13 +6,16 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   checkout:
+    permissions:
+      packages: write
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - name: Archive source
       run: git archive -o kbs.tar.gz HEAD
@@ -24,6 +27,9 @@ jobs:
   e2e-test-amd64:
     needs: checkout
     uses: ./.github/workflows/kbs-e2e.yml
+    permissions:
+      contents: read
+      packages: write
     with:
       tee: sample
       tarball: kbs.tar.gz
@@ -37,3 +43,6 @@ jobs:
       runs-on-test: '["ubuntu-22.04-arm"]'
       tarball: kbs.tar.gz
       kbs-client-features: "sample_only,cca-attester"
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/kbs-e2e.yml
+++ b/.github/workflows/kbs-e2e.yml
@@ -35,7 +35,6 @@ jobs:
   build-binaries:
     runs-on: ${{ fromJSON(inputs.runs-on-build) }}
     permissions:
-      contents: read
       packages: write
     env:
       OS_VERSION: ubuntu-22.04
@@ -44,7 +43,9 @@ jobs:
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
 
     - name: Extract tarball
-      run: tar xzf ./artifact/${{ inputs.tarball }}
+      run: tar xzf "./artifact/${INPUTS_TARBALL}"
+      env:
+        INPUTS_TARBALL: ${{ inputs.tarball }}
 
     - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1.13.0
@@ -67,7 +68,9 @@ jobs:
       working-directory: kbs/test
       run: |
         make install-dev-dependencies
-        make bins TEST_FEATURES=${{ inputs.kbs-client-features }}
+        make bins "TEST_FEATURES=${INPUTS_KBS_CLIENT_FEATURES}"
+      env:
+        INPUTS_KBS_CLIENT_FEATURES: ${{ inputs.kbs-client-features }}
 
     - name: Archive test folder
       run: tar czf test.tar.gz kbs/test

--- a/.github/workflows/kbs-e2e.yml
+++ b/.github/workflows/kbs-e2e.yml
@@ -112,6 +112,7 @@ jobs:
       run: |
         sudo chgrp tss /dev/tpm0
         sudo usermod -a -G tss "$USER"
+        sg tss -c tpm2_pcrread
 
     - name: Run e2e test
       working-directory: kbs/test

--- a/.github/workflows/kbs-rust.yml
+++ b/.github/workflows/kbs-rust.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
     - name: Code checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1.13.0

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Restore lychee cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/workflows/push-as-image-to-ghcr.yml
+++ b/.github/workflows/push-as-image-to-ghcr.yml
@@ -15,7 +15,8 @@ jobs:
     uses: ./.github/workflows/build-as-image.yml
     with:
       build_option: --push
-    secrets: inherit
+    secrets:
+      GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish_multi_arch_image:
     needs: build_and_push_as_image

--- a/.github/workflows/push-kbs-client-image-to-ghcr.yml
+++ b/.github/workflows/push-kbs-client-image-to-ghcr.yml
@@ -15,7 +15,8 @@ jobs:
     uses: ./.github/workflows/build-kbs-client-image.yml
     with:
       build_option: --push
-    secrets: inherit
+    secrets:
+      GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish_multi_arch_image:
     needs: build_and_push_kbs_client_image

--- a/.github/workflows/push-kbs-client-to-ghcr.yml
+++ b/.github/workflows/push-kbs-client-to-ghcr.yml
@@ -32,6 +32,8 @@ jobs:
 
     - name: Check out code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1

--- a/.github/workflows/push-kbs-image-to-ghcr.yml
+++ b/.github/workflows/push-kbs-image-to-ghcr.yml
@@ -15,7 +15,8 @@ jobs:
     uses: ./.github/workflows/build-kbs-image.yml
     with:
       build_option: --push
-    secrets: inherit
+    secrets:
+      GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish_multi_arch_image:
     needs: build_and_push_kbs_image


### PR DESCRIPTION
The fixes have been suggested by the zizmor static analysis tool:

https://docs.zizmor.sh/

it should be mostly uncontroversial, the only thing is maybe the transformation from input text-templating to a intermediate environment variable that actionlint/shellscripts want to quote.

```
build_option: --push --bla
```

will not work, but "option" is singular luckily. and in the end the rule is supposed to prohibit arbitrary unescaped input.

drive-by fix: the az-*-vtpm e2e test run on ephemeral runners. we need to explicitly assert group membership for unprivileged CI runs.