### PR TITLE
ear: Dereference value before as_i8

### DIFF
--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -252,7 +252,7 @@ impl AttestationTokenBroker for EarAttestationTokenBroker {
                 .await?;
 
             for (k, v) in &policy_results.rules_result {
-                let claim_value = v.as_i8().context("Policy claim value not i8")?;
+                let claim_value = (*v).as_i8().context("Policy claim value not i8")?;
                 debug!("Policy claim: {}: {}", k, claim_value);
 
                 appraisal


### PR DESCRIPTION
When running `as_i8` on a reference to a single-digit `regorus::Value::Number`, it works fine. For a multiple-digit number, you'll get

```
Attestation evaluation failed: Policy claim value not i8
```

Dereference instead.

This probably went unnoticed because in AR4SI, "good" values are single digit and "bad" values are double digit, and attestation still failed iff we wanted it. **Very technically**, this fix could inadvertently allow access to resources that had an overly permissive resource policy, but were still effectively guarded by double digit attestation policy values. I'll leave it to the maintainers whether this requires a disclaimer on the next release.