### PR TITLE
e2e-test: remove type=Ear prop from test cfg

### DIFF
--- a/kbs/test/config/kbs.toml
+++ b/kbs/test/config/kbs.toml
@@ -13,7 +13,6 @@ work_dir = "./work/attestation-service"
 policy_engine = "opa"
 
 [attestation_service.attestation_token_broker]
-type = "Ear"
 duration_min = 5
 policy_dir = "./work/attestation-service/token/ear/policies"
 


### PR DESCRIPTION
The simple token has been removed EAR is the only valid type