### PR TITLE
Centralize base path variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,6 +614,7 @@ dependencies = [
  "toml 0.9.7",
  "tonic",
  "tonic-build",
+ "trustee-config",
  "uuid",
  "verifier",
 ]
@@ -3216,6 +3217,7 @@ dependencies = [
  "toml 0.9.7",
  "tonic",
  "tonic-build",
+ "trustee-config",
  "uuid",
  "vaultrs",
 ]
@@ -3568,6 +3570,18 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -4654,6 +4668,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "trustee-config",
  "walkdir",
 ]
 
@@ -6271,6 +6286,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustee-config"
+version = "0.1.0"
+dependencies = [
+ "dirs 6.0.0",
+ "nix",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6534,6 +6557,7 @@ dependencies = [
  "time",
  "tokio",
  "tonic-build",
+ "trustee-config",
  "veraison-apiclient",
  "x509-parser",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "tools/kbs-client",
     "deps/verifier",
     "deps/eventlog",
+    "deps/trustee-config",
     "integration-tests",
 ]
 resolver = "2"

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -70,6 +70,7 @@ tonic = { workspace = true, optional = true }
 uuid = { version = "1.18.0", features = ["v4"] }
 verifier = { path = "../deps/verifier", default-features = false }
 actix-cors = { version = "0.7", optional = true}
+trustee-config = { version = "0.1.0", path = "../deps/trustee-config" }
 
 [build-dependencies]
 shadow-rs.workspace = true

--- a/attestation-service/src/config.rs
+++ b/attestation-service/src/config.rs
@@ -5,10 +5,11 @@ use serde::Deserialize;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
+use trustee_config::default_base_path;
 
 /// Environment macro for Attestation Service work dir.
 const AS_WORK_DIR: &str = "AS_WORK_DIR";
-pub const DEFAULT_WORK_DIR: &str = "/opt/confidential-containers/attestation-service";
+pub(crate) const DEFAULT_WORK_DIR: &str = "attestation-service";
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct Config {
@@ -26,7 +27,11 @@ pub struct Config {
 }
 
 fn default_work_dir() -> PathBuf {
-    PathBuf::from(std::env::var(AS_WORK_DIR).unwrap_or_else(|_| DEFAULT_WORK_DIR.to_string()))
+    if let Ok(value) = std::env::var(AS_WORK_DIR) {
+        PathBuf::from(value)
+    } else {
+        default_base_path().join(DEFAULT_WORK_DIR)
+    }
 }
 
 #[derive(Error, Debug)]

--- a/deps/trustee-config/Cargo.toml
+++ b/deps/trustee-config/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "trustee-config"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+edition.workspace = true
+
+[dependencies]
+dirs = "6.0.0"
+nix = { version = "0.30.1", features = ["user"] }

--- a/deps/trustee-config/src/lib.rs
+++ b/deps/trustee-config/src/lib.rs
@@ -1,0 +1,15 @@
+use dirs::home_dir;
+use nix::unistd::Uid;
+use std::path::PathBuf;
+
+/// default_base_path calculates a default base folder for Trustee according to the current user.
+///
+/// - `/opt/confidential-containers/` remains the base path when running as root.
+/// - `$HOME/.trustee` for all users other than root.
+pub fn default_base_path() -> PathBuf {
+    if Uid::effective().is_root() {
+        "/opt/confidential-containers".into()
+    } else {
+        home_dir().unwrap_or_default().join(".trustee")
+    }
+}

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -78,6 +78,7 @@ bitflags = { version = "2.8.0", features = ["serde"] }
 time = "0.3.41"
 nvml-wrapper = { version = "0.11.0", optional = true, default-features = false, features = ["serde"]}
 p384 = { version = "0.13.1", optional = true }
+trustee-config = { version = "0.1.0", path = "../trustee-config" }
 
 [build-dependencies]
 shadow-rs.workspace = true

--- a/deps/verifier/src/cca/config.rs
+++ b/deps/verifier/src/cca/config.rs
@@ -8,8 +8,7 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
-pub const DEFAULT_CCA_CONFIG: &str =
-    "/opt/confidential-containers/attestation-service/cca/config.json";
+pub const DEFAULT_CCA_CONFIG: &str = "attestation-service/cca/config.json";
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "kebab-case")]

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -88,6 +88,7 @@ openssl.workspace = true
 az-cvm-vtpm = { version = "0.7.0", default-features = false, optional = true }
 derivative = "2.2.0"
 vaultrs = { version = "0.7.4", optional = true }
+trustee-config = { version = "0.1.0", path = "../deps/trustee-config" }
 
 [target.'cfg(not(any(target_arch = "s390x", target_arch = "aarch64")))'.dependencies]
 attestation-service = { path = "../attestation-service", default-features = false, features = [

--- a/kbs/src/plugins/implementations/nebula_ca.rs
+++ b/kbs/src/plugins/implementations/nebula_ca.rs
@@ -27,7 +27,7 @@ const DEFAULT_NEBULA_CA_NAME: &str = "Trustee Nebula CA plugin";
 const DEFAULT_NEBULA_CERT_PATH: &str = "nebula-cert";
 /// Default Nebula CA working directory.
 /// It must have read-write permission.
-const DEFAULT_WORK_DIR: &str = "/opt/confidential-containers/kbs/nebula-ca";
+const DEFAULT_WORK_DIR: &str = "kbs/nebula-ca";
 /// Minimum nebula-cert version required.
 const NEBULA_CERT_VERSION_REQUIREMENT: &str = ">=1.9.5";
 
@@ -105,7 +105,11 @@ impl TryFrom<NebulaCaPluginConfig> for NebulaCaPlugin {
     type Error = Error;
 
     fn try_from(config: NebulaCaPluginConfig) -> Result<Self> {
-        let work_dir = PathBuf::from(config.work_dir.unwrap_or(DEFAULT_WORK_DIR.into()));
+        let work_dir = if let Some(config_work_dir) = config.work_dir {
+            PathBuf::from(config_work_dir)
+        } else {
+            default_base_path.join(DEFAULT_WORK_DIR)
+        };
         let path = PathBuf::from(
             config
                 .nebula_cert_bin_path

--- a/kbs/src/plugins/implementations/resource/local_fs.rs
+++ b/kbs/src/plugins/implementations/resource/local_fs.rs
@@ -9,8 +9,9 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
+use trustee_config::default_base_path;
 
-pub const DEFAULT_REPO_DIR_PATH: &str = "/opt/confidential-containers/kbs/repository";
+pub const DEFAULT_REPO_DIR_PATH: &str = "kbs/repository";
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct LocalFsRepoDesc {
@@ -21,7 +22,10 @@ pub struct LocalFsRepoDesc {
 impl Default for LocalFsRepoDesc {
     fn default() -> Self {
         Self {
-            dir_path: DEFAULT_REPO_DIR_PATH.into(),
+            dir_path: default_base_path()
+                .join(DEFAULT_REPO_DIR_PATH)
+                .to_string_lossy()
+                .to_string(),
         }
     }
 }

--- a/kbs/src/policy_engine/mod.rs
+++ b/kbs/src/policy_engine/mod.rs
@@ -9,13 +9,14 @@ use tokio::sync::Mutex;
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use trustee_config::default_base_path;
 
 mod opa;
 
 mod error;
 pub use error::*;
 
-pub const DEFAULT_POLICY_PATH: &str = "/opt/confidential-containers/kbs/policy.rego";
+pub const DEFAULT_POLICY_PATH: &str = "kbs/policy.rego";
 
 /// Resource policy engine interface
 ///
@@ -50,7 +51,7 @@ pub struct PolicyEngineConfig {
 impl Default for PolicyEngineConfig {
     fn default() -> Self {
         Self {
-            policy_path: PathBuf::from(DEFAULT_POLICY_PATH),
+            policy_path: default_base_path().join(DEFAULT_POLICY_PATH),
         }
     }
 }

--- a/rvps/Cargo.toml
+++ b/rvps/Cargo.toml
@@ -43,6 +43,7 @@ strum.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, optional = true }
 tonic = { workspace = true, optional = true }
+trustee-config = { version = "0.1.0", path = "../deps/trustee-config" }
 
 [build-dependencies]
 shadow-rs.workspace = true

--- a/rvps/src/storage/local_fs/mod.rs
+++ b/rvps/src/storage/local_fs/mod.rs
@@ -8,6 +8,7 @@
 use anyhow::*;
 use async_trait::async_trait;
 use serde::Deserialize;
+use trustee_config::default_base_path;
 
 use crate::ReferenceValue;
 
@@ -15,7 +16,7 @@ use super::ReferenceValueStorage;
 
 /// Local directory path to store the reference values,
 /// which is created by sled engine.
-const FILE_PATH: &str = "/opt/confidential-containers/attestation-service/reference_values";
+const FILE_PATH: &str = "attestation-service/reference_values";
 
 /// `LocalFs` implements [`ReferenceValueStorage`] trait. And
 /// it uses rocksdb inside.
@@ -24,7 +25,10 @@ pub struct LocalFs {
 }
 
 fn default_file_path() -> String {
-    FILE_PATH.to_string()
+    default_base_path()
+        .join(FILE_PATH)
+        .to_string_lossy()
+        .to_string()
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]

--- a/rvps/src/storage/local_json/mod.rs
+++ b/rvps/src/storage/local_json/mod.rs
@@ -7,8 +7,9 @@ use async_trait::async_trait;
 use log::debug;
 use serde::Deserialize;
 use tokio::sync::RwLock;
+use trustee_config::default_base_path;
 
-const FILE_PATH: &str = "/opt/confidential-containers/attestation-service/reference_values.json";
+const FILE_PATH: &str = "attestation-service/reference_values.json";
 
 pub struct LocalJson {
     file_path: String,
@@ -16,7 +17,10 @@ pub struct LocalJson {
 }
 
 fn default_file_path() -> String {
-    FILE_PATH.to_string()
+    default_base_path()
+        .join(FILE_PATH)
+        .to_string_lossy()
+        .to_string()
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]


### PR DESCRIPTION
During #776 I found the hardcoded `/opt/confidential-containers` paths to come in the way for running Trustee as a non-root user. Changing all the paths at runtime means traversing the whole KbsConfig struct, not optimal.

Here I propose a possible alternative, to set the default base path at runtime with a shared logic.

This approach can look heavy, in that it introduces a new package just to share a function. Over time the shared package can become more useful to share more project-wide config. For example if we decide to split the api server from the kbs package. I'd be willing to populate the shared config package a bit more but right now I don't know what else could be moved.

Please propose alternative approaches.

If we like this, I'll have to fix the tests, and possibly make the tests run in both the root and non-root scenario.