### PR TITLE
dependabot: bump open-pull-requests-limit to 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
     allow:
       - dependency-type: direct
 


### PR DESCRIPTION
Currently, only one dependabot PR is allowed to be open at a time. A dependency that requires manual work can blocks other updates if it's not being worked on.

Bump open-pull-requests-limit to 3 to let dependabot to create parallel PRs and not get blocked.