### PR TITLE
deps/verifier: Add DCAP supplemental data claims for SGX/TDX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6353,6 +6353,7 @@ dependencies = [
  "shadow-rs",
  "strum",
  "thiserror 2.0.12",
+ "time",
  "tokio",
  "tonic-build",
  "veraison-apiclient",

--- a/attestation-service/docs/parsed_claims.md
+++ b/attestation-service/docs/parsed_claims.md
@@ -40,22 +40,22 @@ UEFI event log entry contains below fields:
 
 The following fields always exist.
 - `tdx.quote.header.version`: The quote format version. Now supports 4 and 5.
-- `tdx.quote.header.att_key_type`: enum of the algorithm used in signature.
+- `tdx.quote.header.att_key_type`: Enum of the algorithm used in signature.
 - `tdx.quote.header.tee_type`: TDX is always 0x81.
-- `tdx.quote.header.reserved`: reserved.
+- `tdx.quote.header.reserved`: Reserved.
 - `tdx.quote.header.vendor_id`: UID of QE Vendor. QE is a signed software component inside TEE to help to generate tdx quote.
 - `tdx.quote.header.user_data`: Custom attestation key owner data.
 - `tdx.quote.body.mr_config_id`: Software-defined ID for non-owner-defined configuration of the guest TD – e.g., run-time or OS configuration.
 - `tdx.quote.body.mr_owner`: Software-defined ID for the guest TD’s owner.
 - `tdx.quote.body.mr_owner_config`: Software-defined ID for owner-defined configuration of the guest TD – e.g., specific to the workload rather than the run-time or OS.
 - `tdx.quote.body.mr_td`: Measurement of the initial contents of the TD.
-- `tdx.quote.body.mrsigner_seam`: measurement of a 3rd party tdx-module's signer (SHA384 hash). If it is 0, the tdx-module is from Intel.
-- `tdx.quote.body.report_data`: software defined ID for non-owner-defined configuration on the guest TD.
-- `tdx.quote.body.seam_attributes`: for tdx1.0, must be 0.
+- `tdx.quote.body.mrsigner_seam`: Measurement of a 3rd party tdx-module's signer (SHA384 hash). If it is 0, the tdx-module is from Intel.
+- `tdx.quote.body.report_data`: Software defined ID for non-owner-defined configuration on the guest TD.
+- `tdx.quote.body.seam_attributes`: For tdx1.0, must be 0.
 - `tdx.quote.body.td_attributes`: TD's attributes.
-- `tdx.quote.body.mr_seam`: Measurement of the SEAM module
+- `tdx.quote.body.mr_seam`: Measurement of the SEAM module.
 - `tdx.quote.body.tcb_svn`: TEE hardware tcb version, defined and meaningful to Intel. everytime firmware updates this field will change.
-- `tdx.quote.body.xfam`: TD's XFAM
+- `tdx.quote.body.xfam`: TD's XFAM.
 - `tdx.quote.body.rtmr_0`: Runtime extendable measurement register 0.
 - `tdx.quote.body.rtmr_1`: Runtime extendable measurement register 1.
 - `tdx.quote.body.rtmr_2`: Runtime extendable measurement register 2.
@@ -69,9 +69,22 @@ The following fields always exist.
 - `tdx.td_attributes.key_locker`: A boolean value that indicates whether the TD is allowed to use Key Locker.
 - `tdx.td_attributes.perfmon`: A boolean value that indicates whether the TD is allowed to use Perfmon and PERF_METRICS capabilities.
 - `tdx.td_attributes.protection_keys`: A boolean value that indicates whether the TD is allowed to use Supervisor Protection Keys.
-- `tdx.td_attributes.septve_disable`:  A boolean value that determines whether to disable EPT violation conversion to #VE on TD access of PENDING pages.
-- `tdx.advisory_ids`: List of Intel® Product Security Center Advisories
-- `tdx.collateral_expiration_status`:  Expected 0, if none of the inputted collateral has expired as compared to the inputted expiration_check_date.
+- `tdx.td_attributes.septve_disable`: A boolean value that determines whether to disable EPT violation conversion to #VE on TD access of PENDING pages.
+- `tdx.advisory_ids`: List of Intel® Product Security Center Advisories.
+- `tdx.collateral_expiration_status`: Expected 0, if none of the inputted collateral has expired as compared to the inputted expiration_check_date.
+- `tdx.earliest_expiration_date`: Date time value in RFC3339 format - The earliest nextUpdate value, or expiration date, among all collaterals.
+- `tdx.earliest_issue_date`: Date time value in RFC3339 format - The earliest issueDate among all collaterals.
+- `tdx.is_cached_keys`: A boolean value that indicates whether platform root keys are cached by SGX Registration Backend. _Note: this field is only provided if sgx_type is set to either "scalable" or "Scalable with Integrity"._
+- `tdx.is_dynamic_platform`: A boolean value that indicates whether a platform can be extended with additional packages. _Note: this field is only provided if sgx_type is set to either "scalable" or "Scalable with Integrity"._
+- `tdx.is_smt_enabled`: A boolean value that indicates whether a platform has SMT (simultaneous multithreading) enabled. _Note: this field is only provided if sgx_type is set to either "scalable" or "Scalable with Integrity"._
+- `tdx.latest_issue_date`: Date time value in RFC3339 format - The latest issueDate value among all collaterals.
+- `tdx.pck_crl_num`: Indication of the freshness of the PCK cert used.
+- `tdx.platform_provider_id`: The Platform Provisioning ID.
+- `tdx.root_ca_crl_num`: Indication of the freshness of the Root CA cert used.
+- `tdx.root_key_id`: ID of the collateral’s root signer (hash of Root CA’s public key SHA-384).
+- `tdx.sgx_type`: The type of memory used in SGX. Can be one of (`Standard`, `Scalable`, `Scalable with Integrity`).
+- `tdx.tcb_date`: Date time value in RFC3339 format - Earliest date between tcbInfo and qeIdentity.
+- `tdx.tcb_eval_num`: Indication of the freshness of the reference values used.
 
 ## Intel SGX
 

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -73,6 +73,7 @@ ear = { version = "0.3.0", optional = true }
 x509-parser = { version = "0.17.0", optional = true }
 reqwest.workspace = true
 bitflags = { version = "2.8.0", features = ["serde"] }
+time = "0.3.41"
 
 [build-dependencies]
 shadow-rs.workspace = true

--- a/deps/verifier/src/intel_dcap/claims.rs
+++ b/deps/verifier/src/intel_dcap/claims.rs
@@ -1,0 +1,204 @@
+use intel_tee_quote_verification_rs::{sgx_ql_qv_result_t, sgx_ql_qv_supplemental_t};
+use serde_json::{Map, Number, Value};
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+struct SgxQlQvResultWrapper(pub sgx_ql_qv_result_t);
+
+impl SgxQlQvResultWrapper {
+    pub fn as_str_arr(&self) -> Value {
+        let mapping = match self.0 {
+            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OK => "OK",
+            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_MIN => "Min",
+            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OUT_OF_DATE => "OutOfDate",
+            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OUT_OF_DATE_CONFIG_NEEDED => {
+                "OutOfDateConfigurationNeeded"
+            }
+            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_INVALID_SIGNATURE => "InvalidSignature",
+            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_REVOKED => "Revoked",
+            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_UNSPECIFIED => "Unspecified",
+            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_SW_HARDENING_NEEDED => "SoftwareHardeningNeeded",
+            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED => {
+                "ConfigurationAndSoftwareHardeningNeeded"
+            }
+            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED => "TdRelaunchAdvised",
+            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED_CONFIG_NEEDED => {
+                "TdRelaunchAdvisedConfigurationNeeded"
+            }
+            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_MAX => "Max",
+        };
+
+        Value::String(mapping.to_string())
+    }
+}
+
+pub(crate) fn prepare_custom_claims_map(
+    supp_data: &mut sgx_ql_qv_supplemental_t,
+    collateral_expiration_status: u32,
+    quote_verification_result: sgx_ql_qv_result_t,
+) -> Map<String, Value> {
+    let mut claims_map = Map::new();
+
+    claims_map.insert(
+        "earliest_issue_date".to_string(),
+        Value::String(format_rfc3339(supp_data.earliest_issue_date)),
+    );
+    claims_map.insert(
+        "latest_issue_date".to_string(),
+        Value::String(format_rfc3339(supp_data.latest_issue_date)),
+    );
+    claims_map.insert(
+        "earliest_expiration_date".to_string(),
+        Value::String(format_rfc3339(supp_data.earliest_expiration_date)),
+    );
+    claims_map.insert(
+        "tcb_date".to_string(),
+        Value::String(format_rfc3339(supp_data.tcb_level_date_tag)),
+    );
+    claims_map.insert(
+        "pck_crl_num".to_string(),
+        Value::from(Number::from(supp_data.pck_crl_num)),
+    );
+    claims_map.insert(
+        "root_ca_crl_num".to_string(),
+        Value::from(Number::from(supp_data.root_ca_crl_num)),
+    );
+    claims_map.insert(
+        "tcb_eval_num".to_string(),
+        Value::from(Number::from(supp_data.root_ca_crl_num)),
+    );
+    claims_map.insert(
+        "platform_provider_id".to_string(),
+        Value::String(hex::encode(supp_data.pck_ppid)),
+    );
+
+    claims_map.insert(
+        "sgx_type".to_string(),
+        Value::String(match supp_data.sgx_type {
+            0 => "Standard".to_string(),
+            1 => "Scalable".to_string(),
+            2 => "Scalable with Integrity".to_string(),
+            other => format!("Unknown ({})", other),
+        }),
+    );
+    if supp_data.sgx_type > 0 {
+        claims_map.insert(
+            "is_dynamic_platform".to_string(),
+            Value::Bool(supp_data.dynamic_platform == 1),
+        );
+        claims_map.insert(
+            "is_cached_keys".to_string(),
+            Value::Bool(supp_data.cached_keys == 1),
+        );
+        claims_map.insert(
+            "is_smt_enabled".to_string(),
+            Value::Bool(supp_data.smt_enabled == 1),
+        );
+    }
+    claims_map.insert(
+        "root_key_id".to_string(),
+        Value::String(hex::encode(supp_data.root_key_id)),
+    );
+
+    claims_map.insert(
+        "tcb_status".to_string(),
+        SgxQlQvResultWrapper(quote_verification_result).as_str_arr(),
+    );
+    claims_map.insert(
+        "collateral_expiration_status".to_string(),
+        Value::String(collateral_expiration_status.to_string()),
+    );
+    claims_map.insert("advisory_ids".to_string(), get_sa_list(&supp_data.sa_list));
+    claims_map
+}
+
+fn get_sa_list(sa_list: &[c_char; 320]) -> Value {
+    let c_str = unsafe { CStr::from_ptr(sa_list.as_ptr()) };
+
+    let advisory_ids = c_str.to_string_lossy();
+
+    if advisory_ids.is_empty() {
+        return Value::Array(vec![]);
+    }
+
+    advisory_ids
+        .split(',')
+        .map(|s| Value::String(s.to_string()))
+        .collect()
+}
+
+fn format_rfc3339(timestamp: i64) -> String {
+    OffsetDateTime::from_unix_timestamp(timestamp)
+        .expect("invalid unix timestamp.")
+        .format(&Rfc3339)
+        .expect("failed to format timestamp.")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prepare_custom_claims_map;
+    use assert_json_diff::assert_json_eq;
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine;
+    use intel_tee_quote_verification_rs::{sgx_ql_qv_result_t, sgx_ql_qv_supplemental_t};
+    use serde_json::json;
+
+    #[test]
+    fn parse_supplemental_data() {
+        let supplemental_data =
+            "AwADAAAAAAA2owJbAAAAAHAtq2gAAAAAbbbSaAAAAACA7PBlAAAAAAEAAAABAAAAEQAAA\
+        EbkA7008Fo/KBerm63KrMf/yY4PJhAIzTDa6TbKzhjV3PWO7zFGNhPeFXDVFiAJkyfg6mPFvHZoUiXGOj2EQXAHBw\
+        ICAwEAAwAAAAAAAAAACwAAAAAAAAABsNXfABIi8QI8B6FCx2f9QgAAAAEAAAABAAAAAQAAAAAAAAAAAAAAAAAAAAA\
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADajAlsAAAAAbNUZaAAAAADs4ER1AAAA\
+        AIDs8GUAAAAAEQAAAAAAAAA=";
+
+        let mut supp = deserialize_supp_data(supplemental_data);
+
+        let claims =
+            prepare_custom_claims_map(&mut supp, 0, sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OK);
+
+        let expected = json!({
+          "advisory_ids": [],
+          "collateral_expiration_status": "0",
+          "earliest_expiration_date": "2025-09-23T15:02:05Z",
+          "earliest_issue_date": "2018-05-21T10:45:10Z",
+          "is_cached_keys": true,
+          "is_dynamic_platform": true,
+          "is_smt_enabled": true,
+          "latest_issue_date": "2025-08-24T15:19:12Z",
+          "pck_crl_num": 1,
+          "platform_provider_id": "27e0ea63c5bc76685225c63a3d844170",
+          "root_ca_crl_num": 1,
+          "root_key_id": "46e403bd34f05a3f2817ab9badcaacc7ffc98e0f261008cd30dae936cace18d5dcf58eef31463613de1570d516200993",
+          "sgx_type": "Scalable",
+          "tcb_date": "2024-03-13T00:00:00Z",
+          "tcb_eval_num": 1,
+          "tcb_status": "OK"
+        });
+
+        assert_json_eq!(expected, claims);
+    }
+
+    fn deserialize_supp_data(encoded: &str) -> sgx_ql_qv_supplemental_t {
+        let decoded = STANDARD.decode(encoded).expect("invalid base64");
+
+        assert_eq!(decoded.len(), size_of::<sgx_ql_qv_supplemental_t>());
+
+        let mut supp: sgx_ql_qv_supplemental_t = unsafe { std::mem::zeroed() };
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                decoded.as_ptr(),
+                &mut supp as *mut _ as *mut u8,
+                decoded.len(),
+            );
+        }
+
+        supp
+    }
+}

--- a/deps/verifier/src/intel_dcap/mod.rs
+++ b/deps/verifier/src/intel_dcap/mod.rs
@@ -1,3 +1,4 @@
+use crate::intel_dcap::claims::prepare_custom_claims_map;
 use crate::intel_dcap::error::describe_error;
 use crate::TeeEvidenceParsedClaim;
 use anyhow::{anyhow, bail};
@@ -8,11 +9,10 @@ use intel_tee_quote_verification_rs::{
 };
 use log::{debug, warn};
 use serde_json::{Map, Value};
-use std::ffi::CStr;
 use std::mem;
-use std::os::raw::c_char;
 use std::time::{Duration, SystemTime};
 
+mod claims;
 mod error;
 
 pub async fn ecdsa_quote_verification(quote: &[u8]) -> anyhow::Result<Map<String, Value>> {
@@ -101,20 +101,22 @@ pub async fn ecdsa_quote_verification(quote: &[u8]) -> anyhow::Result<Map<String
         | sgx_ql_qv_result_t::SGX_QL_QV_RESULT_CONFIG_NEEDED
         | sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OUT_OF_DATE
         | sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OUT_OF_DATE_CONFIG_NEEDED
+        | sgx_ql_qv_result_t::SGX_QL_QV_RESULT_REVOKED
         | sgx_ql_qv_result_t::SGX_QL_QV_RESULT_SW_HARDENING_NEEDED
-        | sgx_ql_qv_result_t::SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED => {
-            let claims_map = prepare_custom_claims_map(
+        | sgx_ql_qv_result_t::SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED
+        | sgx_ql_qv_result_t::SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED
+        | sgx_ql_qv_result_t::SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED_CONFIG_NEEDED => {
+            Ok(prepare_custom_claims_map(
                 &mut supp_data,
                 collateral_expiration_status,
                 quote_verification_result,
-            );
-
-            Ok(claims_map)
+            ))
         }
-        _ => {
+        terminal_result => {
             bail!(
-                "Verification completed with Terminal result: {:x}",
-                quote_verification_result as u32
+                "Verification completed with Terminal result: {:?} ({:#04x})",
+                terminal_result,
+                terminal_result as u32
             );
         }
     }
@@ -129,69 +131,4 @@ pub fn extend_using_custom_claims(
     };
     map.extend(custom);
     anyhow::Ok(())
-}
-
-fn prepare_custom_claims_map(
-    supp_data: &mut sgx_ql_qv_supplemental_t,
-    collateral_expiration_status: u32,
-    quote_verification_result: sgx_ql_qv_result_t,
-) -> Map<String, Value> {
-    let mut claims_map = Map::new();
-
-    let tcb_status_desc = SgxQlQvResultWrapper(quote_verification_result).as_str();
-
-    let advisory_ids: Vec<Value> = get_sa_list(&supp_data.sa_list)
-        .iter()
-        .map(|s| Value::String(s.to_string()))
-        .collect();
-
-    claims_map.insert(
-        "tcb_status".to_string(),
-        Value::String(tcb_status_desc.to_string()),
-    );
-    claims_map.insert(
-        "collateral_expiration_status".to_string(),
-        Value::String(collateral_expiration_status.to_string()),
-    );
-    claims_map.insert("advisory_ids".to_string(), Value::Array(advisory_ids));
-    claims_map
-}
-
-struct SgxQlQvResultWrapper(pub sgx_ql_qv_result_t);
-
-impl SgxQlQvResultWrapper {
-    pub fn as_str(&self) -> &'static str {
-        match self.0 {
-            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OK => "OK",
-            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_MIN => "Min",
-            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OUT_OF_DATE => "OutOfDate",
-            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OUT_OF_DATE_CONFIG_NEEDED => {
-                "OutOfDateConfigurationNeeded"
-            }
-            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_INVALID_SIGNATURE => "InvalidSignature",
-            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_REVOKED => "Revoked",
-            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_UNSPECIFIED => "Unspecified",
-            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_SW_HARDENING_NEEDED => "SoftwareHardeningNeeded",
-            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED => {
-                "ConfigurationAndSoftwareHardeningNeeded"
-            }
-            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED => "TdRelaunchAdvised",
-            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED_CONFIG_NEEDED => {
-                "TdRelaunchAdvisedConfigurationNeeded"
-            }
-            sgx_ql_qv_result_t::SGX_QL_QV_RESULT_MAX => "Max",
-        }
-    }
-}
-
-fn get_sa_list(sa_list: &[c_char; 320]) -> Vec<String> {
-    let c_str = unsafe { CStr::from_ptr(sa_list.as_ptr()) };
-
-    let advisory_ids = c_str.to_string_lossy();
-
-    if advisory_ids.is_empty() {
-        return vec![];
-    }
-
-    advisory_ids.split(',').map(|s| s.to_string()).collect()
 }

--- a/deps/verifier/src/tdx/quote.rs
+++ b/deps/verifier/src/tdx/quote.rs
@@ -434,13 +434,13 @@ mod tests {
     #[tokio::test]
     #[case(
         "./test_data/tdx_quote_4.dat",
-        r#"{"advisory_ids":["INTEL-SA-00837","INTEL-SA-00960","INTEL-SA-00982","INTEL-SA-00986"],"collateral_expiration_status":"0","tcb_status":"OutOfDate"}"#
+        r#"{"advisory_ids":["INTEL-SA-00837","INTEL-SA-00960","INTEL-SA-00982","INTEL-SA-00986"],"collateral_expiration_status":"0","earliest_expiration_date":"2025-09-23T15:02:05Z","earliest_issue_date":"2018-05-21T10:45:10Z","is_cached_keys":true,"is_dynamic_platform":true,"is_smt_enabled":true,"latest_issue_date":"2025-08-25T15:30:45Z","pck_crl_num":1,"platform_provider_id":"df4c32a9d8d86009aaf380ec43cfcefb","root_ca_crl_num":1,"root_key_id":"46e403bd34f05a3f2817ab9badcaacc7ffc98e0f261008cd30dae936cace18d5dcf58eef31463613de1570d516200993","sgx_type":"Scalable","tcb_date":"2023-02-15T00:00:00Z","tcb_eval_num":1,"tcb_status":"OutOfDate"}"#
     )]
     #[ignore]
     #[tokio::test]
     #[case(
         "./test_data/tdx_quote_5.dat",
-        r#"{"advisory_ids":[],"collateral_expiration_status":"1","tcb_status":"OK"}"#
+        r#"{"advisory_ids":[],"collateral_expiration_status":"1","earliest_expiration_date":"2024-10-08T23:59:59Z","earliest_issue_date":"2018-05-21T10:45:10Z","is_cached_keys":true,"is_dynamic_platform":true,"is_smt_enabled":true,"latest_issue_date":"2025-08-24T15:19:12Z","pck_crl_num":1,"platform_provider_id":"f06984c8d9343452b997c48b36d6e678","root_ca_crl_num":1,"root_key_id":"46e403bd34f05a3f2817ab9badcaacc7ffc98e0f261008cd30dae936cace18d5dcf58eef31463613de1570d516200993","sgx_type":"Scalable","tcb_date":"2023-08-09T00:00:00Z","tcb_eval_num":1,"tcb_status":"OK"}"#
     )]
     async fn test_verify_tdx_quote(#[case] quote: &str, #[case] expected_output: &str) {
         let quote_bin = fs::read(quote).unwrap();


### PR DESCRIPTION
List of added claims:
- earliest_expiration_date,
- earliest_issue_date,
- is_cached_keys,
- is_dynamic_platform,
- is_smt_enabled,
- latest_issue_date,
- pck_crl_num,
- platform_provider_id,
- root_ca_crl_num,
- root_key_id,
- sgx_type,
- tcb_date,
- tcb_eval_num.

Applicable to both SGX and TDX, more details in their respective "Quote Generation Library and Quote Verification Library" docs.