### PR TITLE
kbs: fix config item in unit test

### DIFF
--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -314,6 +314,7 @@ mod tests {
                             storage: ReferenceValueStorageConfig::LocalFs(local_fs::Config{
                                 file_path: "/opt/confidential-containers/attestation-service/reference_values".into(),
                             }),
+                            extractors: None,
                         }),
                         attestation_token_broker: AttestationTokenConfig::Simple(simple::Configuration{
                             duration_min: 5,


### PR DESCRIPTION
To fix the error

error[E0063]: missing field `extractors` in initializer of `reference_value_provider_service::Config`
Error:    --> kbs/src/config.rs:313:58
    |
313 |                         rvps_config: RvpsConfig::BuiltIn(RvpsCrateConfig{
    |                                                          ^^^^^^^^^^^^^^^ missing `extractors`