### PR TITLE
Intel dcap github address update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "intel-tee-quote-verification-rs"
 version = "0.3.0"
-source = "git+https://github.com/intel/SGXDataCenterAttestationPrimitives?tag=DCAP_1.23#e880e54c8f35d44a4763e08dff32a046c8ef2230"
+source = "git+https://github.com/intel/confidential-computing.tee.dcap?tag=DCAP_1.23#e880e54c8f35d44a4763e08dff32a046c8ef2230"
 dependencies = [
  "intel-tee-quote-verification-sys",
 ]

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -73,7 +73,7 @@ sev = { git = "https://github.com/virtee/sev", rev = "d487809188c3c92e397bc92e2c
 sha2.workspace = true
 tokio = { workspace = true, optional = true }
 tracing.workspace = true
-intel-tee-quote-verification-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", tag = "DCAP_1.23", optional = true }
+intel-tee-quote-verification-rs = { git = "https://github.com/intel/confidential-computing.tee.dcap", tag = "DCAP_1.23", optional = true }
 strum.workspace = true
 veraison-apiclient = { git = "https://github.com/veraison/rust-apiclient", rev = "fe149cd", optional = true }
 ccatoken = { git = "https://github.com/veraison/rust-ccatoken", rev = "6d5b8db", optional = true }

--- a/deps/verifier/src/tdx/quote.rs
+++ b/deps/verifier/src/tdx/quote.rs
@@ -264,7 +264,7 @@ pub enum Quote {
     /// First 632 bytes of TD Quote
     /// Excluding the signature data attached at the end of the Quote.
     ///
-    /// Refer to: https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/master/QuoteGeneration/quote_wrapper/common/inc/sgx_quote_4.h#L141
+    /// Refer to: https://github.com/intel/confidential-computing.tee.dcap/blob/main/QuoteGeneration/quote_wrapper/common/inc/sgx_quote_4.h#L141
     V4 {
         header: QuoteHeader,
         body: ReportBody2,
@@ -274,7 +274,7 @@ pub enum Quote {
     /// First 638 bytes of TD Quote
     /// Excluding the signature data attached at the end of the Quote.
     ///
-    /// Refer to: https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/master/QuoteGeneration/quote_wrapper/common/inc/sgx_quote_5.h#L106
+    /// Refer to: https://github.com/intel/confidential-computing.tee.dcap/blob/main/QuoteGeneration/quote_wrapper/common/inc/sgx_quote_5.h#L106
     V5 {
         header: QuoteHeader,
         r#type: QuoteV5Type,
@@ -424,7 +424,7 @@ mod tests {
     /// ```
     ///
     /// The manual modification upon `sgx_default_qcnl.conf` could be promoted after
-    /// https://github.com/intel/SGXDataCenterAttestationPrimitives/issues/409 is resolved.
+    /// https://github.com/intel/confidential-computing.tee.dcap/issues/409 is resolved.
     ///
     /// Finally, DCAP only provides packages on x86-64 platform, thus we only test this on x86-64
     /// platforms.


### PR DESCRIPTION
Updated legacy naming for SGXDataCenterAttestationPrimitives to currently used one.