### PR TITLE
config: Update invalid admin type

### DIFF
--- a/kbs/config/kbs-config.toml
+++ b/kbs/config/kbs-config.toml
@@ -2,8 +2,7 @@
 insecure_http = true
 
 [attestation_token]
-# Do not use this in production.
-type = "InsecureAllowAll"
+insecure_key = true
 
 [attestation_service]
 type = "coco_as_builtin"
@@ -21,7 +20,8 @@ type = "BuiltIn"
 policy_path = "/opa/confidential-containers/kbs/policy.rego"
 
 [admin]
-insecure_api = true
+# Do not use this in production.
+type = "InsecureAllowAll"
 
 [[plugins]]
 name = "resource"


### PR DESCRIPTION
`insecure_key` is not valid for [admin] any more. It seems #1014 changed a wrong value in `kbs/config/kbs-config.toml`. 
If someone tried the file, he/she will face the following error and KBS fails to start:

```
Error: invalid config: missing configuration field "admin.type"
```

This PR updates the type properly and restores the value for [attestation_token].

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>