### PR TITLE
fix(kbs): fix proto3 build error on kbs's build-script-build

### DIFF
--- a/kbs/build.rs
+++ b/kbs/build.rs
@@ -23,7 +23,11 @@ fn main() -> Result<(), String> {
 
     #[cfg(feature = "tonic-build")]
     tonic_build::compile_protos("../protos/attestation.proto").map_err(|e| format!("{e}"))?;
+
     #[cfg(feature = "tonic-build")]
-    tonic_build::compile_protos("../protos/reference.proto").map_err(|e| format!("{e}"))?;
+    tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile_protos(&["../protos/reference.proto"], &["../protos"])
+        .map_err(|e| format!("{e}"))?;
     Ok(())
 }


### PR DESCRIPTION
## Issue
Currently, KBS can not be compiled successfully, due to below error:
```bash
error: failed to run custom build command for `kbs v0.1.0 (/home/erasernoob/trustee/kbs)`

Caused by:
  process didn't exit successfully: `/home/erasernoob/trustee/target/debug/build/kbs-5c16f2ba3c21404a/build-script-build` (exit status: 1)
  --- stdout
  cargo:rustc-env=KBS_GIT_HASH=74f9c5d6dc
  cargo:rustc-env=KBS_BUILD_DATE=2025-11-05T17:26:48.174+08:00
  cargo:rerun-if-changed=../protos/attestation.proto
  cargo:rerun-if-changed=../protos
  cargo:rerun-if-changed=../protos/reference.proto
  cargo:rerun-if-changed=../protos

  --- stderr
  Error: "protoc failed: reference.proto: This file contains proto3 optional fields, but --experimental_allow_proto3_optional was not set.\n"
```
This PR fixes this by adding `--experimental_allow_proto3_optional `.