### PR TITLE
kbs-config.toml: introduce admin_api_ro flag to forbid set_* operations

### DIFF
--- a/attestation-service/src/config.rs
+++ b/attestation-service/src/config.rs
@@ -94,6 +94,7 @@ mod tests {
         rvps_config: RvpsConfig::BuiltIn(RvpsCrateConfig {
             storage: ReferenceValueStorageConfig::LocalFs(local_fs::Config::default()),
             extractors: None,
+            read_only: false,
         }),
         attestation_token_broker: AttestationTokenConfig::Simple(simple::Configuration {
             duration_min: 5,
@@ -107,6 +108,7 @@ mod tests {
         rvps_config: RvpsConfig::BuiltIn(RvpsCrateConfig {
             storage: ReferenceValueStorageConfig::LocalFs(local_fs::Config::default()),
             extractors: None,
+            read_only: false,
         }),
         attestation_token_broker: AttestationTokenConfig::Simple(simple::Configuration {
             duration_min: 5,
@@ -124,6 +126,7 @@ mod tests {
         rvps_config: RvpsConfig::BuiltIn(RvpsCrateConfig {
             storage: ReferenceValueStorageConfig::LocalFs(local_fs::Config::default()),
             extractors: None,
+            read_only: false,
         }),
         attestation_token_broker: AttestationTokenConfig::Ear(ear_broker::Configuration {
             duration_min: 5,
@@ -140,6 +143,7 @@ mod tests {
         rvps_config: RvpsConfig::BuiltIn(RvpsCrateConfig {
             storage: ReferenceValueStorageConfig::LocalFs(local_fs::Config::default()),
             extractors: None,
+            read_only: false,
         }),
         attestation_token_broker: AttestationTokenConfig::Ear(ear_broker::Configuration {
             duration_min: 5,

--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -157,6 +157,7 @@ impl TestHarness {
                 storage: ReferenceValueStorageConfig::LocalJson(local_json::Config {
                     file_path: rv_path,
                 }),
+                read_only: false,
             }),
             RvpsType::Remote => {
                 info!("Starting Remote RVPS");
@@ -165,6 +166,7 @@ impl TestHarness {
                     storage: ReferenceValueStorageConfig::LocalJson(local_json::Config {
                         file_path: rv_path,
                     }),
+                    read_only: false,
                 })?;
                 let inner = Arc::new(RwLock::new(service));
                 let rvps_server = RvpsServer::new(inner.clone());

--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -206,6 +206,7 @@ impl TestHarness {
             admin: AdminConfig {
                 auth_public_key: None,
                 insecure_api: true,
+                admin_api_read_only: false,
             },
             policy_engine: PolicyEngineConfig {
                 policy_path: kbs_policy_path,

--- a/kbs/config/as-config.json
+++ b/kbs/config/as-config.json
@@ -3,7 +3,8 @@
     "policy_engine": "opa",
     "rvps_config": {
         "type": "GrpcRemote",
-        "address": "http://rvps:50003"
+        "address": "http://rvps:50003",
+        "read_only": false
     },
     "attestation_token_broker": {
 	"type": "Ear",

--- a/kbs/config/rvps.json
+++ b/kbs/config/rvps.json
@@ -2,5 +2,6 @@
     "storage": {
 	"type":"LocalFs",
 	"file_path": "/opt/confidential-containers/attestation-service/reference_values"
-    }
+    },
+	"read_only": false
 }

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -204,10 +204,11 @@ Detailed [documentation](https://docs.trustauthority.intel.com).
 
 The following properties can be set under the `[admin]` section.
 
-| Property          | Type    | Description                                                       | Required | Default |
-|-------------------|---------|-------------------------------------------------------------------|----------|---------|
-| `auth_public_key` | String  | Path to the public key used to authenticate the admin APIs        | No       | None    |
-| `insecure_api`    | Boolean | Whether KBS will not verify the public key when called admin APIs | No       | `false` |
+| Property               | Type    | Description                                                       | Required | Default |
+|------------------------|---------|-------------------------------------------------------------------|----------|---------|
+| `auth_public_key`      | String  | Path to the public key used to authenticate the admin APIs        | No       | None    |
+| `insecure_api`         | Boolean | Whether KBS will not verify the public key when called admin APIs | No       | `false` |
+| `admin_api_read_only`  | Boolean | Limit the admin APIs to only get resources.                       | No       | `false` |
 
 ### Policy Engine Configuration
 

--- a/kbs/src/admin/config.rs
+++ b/kbs/src/admin/config.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use serde::Deserialize;
 
 pub const DEFAULT_INSECURE_API: bool = false;
+pub const DEFAULT_ADMIN_API_READ_ONLY: bool = false;
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct AdminConfig {
@@ -18,6 +19,10 @@ pub struct AdminConfig {
     /// WARNING: Using this option enables KBS insecure APIs such as Resource Registration without
     /// verifying the JWK.
     pub insecure_api: bool,
+
+    /// Whether the admin APIs should be read-only or not.
+    /// Useful for operator-based deployments.
+    pub admin_api_read_only: bool,
 }
 
 impl Default for AdminConfig {
@@ -25,6 +30,7 @@ impl Default for AdminConfig {
         Self {
             auth_public_key: None,
             insecure_api: DEFAULT_INSECURE_API,
+            admin_api_read_only: DEFAULT_ADMIN_API_READ_ONLY,
         }
     }
 }

--- a/kbs/src/admin/error.rs
+++ b/kbs/src/admin/error.rs
@@ -19,6 +19,9 @@ pub enum Error {
     #[error("`auth_public_key` is not set in the config file")]
     NoPublicKeyGiven,
 
+    #[error("`admin_api_read_only` limits the admin API to read-only operations (GET/HEAD)")]
+    AdminApiReadOnly,
+
     #[error("Failed to parse admin public key")]
     ParsePublicKey(#[from] jwt_simple::Error),
 

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -320,6 +320,7 @@ mod tests {
                                 file_path: "/opt/confidential-containers/attestation-service/reference_values".into(),
                             }),
                             extractors: None,
+                            read_only: false,
                         }),
                         attestation_token_broker: AttestationTokenConfig::Simple(simple::Configuration{
                             duration_min: 5,

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::admin::config::{AdminConfig, DEFAULT_INSECURE_API};
+use crate::admin::config::{AdminConfig, DEFAULT_ADMIN_API_READ_ONLY, DEFAULT_INSECURE_API};
 use crate::plugins::PluginsConfig;
 use crate::policy_engine::PolicyEngineConfig;
 use crate::token::AttestationTokenVerifierConfig;
@@ -83,6 +83,7 @@ impl TryFrom<&Path> for KbsConfig {
     fn try_from(config_path: &Path) -> Result<Self, Self::Error> {
         let c = Config::builder()
             .set_default("admin.insecure_api", DEFAULT_INSECURE_API)?
+            .set_default("admin.admin_api_read_only", DEFAULT_ADMIN_API_READ_ONLY)?
             .set_default("http_server.insecure_http", DEFAULT_INSECURE_HTTP)?
             .set_default("http_server.sockets", vec![DEFAULT_SOCKET])?
             .set_default(
@@ -169,6 +170,7 @@ mod tests {
         admin: AdminConfig {
             auth_public_key: Some(PathBuf::from("/etc/kbs-admin.pub")),
             insecure_api: false,
+            admin_api_read_only: false,
         },
         policy_engine: PolicyEngineConfig {
             policy_path: PathBuf::from("/etc/kbs-policy.rego"),
@@ -218,6 +220,7 @@ mod tests {
         admin: AdminConfig {
             auth_public_key: None,
             insecure_api: DEFAULT_INSECURE_API,
+            admin_api_read_only: false,
         },
         policy_engine: PolicyEngineConfig {
             policy_path: DEFAULT_POLICY_PATH.into(),
@@ -255,6 +258,7 @@ mod tests {
         admin: AdminConfig {
             auth_public_key: Some(PathBuf::from("/etc/kbs-admin.pub")),
             insecure_api: false,
+            admin_api_read_only: false,
         },
         policy_engine: PolicyEngineConfig {
             policy_path: PathBuf::from("/etc/kbs-policy.rego"),
@@ -293,6 +297,7 @@ mod tests {
         admin: AdminConfig {
             auth_public_key: Some(PathBuf::from("/opt/confidential-containers/kbs/user-keys/public.pub")),
             insecure_api: DEFAULT_INSECURE_API,
+            admin_api_read_only: false,
         },
         policy_engine: PolicyEngineConfig::default(),
         plugins: Vec::new(),
@@ -334,6 +339,7 @@ mod tests {
         admin: AdminConfig {
             auth_public_key: Some("/kbs/kbs.pem".into()),
             insecure_api: DEFAULT_INSECURE_API,
+            admin_api_read_only: false,
         },
         policy_engine: PolicyEngineConfig::default(),
         plugins: Vec::new(),
@@ -369,6 +375,7 @@ mod tests {
         admin: AdminConfig {
             auth_public_key: Some("/kbs/kbs.pem".into()),
             insecure_api: DEFAULT_INSECURE_API,
+            admin_api_read_only: false,
         },
         policy_engine: PolicyEngineConfig::default(),
         plugins: Vec::new(),

--- a/rvps/README.md
+++ b/rvps/README.md
@@ -98,11 +98,13 @@ RVPS can be launched with a specified configuration file by `-c` flag. A configu
     "storage": {
         "type": "LocalFs",
         "file_path": "/opt/confidential-containers/attestation-service/reference_values"
-    }
+    },
+    "read_only": false
 }
 ```
 - `storage.type`: backend storage type to store reference values. Currently `LocalFs` and `LocalJson` are supported.
 - `storage.*`: Each different type of storage has its own associated configuration parameters. This is also a JSON map object.
+- `read_only`: Whether RVPS should run in read-only mode (disable reference value registration). Defaults to `false`.
 
 ## Integrate RVPS into the Attestation Service
 

--- a/rvps/src/bin/rvps.rs
+++ b/rvps/src/bin/rvps.rs
@@ -53,6 +53,12 @@ async fn main() -> Result<()> {
 
     info!("Listen socket: {}", &cli.address);
 
+    if config.read_only {
+        info!("RVPS is running in READ-ONLY mode. Reference value registration is disabled.");
+    } else {
+        info!("RVPS is running in normal mode. Reference value registration is enabled.");
+    }
+
     let socket = cli.address.parse().context("parse socket addr failed")?;
 
     server::start(socket, config).await

--- a/rvps/src/config.rs
+++ b/rvps/src/config.rs
@@ -15,6 +15,9 @@ pub struct Config {
 
     #[serde(default)]
     pub extractors: Option<ExtractorsConfig>,
+
+    #[serde(default)]
+    pub read_only: bool,
 }
 
 impl Config {

--- a/rvps/src/lib.rs
+++ b/rvps/src/lib.rs
@@ -52,6 +52,7 @@ fn default_version() -> String {
 pub struct Rvps {
     extractors: Extractors,
     storage: Box<dyn ReferenceValueStorage + Send + Sync>,
+    read_only: bool,
 }
 
 impl Rvps {
@@ -63,10 +64,17 @@ impl Rvps {
         Ok(Rvps {
             extractors,
             storage,
+            read_only: config.read_only,
         })
     }
 
     pub async fn verify_and_extract(&mut self, message: &str) -> Result<()> {
+        if self.read_only {
+            bail!(
+                "RVPS is configured in read-only mode. Reference value registration is disabled."
+            );
+        }
+
         let message: Message = serde_json::from_str(message).context("parse message")?;
 
         // Judge the version field


### PR DESCRIPTION
In operator-based deployments, kbs-client (and in general the admin API)  should not be allowed to try and modify the resources, for two reasons:
    
    1. trustee runs in a container so the fs is r/o
    2. management of such resources is by design delegated to kubernetes configmaps

Therefore add admin_api_ro flags defaulting to false under the [admin]  section of kbs-config.toml.