### PR TITLE
nvidia-verifier: use openssl crypto everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7007,7 +7007,6 @@ dependencies = [
  "kbs-types",
  "nvml-wrapper 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl",
- "p384",
  "reqwest 0.12.23",
  "rstest",
  "s390_pv",

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -27,7 +27,7 @@ csv-verifier = ["codicon", "csv-rs", "eventlog", "openssl", "tokio/fs"]
 hygon-dcu-verifier = ["csv-rs"]
 cca-verifier = ["ear", "jsonwebtoken", "veraison-apiclient", "ccatoken"]
 se-verifier = ["openssl", "pv", "serde_with", "tokio/sync"]
-nvidia-verifier = ["nvml-wrapper", "p384", "jsonwebtoken", "asn1-rs", "openssl", "x509-parser"]
+nvidia-verifier = ["nvml-wrapper", "jsonwebtoken", "asn1-rs", "openssl", "x509-parser"]
 tpm-verifier = ["az-cvm-vtpm", "openssl", "tss-esapi"]
 
 [dependencies]
@@ -84,7 +84,6 @@ time = "0.3.41"
 nvml-wrapper = { version = "0.11.0", optional = true, default-features = false, features = [
     "serde",
 ] }
-p384 = { version = "0.13.1", optional = true }
 tss-esapi = { version = "7.5", optional = true }
 
 [build-dependencies]


### PR DESCRIPTION
Verifiers use openssl crypto and nvidia-verifier already does that for certificate verification.

Move nvidia-verifier report signature check to use openssl as well to unify crypto libs usage and to get one dependency dropped from verifier crate.

Tested using: cargo test nvidia