### PR TITLE
plugins: expose init-data to plugins

### DIFF
--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -269,7 +269,7 @@ pub(crate) async fn api(
                 // Plugin calls need to be authorized by the admin auth
                 core.admin_auth.validate_auth(&request)?;
                 let response = plugin
-                    .handle(&body, query, additional_path, request.method())
+                    .handle(&body, query, additional_path, request.method(), None)
                     .await
                     .map_err(|e| Error::PluginInternalError { source: e })?;
 
@@ -282,6 +282,8 @@ pub(crate) async fn api(
                     .map_err(|_| Error::TokenNotFound)?;
 
                 let claims = core.token_verifier.verify(token).await?;
+                let init_data = claims
+                    .pointer("/submods/cpu0/ear.veraison.annotated-evidence/init_data_claims");
 
                 let claim_str = serde_json::to_string(&claims)?;
 
@@ -299,7 +301,7 @@ pub(crate) async fn api(
                 KBS_POLICY_APPROVALS.inc();
 
                 let response = plugin
-                    .handle(&body, query, additional_path, request.method())
+                    .handle(&body, query, additional_path, request.method(), init_data)
                     .await
                     .map_err(|e| Error::PluginInternalError { source: e })?;
                 if plugin

--- a/kbs/src/plugins/implementations/nebula_ca.rs
+++ b/kbs/src/plugins/implementations/nebula_ca.rs
@@ -399,6 +399,7 @@ impl ClientPlugin for NebulaCaPlugin {
         query: &str,
         path: &str,
         method: &Method,
+        _init_data: Option<&serde_json::Value>,
     ) -> Result<Vec<u8>> {
         let sub_path = path
             .strip_prefix('/')

--- a/kbs/src/plugins/implementations/pkcs11.rs
+++ b/kbs/src/plugins/implementations/pkcs11.rs
@@ -77,6 +77,7 @@ impl ClientPlugin for Pkcs11Backend {
         _query: &str,
         path: &str,
         method: &Method,
+        _init_data: Option<&serde_json::Value>,
     ) -> Result<Vec<u8>> {
         let desc = path
             .strip_prefix('/')

--- a/kbs/src/plugins/implementations/resource/mod.rs
+++ b/kbs/src/plugins/implementations/resource/mod.rs
@@ -26,6 +26,7 @@ impl ClientPlugin for ResourceStorage {
         _query: &str,
         path: &str,
         method: &Method,
+        _init_data: Option<&serde_json::Value>,
     ) -> Result<Vec<u8>> {
         let resource_desc = path
             .strip_prefix('/')

--- a/kbs/src/plugins/implementations/sample.rs
+++ b/kbs/src/plugins/implementations/sample.rs
@@ -35,6 +35,7 @@ impl ClientPlugin for Sample {
         _query: &str,
         _path: &str,
         _method: &Method,
+        _init_data: Option<&serde_json::Value>,
     ) -> Result<Vec<u8>> {
         Ok("sample plugin response".as_bytes().to_vec())
     }


### PR DESCRIPTION
The init-data contains measured guest configuration. Exposing this to the plugin backend can allow for plugins to implement sophisticated logic based on measured guest data.

For example, a plugin could parse the guest policy and issue a certificate based on the properties of the guest (i.e. which container images are allowed to run).

Some of this logic can already be implemented today via a KBS policy, but exposing the init-data to the plugin itself allows for more flexibility.

The init-data is not always present. If a guest does not set the init-data or if the attestation agent does not validate the init-data and put the init_data_claims into the token, then this feature can't be used. Thus, the init-data argument is an Option.