### PR TITLE
verifier/nvidia: update tcb claims document link

### DIFF
--- a/attestation-service/docs/tcb_claims.md
+++ b/attestation-service/docs/tcb_claims.md
@@ -164,7 +164,7 @@ The local verifier only supports Hopper and returns the following claims.
 - `config.protected_pcie_status`: Protected PCIe status
 - `config.vbios_version`: Device VBIOS version
 
-The remote verifier exports the claims that come from NRAS, which are listed [here](https://github.com/NVIDIA/nvtrust/blob/main/guest_tools/attestation_troubleshooting_guide.md#version-30).
+The remote verifier exports the claims that come from NRAS, which are listed [here](https://docs.nvidia.com/attestation/advanced-documentation/latest/claims-guide/gpu_claims.html).
 Claims version 3 is used. The `x-nvidia-overall-att-result` from the overall claims is included
 along with the full set of detached claims.
 


### PR DESCRIPTION
The original link on github has been removed and the new one is on the official page.

There is another link for [nras license](https://github.com/confidential-containers/trustee/blob/main/deps/verifier/src/nvidia/README.md) which is also 404 which is not covered in this PR

CC @fitzthum could you help to take a look? Please feel free to force-push on this PR or open another fix PR if needed.