### PR TITLE
lint: fix lint error

### DIFF
--- a/rvps/src/extractors/mod.rs
+++ b/rvps/src/extractors/mod.rs
@@ -41,10 +41,7 @@ impl Extractors {
     pub fn new(config: Option<ExtractorsConfig>) -> Result<Self> {
         let mut extractor_map: HashMap<String, ExtractorInstance> = HashMap::new();
 
-        extractor_map.insert(
-            "sample".to_string(),
-            Box::new(sample::SampleExtractor::default()),
-        );
+        extractor_map.insert("sample".to_string(), Box::new(sample::SampleExtractor));
 
         let swid_config = config.clone().map(|c| c.swid_extractor).unwrap_or(None);
         if config.is_none() {


### PR DESCRIPTION
error: use of `default` to create a unit struct
Error:   --> rvps/src/extractors/mod.rs:46:45
   |
46 |             Box::new(sample::SampleExtractor::default()),
   |                                             ^^^^^^^^^^^ help: remove this call to `default`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#default_constructed_unit_structs
   = note: `-D clippy::default-constructed-unit-structs` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::default_constructed_unit_structs)]`