### PR TITLE
chore(deps): update guest-components to version 5185b46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,14 +557,14 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "attestation-agent"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5185b46#5185b46518397a6aa8add92ded73549baf5f629c"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=7be23a1#7be23a14e468a29cb0d0167671b927a609cbe05d"
 dependencies = [
  "anyhow",
  "async-trait",
  "attester",
  "base64 0.22.1",
  "byteorder",
- "config",
+ "config 0.15.18",
  "const_format",
  "crypto",
  "hex",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "attester"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5185b46#5185b46518397a6aa8add92ded73549baf5f629c"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=7be23a1#7be23a14e468a29cb0d0167671b927a609cbe05d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1266,11 +1266,31 @@ dependencies = [
  "nom",
  "pathdiff",
  "ron",
- "rust-ini",
+ "rust-ini 0.20.0",
  "serde",
  "serde_json",
  "toml 0.8.23",
- "yaml-rust2",
+ "yaml-rust2 0.8.1",
+]
+
+[[package]]
+name = "config"
+version = "0.15.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e549344080374f9b32ed41bf3b6b57885ff6a289367b3dbc10eea8acc1918"
+dependencies = [
+ "async-trait",
+ "convert_case",
+ "json5",
+ "pathdiff",
+ "ron",
+ "rust-ini 0.21.3",
+ "serde-untagged",
+ "serde_core",
+ "serde_json",
+ "toml 0.9.8",
+ "winnow",
+ "yaml-rust2 0.10.4",
 ]
 
 [[package]]
@@ -1476,7 +1496,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5185b46#5185b46518397a6aa8add92ded73549baf5f629c"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=7be23a1#7be23a14e468a29cb0d0167671b927a609cbe05d"
 dependencies = [
  "aes-gcm",
  "aes-kw",
@@ -2083,6 +2103,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "259d404d09818dec19332e31d94558aeb442fea04c817006456c24b5460bbd4b"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -3251,7 +3282,7 @@ dependencies = [
  "chrono",
  "clap",
  "concat-kdf",
- "config",
+ "config 0.14.1",
  "cryptoki",
  "derivative",
  "env_logger",
@@ -3331,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "kbs_protocol"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5185b46#5185b46518397a6aa8add92ded73549baf5f629c"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=7be23a1#7be23a14e468a29cb0d0167671b927a609cbe05d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3374,7 +3405,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5185b46#5185b46518397a6aa8add92ded73549baf5f629c"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=7be23a1#7be23a14e468a29cb0d0167671b927a609cbe05d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4581,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "protos"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5185b46#5185b46518397a6aa8add92ded73549baf5f629c"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=7be23a1#7be23a14e468a29cb0d0167671b927a609cbe05d"
 dependencies = [
  "prost",
  "tonic",
@@ -4821,7 +4852,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "clap",
- "config",
+ "config 0.14.1",
  "env_logger",
  "log",
  "path-clean",
@@ -4992,7 +5023,7 @@ dependencies = [
 [[package]]
 name = "resource_uri"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5185b46#5185b46518397a6aa8add92ded73549baf5f629c"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=7be23a1#7be23a14e468a29cb0d0167671b927a609cbe05d"
 dependencies = [
  "anyhow",
  "serde",
@@ -5100,6 +5131,16 @@ name = "rust-ini"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
@@ -5462,6 +5503,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde-untagged"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_core",
+ "typeid",
 ]
 
 [[package]]
@@ -6720,6 +6773,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7598,6 +7657,17 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink 0.8.4",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ hex = "0.4.3"
 jwt-simple = { version = "0.12", default-features = false, features = [
     "pure-rust",
 ] }
-kbs_protocol = { git = "https://github.com/confidential-containers/guest-components.git", rev = "5185b46", default-features = false }
+kbs_protocol = { git = "https://github.com/confidential-containers/guest-components.git", rev = "7be23a1", default-features = false }
 kbs-types = "0.14.0"
-kms = { git = "https://github.com/confidential-containers/guest-components.git", rev = "5185b46", default-features = false }
+kms = { git = "https://github.com/confidential-containers/guest-components.git", rev = "7be23a1", default-features = false }
 jsonwebtoken = { version = "9", default-features = false }
 lazy_static = "1.4.0"
 log = "0.4.28"


### PR DESCRIPTION
this can fix the lint error

error[E0433]: failed to resolve: use of undeclared crate or module `reqwest`
Error:   --> /home/runner/.cargo/git/checkouts/guest-components-ff71bf7258377e6f/5185b46/attestation-agent/kbs_protocol/src/builder.rs:82:39
   |
82 |         let mut http_client_builder = reqwest::Client::builder()
   |                                       ^^^^^^^ use of undeclared crate or module `reqwest`

error[E0433]: failed to resolve: use of undeclared crate or module `reqwest`
Error:   --> /home/runner/.cargo/git/checkouts/guest-components-ff71bf7258377e6f/5185b46/attestation-agent/kbs_protocol/src/builder.rs:91:24
   |
91 |             let cert = reqwest::Certificate::from_pem(customer_root_cert.as_bytes())
   |                        ^^^^^^^ use of undeclared crate or module `reqwest`

error[E0433]: failed to resolve: use of undeclared crate or module `reqwest`
Error:   --> /home/runner/.cargo/git/checkouts/guest-components-ff71bf7258377e6f/5185b46/attestation-agent/kbs_protocol/src/client/mod.rs:42:29
   |
42 |     pub(crate) http_client: reqwest::Client,
   |                             ^^^^^^^ use of undeclared crate or module `reqwest`