### PR TITLE
attestation-service: drop apt-key usage in Dockerfiles and tests

### DIFF
--- a/attestation-service/docker/as-grpc/Dockerfile
+++ b/attestation-service/docker/as-grpc/Dockerfile
@@ -13,8 +13,8 @@ COPY . .
 RUN apt-get update && apt-get install -y protobuf-compiler clang libtss2-dev
 
 # Install TDX Build Dependencies
-RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
-    echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
+RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     apt-get update && apt-get install -y libsgx-dcap-quote-verify-dev; fi
 
 # Build and Install gRPC attestation-service
@@ -45,8 +45,8 @@ RUN apt-get update && apt-get install openssl -y && \
 # Install TDX Runtime Dependencies
 RUN if [ "${ARCH}" = "x86_64" ] && ( [ "${VERIFIER}" = "all-verifier" ] || [ "${VERIFIER}" = "tdx-verifier" ] ); \
     then apt-get update && apt-get install curl gnupg -y && \
-    curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
-    echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
+    curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     apt-get update && \
     apt-get install -y libsgx-dcap-default-qpl libsgx-dcap-quote-verify && \
     apt-get remove curl gnupg -y && \

--- a/attestation-service/docker/as-restful/Dockerfile
+++ b/attestation-service/docker/as-restful/Dockerfile
@@ -13,8 +13,8 @@ COPY . .
 RUN apt-get update && apt-get install -y protobuf-compiler clang libtss2-dev
 
 # Install TDX Build Dependencies
-RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
-    echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
+RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     apt-get update && apt-get install -y libsgx-dcap-quote-verify-dev; fi
 
 # Build and Install RESTful attestation-service
@@ -44,8 +44,8 @@ RUN apt-get update && apt-get install openssl -y && \
 # Install TDX Runtime Dependencies
 RUN if [ "${ARCH}" = "x86_64" ] && ( [ "${VERIFIER}" = "all-verifier" ] || [ "${VERIFIER}" = "tdx-verifier" ] ); \
     then apt-get update && apt-get install curl gnupg -y && \
-    curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
-    echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
+    curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     apt-get update && \
     apt-get install -y libsgx-dcap-default-qpl libsgx-dcap-quote-verify && \
     apt-get remove curl gnupg -y && \

--- a/attestation-service/tests/e2e/Makefile
+++ b/attestation-service/tests/e2e/Makefile
@@ -20,8 +20,8 @@ REQUEST := $(MAKEFILE_DIR)/request.json
 
 .PHONY: install-dependencies
 install-dependencies:
-	curl -L "$(SGX_REPO_URL)/intel-sgx-deb.key" | sudo apt-key add - && \
-	echo "deb [arch=amd64] $(SGX_REPO_URL) jammy main" \
+	curl -L "$(SGX_REPO_URL)/intel-sgx-deb.key" | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
+	echo "deb [arch=amd64  signed-by=/usr/share/keyrings/intel-sgx.gpg] $(SGX_REPO_URL) jammy main" \
 		| sudo tee /etc/apt/sources.list.d/intel-sgx.list && \
 	sudo apt-get update && \
 	sudo apt-get install -y \

--- a/deps/verifier/src/tdx/quote.rs
+++ b/deps/verifier/src/tdx/quote.rs
@@ -411,8 +411,8 @@ mod tests {
     /// This unit test requires two packages, s.t. `libsgx-dcap-quote-verify-dev` and `libsgx-dcap-default-qpl`
     /// On ubuntu 22.04, you need to run the following scripts to install.
     /// ```shell
-    /// curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
-    /// echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
+    /// curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
+    /// echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     /// apt-get update && \
     /// apt-get install -y libsgx-dcap-default-qpl libsgx-dcap-quote-verify
     /// ```

--- a/kbs/quickstart.md
+++ b/kbs/quickstart.md
@@ -15,8 +15,8 @@ source "$HOME/.cargo/env"
 
 Install dependencies:
 ```shell
-curl -L "https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key" | sudo apt-key add -
-echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main" \
+curl -L "https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key" | sudo gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main" \
 	| sudo tee /etc/apt/sources.list.d/intel-sgx.list
 sudo apt-get update
 sudo apt-get install -y \


### PR DESCRIPTION
apt-key has been deprecated for some time. With Debian 13 / trixie it's gone. rust:latest is a moving target and jumped from bookworm to trixie and builds started failing due to missing apt-key.

Remove all occurences of apt-key to gpg based tooling.