### PR TITLE
e2e-test: run tpm tests with sudo

### DIFF
--- a/.github/workflows/kbs-e2e.yml
+++ b/.github/workflows/kbs-e2e.yml
@@ -84,6 +84,9 @@ jobs:
   e2e-test:
     needs: build-binaries
     runs-on: ${{ fromJSON(inputs.runs-on-test) }}
+    env:
+      TEE: ${{ inputs.tee }}
+      RUST_LOG: warn
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -107,18 +110,12 @@ jobs:
         sudo apt-get install -y make --no-install-recommends
         make install-dependencies
 
-    - name: Set TPM permissions
-      if: inputs.tee == 'aztdxvtpm' || inputs.tee == 'azsnpvtpm'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y tpm2-tools --no-install-recommends
-        sudo chgrp tss /dev/tpm0
-        sudo usermod -a -G tss "$USER"
-        sg tss -c tpm2_pcrread
-
     - name: Run e2e test
+      if: inputs.tee != 'aztdxvtpm' && inputs.tee != 'azsnpvtpm'
       working-directory: kbs/test
-      env:
-        TEE: ${{ inputs.tee }}
-        RUST_LOG: warn
       run: make e2e-test
+
+    - name: Run e2e test (w/ sudo)
+      if: inputs.tee == 'aztdxvtpm' || inputs.tee == 'azsnpvtpm'
+      working-directory: kbs/test
+      run: sudo -E make e2e-test


### PR DESCRIPTION
sadly, it's not possible without subshelling and more obscure ceremony to change the runner's user group within an action and have it picked up by the succeeding steps. they are all children of the github runner process, which doesn't recognize the group assignment (it's probably also not a great idea to change the state of the runner host in a step, they runners might not all be ephemeral)

Hence we run the test with sudo for the tpm TEEs.

I confirmed the gh action code to work with a [sample run](https://github.com/mkulke/trustee/actions/runs/17493878779) and an [az-snp-vtpm run](https://github.com/mkulke/trustee/actions/runs/17493878768/job/49689944880) 