### PR TITLE
tests: add test for admin endpoints

### DIFF
--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -99,7 +99,7 @@ pub struct TestParameters {
 /// Internal state of tests
 pub struct TestHarness {
     pub kbs_config: KbsConfig,
-    auth_privkey: String,
+    pub auth_privkey: String,
     kbs_server_handle: actix_web::dev::ServerHandle,
     _work_dir: TempDir,
 
@@ -135,7 +135,7 @@ impl TestHarness {
             .map_err(|e| anyhow!("Failed to join reference values path: {:?}", e))?;
         let auth_pubkey_path = work_dir.path().join("auth_pubkey");
 
-        tokio::fs::write(auth_pubkey_path, auth_pubkey.as_bytes()).await?;
+        tokio::fs::write(auth_pubkey_path.clone(), auth_pubkey.as_bytes()).await?;
 
         let attestation_token_config = match &test_parameters.attestation_token_type[..] {
             "Ear" => AttestationTokenConfig::Ear(ear_broker::Configuration {
@@ -204,8 +204,8 @@ impl TestHarness {
                 payload_request_size: 2,
             },
             admin: AdminConfig {
-                auth_public_key: None,
-                insecure_api: true,
+                auth_public_key: Some(auth_pubkey_path.as_path().to_path_buf()),
+                insecure_api: false,
             },
             policy_engine: PolicyEngineConfig {
                 policy_path: kbs_policy_path,

--- a/integration-tests/tests/admin.rs
+++ b/integration-tests/tests/admin.rs
@@ -1,0 +1,141 @@
+// Copyright (c) 2025 by NVIDIA.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use log::info;
+use openssl::pkey::PKey;
+use rstest::rstest;
+use serial_test::serial;
+
+extern crate integration_tests;
+use crate::integration_tests::common::{KbsConfigType, PolicyType, TestHarness};
+
+//
+// Set the kbs policy with the a valid admin private key
+// and with the wrong admin private key.
+//
+#[rstest]
+#[case::set_policy_with_valid_key(true)]
+#[case::set_policy_with_invalid_key(false)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn set_policy(#[case] valid_key: bool) -> Result<()> {
+    let _ = env_logger::try_init_from_env(env_logger::Env::new().default_filter_or("debug"));
+
+    let mut harness = TestHarness::new(KbsConfigType::EarTokenBuiltInRvps.into()).await?;
+    harness.wait().await;
+
+    if !valid_key {
+        info!("TEST: replacing admin private key");
+
+        let auth_keypair = PKey::generate_ed25519()?;
+        let auth_privkey = String::from_utf8(auth_keypair.private_key_to_pem_pkcs8()?)?;
+
+        harness.auth_privkey = auth_privkey;
+    }
+
+    info!("TEST: setting policy");
+    let res = harness.set_policy(PolicyType::AllowAll).await;
+
+    harness.cleanup().await?;
+    if !valid_key {
+        match res {
+            std::result::Result::Ok(_) => {
+                bail!("Admin key is invalid, but admin operation was successful")
+            }
+            Err(e) if e.to_string().contains("Admin Token verification failed") => return Ok(()),
+            _ => (),
+        }
+    }
+    res
+}
+
+//
+// Set the attestation policy with the a valid admin private key
+// and with the wrong admin private key.
+//
+#[rstest]
+#[case::set_attestation_policy_with_valid_key(true)]
+#[case::set_attestation_policy_with_invalid_key(false)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn set_attestation_policy(#[case] valid_key: bool) -> Result<()> {
+    let _ = env_logger::try_init_from_env(env_logger::Env::new().default_filter_or("debug"));
+
+    let mut harness = TestHarness::new(KbsConfigType::EarTokenBuiltInRvps.into()).await?;
+    harness.wait().await;
+
+    if !valid_key {
+        info!("TEST: replacing admin private key");
+
+        let auth_keypair = PKey::generate_ed25519()?;
+        let auth_privkey = String::from_utf8(auth_keypair.private_key_to_pem_pkcs8()?)?;
+
+        harness.auth_privkey = auth_privkey;
+    }
+
+    info!("TEST: setting attestation policy");
+    let res = harness
+        .set_attestation_policy(DUMMY_POLICY.to_string(), "fake_policy_id".to_string())
+        .await;
+
+    harness.cleanup().await?;
+    if !valid_key {
+        match res {
+            std::result::Result::Ok(_) => {
+                bail!("Admin key is invalid, but admin operation was successful")
+            }
+            Err(e) if e.to_string().contains("Admin Token verification failed") => return Ok(()),
+            _ => (),
+        }
+    }
+    res
+}
+
+const DUMMY_POLICY: &str = "
+package policy
+import rego.v1
+
+default executables = 97
+";
+
+//
+// Set a secret with the a valid admin private key
+// and with the wrong admin private key.
+//
+#[rstest]
+#[case::set_secret_with_valid_key(true)]
+#[case::set_secret_with_invalid_key(false)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn set_secret(#[case] valid_key: bool) -> Result<()> {
+    let _ = env_logger::try_init_from_env(env_logger::Env::new().default_filter_or("debug"));
+
+    let mut harness = TestHarness::new(KbsConfigType::EarTokenBuiltInRvps.into()).await?;
+    harness.wait().await;
+
+    if !valid_key {
+        info!("TEST: replacing admin private key");
+
+        let auth_keypair = PKey::generate_ed25519()?;
+        let auth_privkey = String::from_utf8(auth_keypair.private_key_to_pem_pkcs8()?)?;
+
+        harness.auth_privkey = auth_privkey;
+    }
+
+    info!("TEST: setting secret");
+    let res = harness.set_secret("a/b/c".to_string(), vec![0u8; 10]).await;
+
+    harness.cleanup().await?;
+    if !valid_key {
+        match res {
+            std::result::Result::Ok(_) => {
+                bail!("Admin key is invalid, but admin operation was successful")
+            }
+            Err(e) if e.to_string().contains("Admin Token verification failed") => return Ok(()),
+            _ => (),
+        }
+    }
+    res
+}


### PR DESCRIPTION
Make sure that the admin endpoints cannot be accessed when using the wrong admin key.

This is not totally rigorous (not all endpoints and not all failure modes) but it's a good start.