### PR TITLE
feat(ci): add kbs-client-features to Azure vTPM e2e tests

### DIFF
--- a/.github/workflows/kbs-e2e-azure-vtpm.yml
+++ b/.github/workflows/kbs-e2e-azure-vtpm.yml
@@ -38,6 +38,7 @@ jobs:
       runs-on-test: '["self-hosted","azure-cvm-tdx"]'
       tee: az-tdx-vtpm
       tarball: kbs.tar.gz
+      kbs-client-features: az-tdx-vtpm-attester
 
   snp-e2e-test:
     needs:
@@ -50,3 +51,4 @@ jobs:
       runs-on-test: '["self-hosted","azure-cvm"]'
       tee: az-snp-vtpm
       tarball: kbs.tar.gz
+      kbs-client-features: az-snp-vtpm-attester


### PR DESCRIPTION
Add kbs-client-features parameter to both TDX and SNP e2e test jobs in the Azure vTPM workflow:
- az-tdx-vtpm-e2e-test: az-tdx-vtpm-attester
- snp-e2e-test: az-snp-vtpm-attester

This ensures the correct client features are used for each TEE type during the e2e test execution.

Fixes #1041 

cc @mkulke 