### PR TITLE
Http server: configurable number of worker threads

### DIFF
--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -218,6 +218,8 @@ impl TestHarness {
                 certificate: None,
                 insecure_http: true,
                 payload_request_size: 2,
+                worker_count: Some(4),
+            
             },
             admin: admin_config,
             policy_engine: PolicyEngineConfig {

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -19,13 +19,14 @@ The following sections list the KBS properties which can be set through the conf
 
 The following properties can be set under the `[http_server]` section.
 
-| Property               | Type         | Description                                      | Required | Default              |
-|------------------------|--------------|--------------------------------------------------|----------|----------------------|
-| `sockets`              | String array | One or more sockets to listen on.                | No       | `["127.0.0.1:8080"]` |
-| `insecure_http`        | Boolean      | Don't use TLS for the KBS HTTP endpoint.         | No       | `false`              |
-| `private_key`          | String       | Path to a private key file to be used for HTTPS. | No       | None                 |
-| `certificate`          | String       | Path to a certificate file to be used for HTTPS. | No       | None                 |
-| `payload_request_size` | Integer      | Request payload size in mega bytes.              | No       | 2                    |
+| Property               | Type         | Description                                      |  Required | Default                  |
+|------------------------|--------------|--------------------------------------------------|----------|--------------------------|
+| `sockets`              | String array | One or more sockets to listen on.                | No       | `["127.0.0.1:8080"]`     |
+| `insecure_http`        | Boolean      | Don't use TLS for the KBS HTTP endpoint.         | No       | `false`                  |
+| `private_key`          | String       | Path to a private key file to be used for HTTPS. | No       | None                     |
+| `certificate`          | String       | Path to a certificate file to be used for HTTPS. | No       | None                     |
+| `payload_request_size` | Integer      | Request payload size in mega bytes.              | No       | 2                        |
+| `worker_count`         | Integer      | Number of HTTP actix worker threads              | No       | Num of logical CPU cores |
 
 ### Attestation Token Configuration
 

--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -114,7 +114,7 @@ impl ApiServer {
         let http_config = self.config.http_server.clone();
 
         #[allow(clippy::redundant_closure)]
-        let http_server = HttpServer::new({
+        let mut http_server = HttpServer::new({
             move || {
                 let api_server = self.clone();
                 App::new()
@@ -136,6 +136,10 @@ impl ApiServer {
                     )
             }
         });
+
+        if let Some(worker_count) = http_config.worker_count {
+            http_server = http_server.workers(worker_count);
+        }
 
         if !http_config.insecure_http {
             let tls_server = http_server

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -35,6 +35,10 @@ pub struct HttpServerConfig {
 
     /// Request payload size in MB
     pub payload_request_size: u32,
+
+    /// Number of worker threads for the actix-web server.
+    /// If not specified, defaults to the number of logical CPU cores.
+    pub worker_count: Option<usize>,
 }
 
 impl Default for HttpServerConfig {
@@ -45,6 +49,7 @@ impl Default for HttpServerConfig {
             certificate: None,
             insecure_http: DEFAULT_INSECURE_HTTP,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
+            worker_count: None,
         }
     }
 }
@@ -160,6 +165,7 @@ mod tests {
             certificate: Some("/etc/kbs-cert.pem".into()),
             insecure_http: false,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
+            worker_count: None,
         },
         admin: AdminConfig {
             admin_backend: AdminBackendType::DenyAll,
@@ -209,6 +215,7 @@ mod tests {
             certificate: None,
             insecure_http: DEFAULT_INSECURE_HTTP,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
+            worker_count: None,
         },
         admin: AdminConfig {
             admin_backend: AdminBackendType::DenyAll,
@@ -245,6 +252,7 @@ mod tests {
             certificate: Some("/etc/kbs-cert.pem".into()),
             insecure_http: false,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
+            worker_count: None,
         },
         admin: AdminConfig {
             admin_backend: AdminBackendType::DenyAll,
@@ -282,6 +290,7 @@ mod tests {
             certificate: None,
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
+            worker_count: None,
         },
         admin: AdminConfig {
             admin_backend: AdminBackendType::Simple(SimpleAdminConfig {
@@ -328,6 +337,7 @@ mod tests {
             certificate: None,
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
+            worker_count: None,
         },
         admin: AdminConfig {
             admin_backend: AdminBackendType::InsecureAllowAll,
@@ -362,6 +372,7 @@ mod tests {
             certificate: None,
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
+            worker_count: None,
         },
         admin: AdminConfig {
             admin_backend: AdminBackendType::DenyAll,


### PR DESCRIPTION
Added `worker_count` attribute to the trustee `http_server` section for specifying the number of worker threads.
If not provided, defaults to the logical number of logical CPU cores

Fixes #1036