### PR TITLE
AS: allow underscore trustworthiness claim names in ear policy

### DIFF
--- a/attestation-service/src/token/ear_broker.rs
+++ b/attestation-service/src/token/ear_broker.rs
@@ -255,9 +255,15 @@ impl AttestationTokenBroker for EarAttestationTokenBroker {
                 let claim_value = v.as_i8().context("Policy claim value not i8")?;
                 debug!("Policy claim: {}: {}", k, claim_value);
 
+                // The definition of Trustworthiness Claims in AR4SI
+                // (https://www.ietf.org/archive/id/draft-ietf-rats-ar4si-09.html#name-supportable-trustworthiness-cl)
+                // uses hyphens while the policy engine uses underscores.
+                // so we need to convert underscores to hyphens here.
+                let k = k.replace('_', "-");
+
                 appraisal
                     .trust_vector
-                    .mut_by_name(k)
+                    .mut_by_name(&k)
                     .unwrap()
                     .set(claim_value);
             }


### PR DESCRIPTION
The definition of Trustworthiness Claims in AR4SI uses hyphens, but in rego a variable can only be concatted with underscores.

Thus we explicitly convert underscores to hyphens in the ear processor to allow underscores in the rego policy.