### PR TITLE
e2e-test: propagate tss group membership

### DIFF
--- a/.github/workflows/kbs-e2e.yml
+++ b/.github/workflows/kbs-e2e.yml
@@ -109,6 +109,7 @@ jobs:
       run: |
         sudo chgrp tss /dev/tpm0
         sudo usermod -a -G tss "$USER"
+        sg tss -c tpm2_pcrread
 
     - name: Run e2e test
       working-directory: kbs/test


### PR DESCRIPTION
(this is required to make az-*-vtpm tests pass on ephemeral private runners)

The group membership of a github action user will not be updated in succeeding github action steps, we need to explicitly assert it by running a command w/ the tss group membership.