### PR TITLE
attestation-policy is not protected by admin autentication

### DIFF
--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -194,6 +194,7 @@ pub(crate) async fn api(
             .map_err(From::from),
         #[cfg(feature = "as")]
         "attestation-policy" if request.method() == Method::POST => {
+            core.admin_auth.validate_auth(&request)?;
             core.attestation_service.set_policy(&body).await?;
 
             Ok(HttpResponse::Ok().finish())


### PR DESCRIPTION
Seems that this is a bug? Not sure but why is attestation-policy endpoint not validated for authentication?