### PR TITLE
kbs: update ITA v2 token claim paths

### DIFF
--- a/kbs/config/kubernetes/ita/policy.rego
+++ b/kbs/config/kubernetes/ita/policy.rego
@@ -38,5 +38,5 @@ package policy
 default allow = false
 
 allow {
-	input["attester_type"] != "sample"
+	input["tdx"]["attester_type"] != "sample"
 }

--- a/kbs/src/token/mod.rs
+++ b/kbs/src/token/mod.rs
@@ -12,8 +12,8 @@ mod error;
 pub(crate) mod jwk;
 pub use error::*;
 
-pub const TOKEN_TEE_PUBKEY_PATH_ITA: &str = "/attester_runtime_data/tee-pubkey";
-pub const TOKEN_TEE_PUBKEY_PATH_ITA_VTPM: &str = "/attester_user_data/tee-pubkey";
+pub const TOKEN_TEE_PUBKEY_PATH_ITA: &str = "/tdx/attester_runtime_data/tee-pubkey";
+pub const TOKEN_TEE_PUBKEY_PATH_ITA_VTPM: &str = "/tdx/attester_user_data/tee-pubkey";
 pub const TOKEN_TEE_PUBKEY_PATH_COCO: &str = "/customized_claims/runtime_data/tee-pubkey";
 pub const TOKEN_TEE_PUBKEY_PATH_EAR: &str =
     "/submods/cpu0/ear.veraison.annotated-evidence/runtime_data_claims/tee-pubkey";


### PR DESCRIPTION
With the move to ITA v2 appraisal API that supports composite evidence, the token claim paths got changed. The claims we used previously are now under 'tdx'.