### PR TITLE
snp-verifier: http_cache_reqwest to cache vceks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2247,6 +2258,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eventlog"
 version = "0.1.0"
 dependencies = [
@@ -2779,6 +2800,61 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-cache"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1437561a949a2168929d7559aecd2f0ecb18b9e676080396388cdc399ddb723a"
+dependencies = [
+ "async-trait",
+ "bincode 1.3.3",
+ "http 1.3.1",
+ "http-cache-semantics",
+ "httpdate",
+ "moka",
+ "serde",
+ "url",
+]
+
+[[package]]
+name = "http-cache-reqwest"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccca775a066b2a65da33611921e078ebdcfc27065c8bee96794703541101886"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.3.1",
+ "http-cache",
+ "http-cache-semantics",
+ "reqwest 0.12.26",
+ "reqwest-middleware",
+ "serde",
+ "url",
+]
+
+[[package]]
+name = "http-cache-semantics"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92baf25cf0b8c9246baecf3a444546360a97b569168fdf92563ee6a47829920c"
+dependencies = [
+ "http 1.3.1",
+ "http-serde",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http 1.3.1",
+ "serde",
 ]
 
 [[package]]
@@ -3818,6 +3894,27 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8261cd88c312e0004c1d51baad2980c66528dfdb2bee62003e643a4d8f86b077"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot 0.12.5",
+ "portable-atomic",
+ "rustc_version",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -5277,6 +5374,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.3.1",
+ "reqwest 0.12.26",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
 name = "resource_uri"
 version = "0.1.0"
 source = "git+https://github.com/confidential-containers/guest-components.git?rev=7be23a1#7be23a14e468a29cb0d0167671b927a609cbe05d"
@@ -6500,6 +6612,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7358,6 +7476,7 @@ dependencies = [
  "env_logger",
  "eventlog",
  "hex",
+ "http-cache-reqwest",
  "intel-tee-quote-verification-rs",
  "jsonwebkey 0.4.0",
  "jsonwebtoken 10.2.0",
@@ -7365,6 +7484,7 @@ dependencies = [
  "nvml-wrapper 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl",
  "reqwest 0.12.26",
+ "reqwest-middleware",
  "rstest",
  "s390_pv",
  "scroll",

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -80,6 +80,8 @@ ccatoken = { git = "https://github.com/veraison/rust-ccatoken", rev = "6d5b8db",
 ear = { version = "0.4.0", optional = true }
 x509-parser = { version = "0.18.0", optional = true }
 reqwest.workspace = true
+reqwest-middleware = "0.4.2"
+http-cache-reqwest = { version = "0.16.0", default-features = false, features = ["manager-moka"] }
 bitflags = { version = "2.10.0", features = ["serde"] }
 time = "0.3.41"
 nvml-wrapper = { version = "0.11.0", optional = true, default-features = false, features = [


### PR DESCRIPTION
Use http_cache_reqwest to cache VCEKs. After review comments, this PR will cover only an in-memory performance cache, with a filesystem persistent cache to be added in a follow-up PR. 

---
Initial PR description:

> Support configuration option in snp verifier to use http_cache_reqwest to cache VCEKs. This allows users to pre-load them for offline environments if desired. Add tool to convert VCEK URLs to cache contents.
> 
> Follow up from https://github.com/confidential-containers/trustee/pull/989, implementing suggestion https://github.com/confidential-containers/trustee/pull/989#issuecomment-3400679521
> 
> Notes:
> - Main doc describing implementation: https://github.com/amd-aliem/trustee/blob/amd-cert-cache/attestation-service/docs/amd-offline-certificate-cache.md
> - Having this as an opt-in, despite performance benefits even in normal online situations. Reasoning is that I'm not 100% sure http_cache_reqwest ever evicts elements, and in default caching mode it appeared to only keep cache contents valid on the same request. Worried it will take up non-negligible disk space over time. 
> - Currently this new doc only describes how to enable w/ docker. Plan to add k8s operator instructions in the future but I haven't figured out how to test local changes w/ that yet.