### PR TITLE
Dockerfile: Bump base Ubuntu to 24.04

### DIFF
--- a/attestation-service/docker/as-grpc/Dockerfile
+++ b/attestation-service/docker/as-grpc/Dockerfile
@@ -2,7 +2,10 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=${BUILDPLATFORM:-linux/amd64} docker.io/library/rust:latest AS builder
+# rust:1.89.0
+FROM --platform=${BUILDPLATFORM:-linux/amd64} \
+    docker.io/library/rust@sha256:6e6d04bd50cd4c433a805c58c13f186a508c5b5417b9b61cae40ec28e0593c51 \
+    AS builder
 ARG ARCH=x86_64
 ARG VERIFIER=all-verifier
 
@@ -29,8 +32,8 @@ RUN if [ "$(uname -m)" != "${ARCH}" ]; then \
     rustup target add ${RUSTC_TARGET}; fi; \
     cargo install --path attestation-service --bin grpc-as --features grpc-bin,${VERIFIER} --locked ${TARGET_FLAG}
 
-
-FROM ubuntu:22.04
+# ubuntu:24.04
+FROM ubuntu@sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf20f9
 ARG ARCH=x86_64
 ARG VERIFIER=all-verifier
 

--- a/attestation-service/docker/as-restful/Dockerfile
+++ b/attestation-service/docker/as-restful/Dockerfile
@@ -2,7 +2,10 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=${BUILDPLATFORM:-linux/amd64} docker.io/library/rust:latest AS builder
+# rust:1.89.0
+FROM --platform=${BUILDPLATFORM:-linux/amd64} \
+    docker.io/library/rust@sha256:6e6d04bd50cd4c433a805c58c13f186a508c5b5417b9b61cae40ec28e0593c51 \
+    AS builder
 ARG ARCH=x86_64
 ARG VERIFIER=all-verifier
 
@@ -29,7 +32,9 @@ RUN if [ "$(uname -m)" != "${ARCH}" ]; then \
     rustup target add ${RUSTC_TARGET}; fi; \
     cargo install --path attestation-service --bin restful-as --features restful-bin,${VERIFIER} --locked ${TARGET_FLAG}
 
-FROM ubuntu:22.04
+# ubuntu:24.04
+FROM ubuntu@sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf20f9
+
 ARG ARCH=x86_64
 ARG VERIFIER=all-verifier
 

--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -1,4 +1,7 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} docker.io/library/rust:slim AS builder
+# rust:1.89.0-slim
+FROM --platform=${BUILDPLATFORM:-linux/amd64} \
+    docker.io/library/rust@sha256:6c828d9865870a3bc8c02919d73803df22cac59b583d8f2cb30a296abe64748f \
+    AS builder
 ARG ARCH=x86_64
 ARG ALIYUN=false
 
@@ -41,7 +44,8 @@ COPY . .
 RUN cd kbs && make AS_FEATURE=coco-as-builtin ALIYUN=${ALIYUN} ARCH=${ARCH} && \
     make ARCH=${ARCH} install-kbs
 
-FROM ubuntu:22.04
+# ubuntu:24.04
+FROM ubuntu@sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf20f9
 ARG ARCH=x86_64
 
 WORKDIR /tmp
@@ -49,6 +53,7 @@ WORKDIR /tmp
 RUN apt-get update && \
     apt-get install -y \
     curl \
+    gnupg \
     gnupg-agent && \
     if [ "${ARCH}" = "x86_64" ]; then curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
     gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \

--- a/kbs/docker/coco-as-grpc/Dockerfile
+++ b/kbs/docker/coco-as-grpc/Dockerfile
@@ -1,4 +1,7 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} docker.io/library/rust:latest AS builder
+# rust:1.89.0
+FROM --platform=${BUILDPLATFORM:-linux/amd64} \
+    docker.io/library/rust@sha256:6e6d04bd50cd4c433a805c58c13f186a508c5b5417b9b61cae40ec28e0593c51 \
+    AS builder
 ARG BUILDPLATFORM=linux/amd64
 ARG ARCH=x86_64
 ARG ALIYUN=false
@@ -30,7 +33,8 @@ RUN if [ "${NEBULA_CA_PLUGIN}" = "true" ]; then \
        touch /usr/local/bin/nebula-cert-dummy; \
     fi
 
-FROM ubuntu:22.04
+# ubuntu:24.04
+FROM ubuntu@sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf20f9
 
 LABEL org.opencontainers.image.source="https://github.com/confidential-containers/trustee/kbs"
 

--- a/kbs/docker/intel-trust-authority/Dockerfile
+++ b/kbs/docker/intel-trust-authority/Dockerfile
@@ -1,4 +1,6 @@
-FROM docker.io/library/rust:latest AS builder
+# rust:1.89.0
+FROM docker.io/library/rust@sha256:6e6d04bd50cd4c433a805c58c13f186a508c5b5417b9b61cae40ec28e0593c51 \
+    AS builder
 ARG ALIYUN=false
 
 WORKDIR /usr/src/kbs
@@ -10,7 +12,8 @@ RUN apt-get update && apt install -y git
 RUN cd kbs && make AS_FEATURE=intel-trust-authority-as ALIYUN=${ALIYUN} && \
     make install-kbs
 
-FROM ubuntu:22.04
+# ubuntu:24.04
+FROM ubuntu@sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf20f9
 
 LABEL org.opencontainers.image.source="https://github.com/confidential-containers/trustee/kbs"
 

--- a/kbs/docker/kbs-client-image/Dockerfile
+++ b/kbs/docker/kbs-client-image/Dockerfile
@@ -1,4 +1,6 @@
-FROM docker.io/library/rust:1.85.1 AS builder
+# rust:1.85.1
+FROM docker.io/library/rust@sha256:e51d0265072d2d9d5d320f6a44dde6b9ef13653b035098febd68cce8fa7c0bc4 \
+    AS builder
 
 WORKDIR /usr/src/kbs
 COPY . .
@@ -9,6 +11,7 @@ RUN apt-get update && apt-get install -y pkg-config libssl-dev git sudo
 RUN cd kbs && make cli-static-linux && \
     cp ../target/$(uname -m)-unknown-linux-gnu/release/kbs-client /
 
-FROM ubuntu:22.04
+# ubuntu:24.04
+FROM ubuntu@sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf20f9
 
 COPY --from=builder /kbs-client /usr/local/bin/kbs-client


### PR DESCRIPTION
The base image used for building KBS (`rust:slim`) was recently updated, and its toolchain now requires glibc 2.38. However, the runtime base image is still `ubuntu:22.04`, which only provides glibc 2.35.

This mismatch causes runtime errors, e.g.:

```
/usr/local/bin/kbs: /lib/s390x-linux-gnu/libc.so.6:
version `GLIBC_2.38' not found (required by /usr/local/bin/kbs)
```

This PR updates the runtime image to `ubuntu:24.04` to match the required glibc version.
Additionally, the update pins the image by digest rather than tag to prevent similar regressions.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>