### PR TITLE
kbs: Update kbs-types, remove duplicate definitions

### DIFF
--- a/.github/workflows/kbs-e2e-azure-vtpm.yml
+++ b/.github/workflows/kbs-e2e-azure-vtpm.yml
@@ -37,7 +37,7 @@ jobs:
   #     contents: read
   #   with:
   #     runs-on-test: '["self-hosted","azure-cvm-tdx"]'
-  #     tee: aztdxvtpm
+  #     tee: az-tdx-vtpm
   #     tarball: kbs.tar.gz
 
   snp-e2e-test:

--- a/.github/workflows/kbs-e2e-azure-vtpm.yml
+++ b/.github/workflows/kbs-e2e-azure-vtpm.yml
@@ -49,5 +49,5 @@ jobs:
       contents: read
     with:
       runs-on-test: '["self-hosted","azure-cvm"]'
-      tee: azsnpvtpm
+      tee: az-snp-vtpm
       tarball: kbs.tar.gz

--- a/.github/workflows/kbs-e2e.yml
+++ b/.github/workflows/kbs-e2e.yml
@@ -111,11 +111,11 @@ jobs:
         make install-dependencies
 
     - name: Run e2e test
-      if: inputs.tee != 'aztdxvtpm' && inputs.tee != 'azsnpvtpm'
+      if: inputs.tee != 'aztdxvtpm' && inputs.tee != 'az-snp-vtpm'
       working-directory: kbs/test
       run: make e2e-test
 
     - name: Run e2e test (w/ sudo)
-      if: inputs.tee == 'aztdxvtpm' || inputs.tee == 'azsnpvtpm'
+      if: inputs.tee == 'aztdxvtpm' || inputs.tee == 'az-snp-vtpm'
       working-directory: kbs/test
       run: sudo -E make e2e-test

--- a/.github/workflows/kbs-e2e.yml
+++ b/.github/workflows/kbs-e2e.yml
@@ -97,7 +97,7 @@ jobs:
       run: tar xzf ./test.tar.gz
 
     - name: Set up SGX/TDX certificates cache
-      if: inputs.tee == 'aztdxvtpm'
+      if: inputs.tee == 'az-tdx-vtpm'
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: .dcap-qcnl
@@ -111,11 +111,11 @@ jobs:
         make install-dependencies
 
     - name: Run e2e test
-      if: inputs.tee != 'aztdxvtpm' && inputs.tee != 'az-snp-vtpm'
+      if: inputs.tee != 'az-tdx-vtpm' && inputs.tee != 'az-snp-vtpm'
       working-directory: kbs/test
       run: make e2e-test
 
     - name: Run e2e test (w/ sudo)
-      if: inputs.tee == 'aztdxvtpm' || inputs.tee == 'az-snp-vtpm'
+      if: inputs.tee == 'az-tdx-vtpm' || inputs.tee == 'az-snp-vtpm'
       working-directory: kbs/test
       run: sudo -E make e2e-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
  "const_format",
  "crypto",
  "hex",
- "kbs-types 0.12.0 (git+https://github.com/confidential-containers/kbs-types.git?rev=900aa8f)",
+ "kbs-types 0.12.0",
  "log",
  "serde",
  "serde_json",
@@ -589,7 +589,7 @@ dependencies = [
  "futures",
  "hex",
  "jsonwebtoken",
- "kbs-types 0.12.0 (git+https://github.com/virtee/kbs-types.git?rev=e3cc706)",
+ "kbs-types 0.14.0",
  "lazy_static",
  "log",
  "openssl",
@@ -637,7 +637,7 @@ dependencies = [
  "hyper 0.14.32",
  "hyper-tls 0.5.0",
  "iocuddle",
- "kbs-types 0.12.0 (git+https://github.com/confidential-containers/kbs-types.git?rev=900aa8f)",
+ "kbs-types 0.12.0",
  "log",
  "num-traits",
  "nvml-wrapper 0.11.0 (git+https://github.com/rust-nvml/nvml-wrapper?rev=7e0752f331)",
@@ -1442,7 +1442,7 @@ dependencies = [
  "base64 0.22.1",
  "concat-kdf",
  "ctr",
- "kbs-types 0.12.0 (git+https://github.com/confidential-containers/kbs-types.git?rev=900aa8f)",
+ "kbs-types 0.12.0",
  "p256",
  "rand 0.8.5",
  "rand 0.9.2",
@@ -1736,12 +1736,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3068,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.80"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3185,7 +3185,7 @@ dependencies = [
  "josekit",
  "jsonwebtoken",
  "jwt-simple",
- "kbs-types 0.12.0 (git+https://github.com/virtee/kbs-types.git?rev=e3cc706)",
+ "kbs-types 0.14.0",
  "kms",
  "lazy_static",
  "log",
@@ -3253,13 +3253,16 @@ dependencies = [
 
 [[package]]
 name = "kbs-types"
-version = "0.12.0"
-source = "git+https://github.com/virtee/kbs-types.git?rev=e3cc706#e3cc706ec4c1a88565598c5ce224da06a03f2265"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b02b8dec349b64f7bc236309667cd6f8b4a9c7e5d7bc4677c38b0dd5333b46c"
 dependencies = [
  "base64 0.22.1",
+ "ear",
  "serde",
  "serde_json",
  "sha2",
+ "sm3",
  "strum",
  "thiserror 2.0.16",
 ]
@@ -3276,7 +3279,7 @@ dependencies = [
  "canon-json",
  "crypto",
  "jwt-simple",
- "kbs-types 0.12.0 (git+https://github.com/confidential-containers/kbs-types.git?rev=900aa8f)",
+ "kbs-types 0.12.0",
  "log",
  "reqwest 0.12.23",
  "resource_uri",
@@ -3345,9 +3348,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libgit2-sys"
@@ -5809,9 +5812,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
@@ -6530,7 +6533,7 @@ dependencies = [
  "intel-tee-quote-verification-rs",
  "jsonwebkey",
  "jsonwebtoken",
- "kbs-types 0.12.0 (git+https://github.com/virtee/kbs-types.git?rev=e3cc706)",
+ "kbs-types 0.14.0",
  "log",
  "nvml-wrapper 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl",
@@ -6621,9 +6624,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6634,9 +6637,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -6648,9 +6651,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.53"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b221ff421256839509adbb55998214a70d829d3a28c69b4a6672e9d2a42f67"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6661,9 +6664,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6671,9 +6674,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6684,18 +6687,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.80"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,7 @@ jwt-simple = { version = "0.12", default-features = false, features = [
     "pure-rust",
 ] }
 kbs_protocol = { git = "https://github.com/confidential-containers/guest-components.git", rev = "c35306f", default-features = false }
-# TODO: Change this to kbs-types release
-kbs-types = { "git" = "https://github.com/virtee/kbs-types.git", rev = "e3cc706" }
+kbs-types = "0.14.0"
 kms = { git = "https://github.com/confidential-containers/guest-components.git", rev = "c35306f", default-features = false }
 jsonwebtoken = { version = "9", default-features = false }
 lazy_static = "1.4.0"

--- a/attestation-service/README.md
+++ b/attestation-service/README.md
@@ -133,7 +133,7 @@ Supported Verifier Drivers:
 - `tdx`: Verifier Driver for Intel Trust Domain Extention (Intel TDX).
 - `snp`: Verifier Driver for AMD Secure Encrypted Virtualization-Secure Nested Paging (AMD SNP).
 - `sgx`: Verifier Driver for Intel Software Guard Extensions (Intel SGX).
-- `azsnpvtpm`: Verifier Driver for Azure vTPM based on SNP (Azure SNP vTPM)
+- `az-snp-vtpm`: Verifier Driver for Azure vTPM based on SNP (Azure SNP vTPM)
 - `cca`: Verifier Driver for Confidential Compute Architecture (Arm CCA).
 - `csv`: Verifier Driver for China Security Virtualization (Hygon CSV).
 - `se`: Verifier Driver for IBM Secure Execution (SE).

--- a/attestation-service/docs/grpc-as.md
+++ b/attestation-service/docs/grpc-as.md
@@ -11,7 +11,7 @@ Now the following types of evidence are supported:
 - `cca`: Arm CCA
 - `sample`: A fake platform. Only for test and sample
 - `csv`: Hygon CSV
-- `aztdxvtpm`: Azure TDX vTPM
+- `az-tdx-vtpm`: Azure TDX vTPM
 - `se`: IBM Secure Execution
 
 ## Quick Start

--- a/attestation-service/docs/grpc-as.md
+++ b/attestation-service/docs/grpc-as.md
@@ -3,7 +3,7 @@
 `grpc-as` is an Attestation Service application based on gRPC protocol.
 
 Now the following types of evidence are supported:
-- `azsnpvtpm`: Azure SNP vTPM
+- `az-snp-vtpm`: Azure SNP vTPM
 - `sev`: AMD SEV (Not implemented)
 - `sgx`: Intel SGX
 - `snp`: AMD SNP

--- a/attestation-service/docs/restful-as.md
+++ b/attestation-service/docs/restful-as.md
@@ -3,7 +3,7 @@
 `restful-as` is an Attestation Service application based on RESTful.
 
 Now the following types of evidence are supported:
-- `azsnpvtpm`: Azure SNP vTPM
+- `az-snp-vtpm`: Azure SNP vTPM
 - `sev`: AMD SEV (Not implemented)
 - `sgx`: Intel SGX
 - `snp`: AMD SNP

--- a/attestation-service/docs/restful-as.md
+++ b/attestation-service/docs/restful-as.md
@@ -11,7 +11,7 @@ Now the following types of evidence are supported:
 - `cca`: Arm CCA
 - `sample`: A fake platform. Only for test and sample
 - `csv`: Hygon CSV
-- `aztdxvtpm`: Azure TDX vTPM
+- `az-tdx-vtpm`: Azure TDX vTPM
 - `se`: IBM Secure Execution
 
 ## Quick Start

--- a/attestation-service/src/bin/grpc/mod.rs
+++ b/attestation-service/src/bin/grpc/mod.rs
@@ -38,7 +38,7 @@ fn to_kbs_tee(tee: &str) -> anyhow::Result<Tee> {
         "sample" => Tee::Sample,
         "az-snp-vtpm" => Tee::AzSnpVtpm,
         "cca" => Tee::Cca,
-        "aztdxvtpm" => Tee::AzTdxVtpm,
+        "az-tdx-vtpm" => Tee::AzTdxVtpm,
         "se" => Tee::Se,
         "hygondcu" => Tee::HygonDcu,
         "nvidia" => Tee::Nvidia,

--- a/attestation-service/src/bin/grpc/mod.rs
+++ b/attestation-service/src/bin/grpc/mod.rs
@@ -36,7 +36,7 @@ fn to_kbs_tee(tee: &str) -> anyhow::Result<Tee> {
         "tdx" => Tee::Tdx,
         "csv" => Tee::Csv,
         "sample" => Tee::Sample,
-        "azsnpvtpm" => Tee::AzSnpVtpm,
+        "az-snp-vtpm" => Tee::AzSnpVtpm,
         "cca" => Tee::Cca,
         "aztdxvtpm" => Tee::AzTdxVtpm,
         "se" => Tee::Se,

--- a/attestation-service/src/bin/restful/mod.rs
+++ b/attestation-service/src/bin/restful/mod.rs
@@ -85,7 +85,7 @@ fn to_tee(tee: &str) -> anyhow::Result<Tee> {
         "csv" => Tee::Csv,
         "sample" => Tee::Sample,
         "sampledevice" => Tee::SampleDevice,
-        "aztdxvtpm" => Tee::AzTdxVtpm,
+        "az-tdx-vtpm" => Tee::AzTdxVtpm,
         "se" => Tee::Se,
         "hygondcu" => Tee::HygonDcu,
         other => bail!("tee `{other} not supported`"),

--- a/attestation-service/src/bin/restful/mod.rs
+++ b/attestation-service/src/bin/restful/mod.rs
@@ -76,7 +76,7 @@ enum InitDataInput {
 
 fn to_tee(tee: &str) -> anyhow::Result<Tee> {
     let res = match tee {
-        "azsnpvtpm" => Tee::AzSnpVtpm,
+        "az-snp-vtpm" => Tee::AzSnpVtpm,
         "sev" => Tee::Sev,
         "sgx" => Tee::Sgx,
         "snp" => Tee::Snp,

--- a/attestation-service/src/token/ear_default_policy_cpu.rego
+++ b/attestation-service/src/token/ear_default_policy_cpu.rego
@@ -195,22 +195,22 @@ configuration := 2 if {
 
 ##### Azure vTPM TDX
 executables := 3 if {
-	input.aztdxvtpm.tpm.pcr11 in data.reference.tdx_pcr11
+	input.az_tdx_vtpm.tpm.pcr11 in data.reference.tdx_pcr11
 }
 
 hardware := 2 if {
 	# Check the quote is a TDX quote signed by Intel SGX Quoting Enclave
-	input.aztdxvtpm.quote.header.tee_type == "81000000"
-	input.aztdxvtpm.quote.header.vendor_id == "939a7233f79c4ca9940a0db3957f0607"
+	input.az_tdx_vtpm.quote.header.tee_type == "81000000"
+	input.az_tdx_vtpm.quote.header.vendor_id == "939a7233f79c4ca9940a0db3957f0607"
 
 	# Check TDX Module version and its hash. Also check OVMF code hash.
-	input.aztdxvtpm.quote.body.mr_seam in data.reference.mr_seam
-	input.aztdxvtpm.quote.body.tcb_svn in data.reference.tcb_svn
-	input.aztdxvtpm.quote.body.mr_td in data.reference.mr_td
+	input.az_tdx_vtpm.quote.body.mr_seam in data.reference.mr_seam
+	input.az_tdx_vtpm.quote.body.tcb_svn in data.reference.tcb_svn
+	input.az_tdx_vtpm.quote.body.mr_td in data.reference.mr_td
 }
 
 configuration := 2 if {
-	input.aztdxvtpm.quote.body.xfam in data.reference.xfam
+	input.az_tdx_vtpm.quote.body.xfam in data.reference.xfam
 }
 
 ##### SE TODO

--- a/attestation-service/src/token/ear_default_policy_cpu.rego
+++ b/attestation-service/src/token/ear_default_policy_cpu.rego
@@ -168,16 +168,16 @@ tdx_uefi_event_tdvfkernelparams_ok if {
 
 ##### Azure vTPM SNP
 executables := 3 if {
-	input.azsnpvtpm.measurement in data.reference.measurement
-	input.azsnpvtpm.tpm.pcr11 in data.reference.snp_pcr11
+	input.az_snp_vtpm.measurement in data.reference.measurement
+	input.az_snp_vtpm.tpm.pcr11 in data.reference.snp_pcr11
 }
 
 hardware := 2 if {
 	# Check the reported TCB to validate the ASP FW
-	input.azsnpvtpm.reported_tcb_bootloader in data.reference.tcb_bootloader
-	input.azsnpvtpm.reported_tcb_microcode in data.reference.tcb_microcode
-	input.azsnpvtpm.reported_tcb_snp in data.reference.tcb_snp
-	input.azsnpvtpm.reported_tcb_tee in data.reference.tcb_tee
+	input.az_snp_vtpm.reported_tcb_bootloader in data.reference.tcb_bootloader
+	input.az_snp_vtpm.reported_tcb_microcode in data.reference.tcb_microcode
+	input.az_snp_vtpm.reported_tcb_snp in data.reference.tcb_snp
+	input.az_snp_vtpm.reported_tcb_tee in data.reference.tcb_tee
 }
 
 # For the 'configuration' trust claim 2 stands for
@@ -185,12 +185,12 @@ hardware := 2 if {
 #
 # For this, we compare all the configuration fields.
 configuration := 2 if {
-	input.azsnpvtpm.platform_smt_enabled in data.reference.smt_enabled
-	input.azsnpvtpm.platform_tsme_enabled in data.reference.tsme_enabled
-	input.azsnpvtpm.policy_abi_major in data.reference.abi_major
-	input.azsnpvtpm.policy_abi_minor in data.reference.abi_minor
-	input.azsnpvtpm.policy_single_socket in data.reference.single_socket
-	input.azsnpvtpm.policy_smt_allowed in data.reference.smt_allowed
+	input.az_snp_vtpm.platform_smt_enabled in data.reference.smt_enabled
+	input.az_snp_vtpm.platform_tsme_enabled in data.reference.tsme_enabled
+	input.az_snp_vtpm.policy_abi_major in data.reference.abi_major
+	input.az_snp_vtpm.policy_abi_minor in data.reference.abi_minor
+	input.az_snp_vtpm.policy_single_socket in data.reference.single_socket
+	input.az_snp_vtpm.policy_smt_allowed in data.reference.smt_allowed
 }
 
 ##### Azure vTPM TDX

--- a/kbs/docs/kbs_attestation_protocol.md
+++ b/kbs/docs/kbs_attestation_protocol.md
@@ -95,7 +95,7 @@ Used to declare the type of HW-TEE platform where KBC is located. Currently, kno
 
 | TEE            | Description                                                       |
 |----------------|-------------------------------------------------------------------|
-| `azsnpvtpm`    | Microsoft Azure AMD SNP VTPM                                      |
+| `az-snp-vtpm`  | Microsoft Azure AMD SNP VTPM                                      |
 | `aztdxvtpm`    | Microsoft Azure TDX VTPM                                          |
 | `sev`          | AMD SEV                                                           |
 | `snp`          | AMD SNP                                                           |

--- a/kbs/docs/kbs_attestation_protocol.md
+++ b/kbs/docs/kbs_attestation_protocol.md
@@ -96,7 +96,7 @@ Used to declare the type of HW-TEE platform where KBC is located. Currently, kno
 | TEE            | Description                                                       |
 |----------------|-------------------------------------------------------------------|
 | `az-snp-vtpm`  | Microsoft Azure AMD SNP VTPM                                      |
-| `aztdxvtpm`    | Microsoft Azure TDX VTPM                                          |
+| `az-tdx-vtpm`  | Microsoft Azure TDX VTPM                                          |
 | `sev`          | AMD SEV                                                           |
 | `snp`          | AMD SNP                                                           |
 | `sgx`          | Intel SGX                                                         |


### PR DESCRIPTION
CompositeEvidence, RuntimeData, and InitData were all being deserialized with each KBS attestation request. Therefore, they were further integrated into the KBS protocol and added to kbs-types. Update kbs-types and use its definitions of these structs.