### PR TITLE
Add Caching backend to Trustee and use it for caching AMD VCEKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ dependencies = [
  "assert-json-diff",
  "async-trait",
  "base64 0.22.1",
+ "cache",
  "canon-json",
  "cfg-if",
  "clap",
@@ -1004,6 +1005,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "cache"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -2913,6 +2927,7 @@ dependencies = [
  "anyhow",
  "attestation-service",
  "base64 0.22.1",
+ "cache",
  "env_logger 0.10.2",
  "kbs",
  "kbs-client",
@@ -3173,6 +3188,7 @@ dependencies = [
  "attestation-service",
  "az-cvm-vtpm",
  "base64 0.22.1",
+ "cache",
  "cfg-if",
  "chrono",
  "clap",
@@ -6502,6 +6518,7 @@ dependencies = [
  "bincode 1.3.3",
  "bitflags 2.9.4",
  "byteorder",
+ "cache",
  "ccatoken",
  "cfg-if",
  "codicon",

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -38,6 +38,7 @@ actix-web = { workspace = true, optional = true }
 anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true
+cache = { path = "../deps/cache" }
 canon-json = "0.2.1"
 cfg-if.workspace = true
 clap = { workspace = true, optional = true }

--- a/attestation-service/src/config.rs
+++ b/attestation-service/src/config.rs
@@ -1,6 +1,7 @@
 use crate::rvps::RvpsConfig;
 use crate::token::AttestationTokenConfig;
 
+use cache::CacheConfig;
 use serde::Deserialize;
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -23,6 +24,10 @@ pub struct Config {
     /// The Attestation Result Token Broker Config
     #[serde(default)]
     pub attestation_token_broker: AttestationTokenConfig,
+
+    /// Configuration for Attestation Service caching
+    #[serde(default)]
+    pub cache: CacheConfig,
 }
 
 fn default_work_dir() -> PathBuf {
@@ -48,6 +53,7 @@ impl Default for Config {
             work_dir: default_work_dir(),
             rvps_config: RvpsConfig::default(),
             attestation_token_broker: AttestationTokenConfig::default(),
+            cache: CacheConfig::default(),
         }
     }
 }
@@ -86,6 +92,8 @@ mod tests {
         rvps::RvpsConfig,
         token::{ear_broker, simple, AttestationTokenConfig},
     };
+
+    use cache::{CacheConfig, CacheType};
     use reference_value_provider_service::storage::{local_fs, ReferenceValueStorageConfig};
 
     #[rstest]
@@ -100,7 +108,11 @@ mod tests {
             issuer_name: "test".into(),
             signer: None,
             policy_dir: "/var/lib/attestation-service/policies".into(),
-        })
+        }),
+        cache: CacheConfig {
+            r#type: CacheType::Simple,
+            initial_values: None,
+        }
     })]
     #[case("./tests/configs/example2.json", Config {
         work_dir: PathBuf::from("/var/lib/attestation-service/"),
@@ -117,7 +129,11 @@ mod tests {
                 cert_url: Some("https://example.io".into()),
                 cert_path: Some("/etc/cert.pem".into())
             })
-        })
+        }),
+        cache: CacheConfig {
+            r#type: CacheType::Simple,
+            initial_values: None,
+        }
     })]
     #[case("./tests/configs/example3.json", Config {
         work_dir: PathBuf::from("/var/lib/attestation-service/"),
@@ -133,7 +149,11 @@ mod tests {
             developer_name: "someone".into(),
             build_name: "0.1.0".into(),
             profile_name: "tag:github.com,2024:confidential-containers/Trustee".into()
-        })
+        }),
+        cache: CacheConfig {
+            r#type: CacheType::Simple,
+            initial_values: None,
+        }
     })]
     #[case("./tests/configs/example4.json", Config {
         work_dir: PathBuf::from("/var/lib/attestation-service/"),
@@ -153,7 +173,11 @@ mod tests {
                 cert_url: Some("https://example.io".into()),
                 cert_path: Some("/etc/cert.pem".into())
             })
-        })
+        }),
+        cache: CacheConfig {
+            r#type: CacheType::Simple,
+            initial_values: None,
+        }
     })]
     fn read_config(#[case] config: &str, #[case] expected: Config) {
         let config = std::fs::read_to_string(config).unwrap();

--- a/deps/cache/Cargo.toml
+++ b/deps/cache/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cache"
+description = "Caching backend for Trustee"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+base64.workspace = true
+log.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true

--- a/deps/cache/src/lib.rs
+++ b/deps/cache/src/lib.rs
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 NVIDIA
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//
+
+pub mod simple;
+
+use anyhow::Result;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// A cache allows any component in the Attestation Service
+/// to store and retrieve values.
+///
+/// A cache has String keys and String values.
+/// The caller should namespace the keys to avoid collisions.
+/// The caller should marshal values to/from String as needed.
+#[async_trait::async_trait]
+pub trait Cache {
+    /// Get a value from the cache
+    async fn get(&self, key: String) -> Option<String>;
+
+    /// Set a value in the cache. This can be called
+    /// after trying to get a value or it can be called
+    /// during setup to provision values from a config
+    /// into the cache.
+    /// Cache implementations should use internal mutability.
+    async fn set(&self, key: String, value: String) -> Result<()>;
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+pub enum CacheType {
+    Simple,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+pub struct CacheConfig {
+    pub r#type: CacheType,
+
+    /// Any key, value pairs that should be added to the cache on startup.
+    /// This can be used to pre-provision values in offline environments.
+    /// For persistent cache backends, the behavior of the initial_values
+    /// is determined by the implementation.
+    pub initial_values: Option<HashMap<String, String>>,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            r#type: CacheType::Simple,
+            initial_values: None,
+        }
+    }
+}
+
+impl CacheConfig {
+    pub async fn to_cache(&self) -> Result<Arc<dyn Cache + Send + Sync>> {
+        let cache = match self.r#type {
+            CacheType::Simple => simple::SimpleCache::default(),
+        };
+
+        if let Some(iv) = &self.initial_values {
+            for (key, value) in iv {
+                // If any duplicate keys are present, only one will be added
+                // to the cache.
+                let _ = cache.set(key.to_string(), value.to_string()).await;
+            }
+        }
+
+        Ok(Arc::new(cache) as Arc<dyn Cache + Send + Sync>)
+    }
+}

--- a/deps/cache/src/simple.rs
+++ b/deps/cache/src/simple.rs
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 NVIDIA
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//
+
+use super::Cache;
+
+use anyhow::Result;
+use std::collections::HashMap;
+use tokio::sync::RwLock;
+
+pub struct SimpleCache {
+    cache: RwLock<HashMap<String, String>>,
+}
+
+impl Default for SimpleCache {
+    fn default() -> Self {
+        Self {
+            cache: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Cache for SimpleCache {
+    async fn get(&self, key: String) -> Option<String> {
+        self.cache.read().await.get(&key).cloned()
+    }
+
+    async fn set(&self, key: String, value: String) -> Result<()> {
+        let _ = self.cache.write().await.insert(key, value);
+        Ok(())
+    }
+}

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -42,6 +42,7 @@ az-tdx-vtpm = { version = "0.7.4", default-features = false, features = [
 base64 = "0.22.1"
 bincode = "1.3.3"
 byteorder.workspace = true
+cache = { path = "../cache" }
 cfg-if = "1.0.0"
 codicon = { version = "3.0", optional = true }
 csv-rs = { git = "https://github.com/openanolis/csv-rs", rev = "b67a07e", optional = true, default-features = false, features = [

--- a/deps/verifier/src/lib.rs
+++ b/deps/verifier/src/lib.rs
@@ -4,6 +4,9 @@ use anyhow::*;
 use async_trait::async_trait;
 use kbs_types::Tee;
 use log::debug;
+use std::sync::Arc;
+
+use cache::Cache;
 
 pub mod sample;
 pub mod sample_device;
@@ -45,7 +48,7 @@ pub mod nvidia;
 ))]
 pub mod intel_dcap;
 
-pub fn to_verifier(tee: &Tee) -> Result<Box<dyn Verifier + Send + Sync>> {
+pub fn to_verifier(tee: &Tee, _cache: Arc<dyn Cache + Send + Sync>) -> Result<Box<dyn Verifier + Send + Sync>> {
     match tee {
         Tee::Sev => todo!(),
         Tee::AzSnpVtpm => {

--- a/deps/verifier/src/lib.rs
+++ b/deps/verifier/src/lib.rs
@@ -82,7 +82,7 @@ pub fn to_verifier(tee: &Tee, _cache: Arc<dyn Cache + Send + Sync>) -> Result<Bo
         Tee::Snp => {
             cfg_if::cfg_if! {
                 if #[cfg(feature = "snp-verifier")] {
-                    let verifier = snp::Snp::default();
+                    let verifier = snp::Snp::new(_cache);
                     Ok(Box::new(verifier) as Box<dyn Verifier + Send + Sync>)
                 } else {
                     bail!("feature `snp-verifier` is not enabled for `verifier` crate.")

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -7,6 +7,7 @@ documentation.workspace = true
 edition.workspace = true
 
 [dependencies] 
+cache = { path = "../deps/cache" }
 kbs = { path = "../kbs" }
 reference-value-provider-service = { path = "../rvps" }
 

--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use cache::{CacheConfig, CacheType};
 use kbs::admin::config::AdminConfig;
 use kbs::attestation::config::{AttestationConfig, AttestationServiceConfig};
 use kbs::config::HttpServerConfig;
@@ -193,6 +194,10 @@ impl TestHarness {
                     work_dir: work_dir.path().to_path_buf(),
                     rvps_config,
                     attestation_token_broker: attestation_token_config,
+                    cache: CacheConfig {
+                        r#type: CacheType::Simple,
+                        initial_values: None,
+                    },
                 }),
                 timeout: 5,
             },

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -16,7 +16,7 @@ as = []
 coco-as = ["as"]
 
 # Use built-in CoCo-AS as backend attestation service
-coco-as-builtin = ["coco-as", "attestation-service/default"]
+coco-as-builtin = ["coco-as", "attestation-service/default", "cache"]
 
 # Use built-in CoCo-AS as backend attestation service without verifier
 coco-as-builtin-no-verifier = ["coco-as"]
@@ -49,6 +49,7 @@ aes-kw = "0.2.1"
 anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true
+cache = { path = "../deps/cache", optional = true }
 cfg-if.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 config.workspace = true

--- a/kbs/src/attestation/config.rs
+++ b/kbs/src/attestation/config.rs
@@ -29,6 +29,7 @@ fn default_timeout() -> i64 {
     DEFAULT_TIMEOUT
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum AttestationServiceConfig {

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -136,6 +136,9 @@ mod tests {
         token::{simple, AttestationTokenConfig, COCO_AS_ISSUER_NAME, DEFAULT_TOKEN_DURATION},
     };
 
+    #[cfg(feature = "coco-as-builtin")]
+    use cache::{CacheConfig, CacheType};
+
     use reference_value_provider_service::storage::{local_fs, ReferenceValueStorageConfig};
 
     use rstest::rstest;
@@ -204,6 +207,10 @@ mod tests {
                             signer: None,
                             ..Default::default()
                         }),
+                        cache: CacheConfig {
+                            r#type: CacheType::Simple,
+                            initial_values: None,
+                        },
                     }
                 ),
             timeout: crate::attestation::config::DEFAULT_TIMEOUT,
@@ -320,6 +327,10 @@ mod tests {
                             duration_min: 5,
                             ..Default::default()
                         }),
+                        cache: CacheConfig {
+                            r#type: CacheType::Simple,
+                            initial_values: None,
+                        },
                     }
                 ),
             timeout: crate::attestation::config::DEFAULT_TIMEOUT,
@@ -450,6 +461,10 @@ mod tests {
                             policy_dir: "/opt/confidential-containers/attestation-service/simple-policies".into(),
                             ..Default::default()
                         }),
+                        cache: CacheConfig {
+                            r#type: CacheType::Simple,
+                            initial_values: None,
+                        },
                     }
                 ),
             timeout: crate::attestation::config::DEFAULT_TIMEOUT,


### PR DESCRIPTION
Introduce a Cache backend to Trustee. This is added as a new package in `deps` to avoid circular dependencies (since we use the Cache in the AS and the Verifier). We can use the same cache logic for the KBS and RVPS in the future.

Introduce one simple caching backend which is just a HashMap. This doesn't support any kind of eviction or expiration, but that can be implemented in a more complex caching backend.

The AS config file can be populated with initial cache values that will be added to whatever caching backend is used at startup. This allows cache values (such as VCEKs) to be pre-provisioned in offline environments. cc @bpradipt 

Update the SNP verifier to use the cache when fetching the VCEK. Use the VCEK URL as the key for the cache. I haven't tested this with an SNP system yet. cc @ryansavino 