### PR TITLE
e2e-test: install tpm2-tools when required

### DIFF
--- a/.github/workflows/kbs-e2e.yml
+++ b/.github/workflows/kbs-e2e.yml
@@ -110,6 +110,8 @@ jobs:
     - name: Set TPM permissions
       if: inputs.tee == 'aztdxvtpm' || inputs.tee == 'azsnpvtpm'
       run: |
+        sudo apt-get update
+        sudo apt-get install -y tpm2-tools --no-install-recommends
         sudo chgrp tss /dev/tpm0
         sudo usermod -a -G tss "$USER"
         sg tss -c tpm2_pcrread


### PR DESCRIPTION
They are not really required at test runtime, but we want to use it to probe the user is able to access the tpm device.