### PR TITLE
e2e-tests: run tests unprivileged

### DIFF
--- a/.github/workflows/kbs-e2e.yml
+++ b/.github/workflows/kbs-e2e.yml
@@ -91,9 +91,10 @@ jobs:
       run: tar xzf ./test.tar.gz
 
     - name: Set up SGX/TDX certificates cache
+      if: inputs.tee == 'aztdxvtpm'
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
-        path: /root/.dcap-qcnl
+        path: .dcap-qcnl
         key: ${{ runner.os }}-dcap-qcnl
 
     - name: Install dependencies
@@ -101,11 +102,17 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y make --no-install-recommends
-        sudo make install-dependencies
-    
+        make install-dependencies
+
+    - name: Set TPM permissions
+      if: inputs.tee == 'aztdxvtpm' || inputs.tee == 'azsnpvtpm'
+      run: |
+        sudo chgrp tss /dev/tpm0
+        sudo usermod -a -G tss "$USER"
+
     - name: Run e2e test
       working-directory: kbs/test
       env:
         TEE: ${{ inputs.tee }}
         RUST_LOG: warn
-      run: sudo -E make e2e-test
+      run: make e2e-test

--- a/kbs/test/Makefile
+++ b/kbs/test/Makefile
@@ -73,7 +73,7 @@ install-dev-dependencies: install-dependencies
 .PHONY: install-dependencies
 install-dependencies:
 	if [ "${ARCH}" = "x86_64" ]; then \
-	curl -L "$(SGX_REPO_URL)/intel-sgx-deb.key" | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
+	curl -L "$(SGX_REPO_URL)/intel-sgx-deb.key" | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg --yes && \
 	echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] $(SGX_REPO_URL) $(CODENAME) main" \
 		| sudo tee /etc/apt/sources.list.d/intel-sgx.list && \
 	sudo apt-get update && \

--- a/kbs/test/config/kbs.toml
+++ b/kbs/test/config/kbs.toml
@@ -15,6 +15,7 @@ policy_engine = "opa"
 [attestation_service.attestation_token_broker]
 type = "Ear"
 duration_min = 5
+policy_dir = "./work/attestation-service/token/ear/policies"
 
 [attestation_service.attestation_token_broker.signer]
 key_path = "./work/token.key"
@@ -22,6 +23,10 @@ cert_path = "./work/token-cert-chain.pem"
 
 [attestation_service.rvps_config]
 type = "BuiltIn"
+
+[attestation_service.rvps_config.storage]
+type = "LocalFs"
+file_path = "./work/attestation-service/reference_values"
 
 [policy_engine]
 policy_path = "./work/kbs-policy.rego"


### PR DESCRIPTION
The e2e tests can run in an unprivileged mode, causing less pollution on self-hosted runners.