### PR TITLE
refactor: remove sample_only feature from kbs-client

### DIFF
--- a/.github/workflows/kbs-docker-e2e.yml
+++ b/.github/workflows/kbs-docker-e2e.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Build client
       run: |
-        cargo build --manifest-path tools/kbs-client/Cargo.toml --no-default-features --features sample_only --release
+        cargo build --manifest-path tools/kbs-client/Cargo.toml --no-default-features --release
 
     - name: Setup Keys
       run: | 

--- a/.github/workflows/kbs-e2e-sample.yml
+++ b/.github/workflows/kbs-e2e-sample.yml
@@ -43,7 +43,7 @@ jobs:
       runs-on-build: '["ubuntu-22.04-arm"]'
       runs-on-test: '["ubuntu-22.04-arm"]'
       tarball: kbs.tar.gz
-      kbs-client-features: "sample_only,cca-attester"
+      kbs-client-features: "cca-attester"
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/kbs-rust.yml
+++ b/.github/workflows/kbs-rust.yml
@@ -30,7 +30,7 @@ jobs:
         - instance: ubuntu-24.04
           test_features: ""
         - instance: ubuntu-24.04-arm
-          test_features: "coco-as-builtin,coco-as-grpc,intel-trust-authority-as,sample_only,cca-attester"
+          test_features: "coco-as-builtin,coco-as-grpc,intel-trust-authority-as,cca-attester"
     runs-on: ${{ matrix.instance }}
 
     steps:

--- a/kbs/Makefile
+++ b/kbs/Makefile
@@ -60,12 +60,12 @@ ifeq ($(VAULT), true)
   FEATURES += vault
 endif
 
-ifndef CLI_FEATURES
-  ifdef ATTESTER
-    CLI_FEATURES = "sample_only,$(ATTESTER)"
-  else
-    CLI_FEATURES += "sample_only,all-attesters"
-  endif
+ifeq ($(CLI_FEATURES),sample_only)
+  CLI_FEATURES = "," # this is a dummy feature to satisfy the cargo build command
+else ifdef ATTESTER
+  CLI_FEATURES = "$(ATTESTER)"
+else
+  CLI_FEATURES += "all-attesters"
 endif
 
 ifneq ($(TEST_FEATURES),)
@@ -100,8 +100,7 @@ cli-static-linux:
       --config "target.$(ARCH)-unknown-linux-gnu.rustflags = '-C target-feature=+crt-static'" \
       --locked \
       --release \
-      --no-default-features \
-      --features sample_only
+      --no-default-features
 
 install-kbs:
 	install -D -m0755 $(RELEASE_DIR)/kbs $(INSTALL_DESTDIR)

--- a/tools/kbs-client/Cargo.toml
+++ b/tools/kbs-client/Cargo.toml
@@ -18,7 +18,7 @@ base64.workspace = true
 clap = { version = "4.5.48", features = ["derive"] }
 env_logger.workspace = true
 jwt-simple.workspace = true
-kbs_protocol = { workspace = true, default-features = false }
+kbs_protocol = { workspace = true, default-features = false, features = ["background_check", "passport"] }
 log.workspace = true
 reqwest = { workspace = true, default-features = false, features = ["cookies", "json"] }
 serde = { workspace = true, features = ["derive"] }
@@ -26,8 +26,7 @@ serde_json.workspace = true
 tokio.workspace = true
 
 [features]
-default = ["kbs_protocol/default"]
-sample_only = ["kbs_protocol/background_check", "kbs_protocol/passport", "kbs_protocol/rust-crypto"]
+default = []
 
 all-attesters = ["kbs_protocol/all-attesters"]
 tdx-attester = ["kbs_protocol/tdx-attester"]

--- a/tools/kbs-client/README.md
+++ b/tools/kbs-client/README.md
@@ -26,8 +26,7 @@ Build the client binary with support to the default features as:
 make -C ../../kbs cli
 ```
 
-By default the client is built with support to the sample attester, apart from the
-TEE specific ones. If you want to build it with that sample attester only (this will
+By default the client is built with support to the all attesters. If you want to build it with that sample attester only (this will
 require fewer dependencies and so usually handy for CI) then you can pass the
 `sample_only` feature as:
 


### PR DESCRIPTION
This patch is to fix the compilation error when building cli with default feature

```
error[E0599]: no method named `get_token` found for struct `KbsClient` in the current scope
Error:   --> tools/kbs-client/src/lib.rs:41:29
   |
41 |     let (token, _) = client.get_token().await?;
   |                             ^^^^^^^^^ method not found in `KbsClient<Box<dyn EvidenceProvider>>`
   |
   = note: the full type name has been written to '/home/runner/work/trustee/trustee/target/debug/deps/kbs_client-b572fa785161aa52.long-type-2778283832653063124.txt'
   = note: consider using `--verbose` to print the full type name to the console

error[E0599]: no method named `get_resource` found for struct `KbsClient` in the current scope
Error:   --> tools/kbs-client/src/lib.rs:72:10
   |
71 |       let resource_bytes = client
   |  __________________________-
72 | |         .get_resource(serde_json::from_str(&format!("\"{resource_kbs_uri}\""))?)
   | |         -^^^^^^^^^^^^ method not found in `KbsClient<Box<dyn TokenProvider>>`
   | |_________|
   |
   |
   = note: the full type name has been written to '/home/runner/work/trustee/trustee/target/debug/deps/kbs_client-b572fa785161aa52.long-type-1199874662950908608.txt'
   = note: consider using `--verbose` to print the full type name to the console

error[E0599]: no method named `get_resource` found for struct `KbsClient` in the current scope
Error:    --> tools/kbs-client/src/lib.rs:102:10
    |
101 |       let resource_bytes = client
    |  __________________________-
102 | |         .get_resource(serde_json::from_str(&format!("\"{resource_kbs_uri}\""))?)
    | |         -^^^^^^^^^^^^ method not found in `KbsClient<Box<dyn EvidenceProvider>>`
    | |_________|
    |
    |
    = note: the full type name has been written to '/home/runner/work/trustee/trustee/target/debug/deps/kbs_client-b572fa785161aa52.long-type-18165190474830539831.txt'
    = note: consider using `--verbose` to print the full type name to the console
```

sample_only feature is actually by default enabled by kbs_protocol crate, thus we do not need this feature explicitly in the code. But we still need this feature mark in the Makefile.

Remove the sample_only feature flag and make background_check and passport features the default behavior. Update build configurations and CI workflows accordingly.

Changes:
- Remove sample_only feature from kbs-client Cargo.toml
- Set kbs_protocol features directly in dependencies
- Update Makefile to handle CLI_FEATURES without sample_only default
- Update GitHub workflows to remove sample_only from build commands
- Update README documentation to reflect new default behavior