### PR TITLE
Replace derivative dependency with educe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,17 +1861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,6 +2084,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2131,6 +2132,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3364,7 +3385,7 @@ dependencies = [
  "concat-kdf",
  "config",
  "cryptoki",
- "derivative",
+ "educe",
  "env_logger",
  "hex",
  "josekit",
@@ -3472,7 +3493,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
- "derivative",
+ "educe",
  "pg-connection-string",
  "rstest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ cfg-if = "1.0.4"
 chrono = "0.4.41"
 clap = { version = "4", features = ["derive"] }
 config = "0.15.19"
-derivative = "2.2.0"
+educe = "0.6"
 ear = { git = "https://github.com/veraison/rust-ear.git", rev = "3d5fa46" }
 env_logger = "0.11.8"
 hex = "0.4.3"

--- a/deps/key-value-storage/Cargo.toml
+++ b/deps/key-value-storage/Cargo.toml
@@ -12,7 +12,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 pg-connection-string = { version = "0.0.2", optional = true }
-derivative.workspace = true
+educe.workspace = true
 serde.workspace = true
 sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio"], optional = true }
 thiserror.workspace = true

--- a/deps/key-value-storage/src/postgres/mod.rs
+++ b/deps/key-value-storage/src/postgres/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use sqlx::PgPool;
 use sqlx::{postgres::PgPoolOptions, query, Row};
@@ -30,8 +30,8 @@ pub const VALUE_COLUMN: &str = "value";
 /// The environment variable name for the PostgreSQL URL.
 pub const POSTGRES_URL_ENV_VAR: &str = "POSTGRES_URL";
 
-#[derive(Deserialize, Derivative, Clone, PartialEq)]
-#[derivative(Debug)]
+#[derive(Deserialize, Educe, Clone, PartialEq)]
+#[educe(Debug)]
 #[serde(default)]
 pub struct Config {
     /// The name of the PostgreSQL database.
@@ -41,7 +41,7 @@ pub struct Config {
     pub username: String,
 
     /// The password of the PostgreSQL database.
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub password: Option<String>,
 
     /// The port of the PostgreSQL database.

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -54,7 +54,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 config.workspace = true
 concat-kdf = "0.1.0"
 cryptoki = { version = "0.10.0", optional = true }
-derivative.workspace = true
+educe.workspace = true
 env_logger.workspace = true
 hex.workspace = true
 jsonwebtoken = { workspace = true, default-features = false }

--- a/kbs/src/attestation/intel_trust_authority/mod.rs
+++ b/kbs/src/attestation/intel_trust_authority/mod.rs
@@ -10,7 +10,7 @@ use anyhow::*;
 use async_trait::async_trait;
 use az_cvm_vtpm::hcl::HclReport;
 use base64::{engine::general_purpose::STANDARD, Engine};
-use derivative::Derivative;
+use educe::Educe;
 use kbs_types::{Challenge, HashAlgorithm, Tee};
 use reqwest::header::{ACCEPT, CONTENT_TYPE, USER_AGENT};
 use serde::{Deserialize, Serialize};
@@ -83,11 +83,11 @@ struct ErrorResponse {
     error: String,
 }
 
-#[derive(Clone, Derivative, Deserialize, PartialEq, Default)]
-#[derivative(Debug)]
+#[derive(Clone, Educe, Deserialize, PartialEq, Default)]
+#[educe(Debug)]
 pub struct IntelTrustAuthorityConfig {
     pub base_url: String,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub api_key: String,
     pub certs_file: String,
     pub allow_unmatched_policy: Option<bool>,

--- a/kbs/src/plugins/implementations/pkcs11.rs
+++ b/kbs/src/plugins/implementations/pkcs11.rs
@@ -21,7 +21,7 @@ use cryptoki::{
     session::{Session, UserType},
     types::AuthPin,
 };
-use derivative::Derivative;
+use educe::Educe;
 use serde::Deserialize;
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::Mutex;
@@ -29,8 +29,8 @@ use tokio::sync::Mutex;
 use super::super::plugin_manager::ClientPlugin;
 
 /// Enum representing supported RSA mechanisms.
-#[derive(Derivative, Deserialize, Clone, PartialEq, Default)]
-#[derivative(Debug)]
+#[derive(Educe, Deserialize, Clone, PartialEq, Default)]
+#[educe(Debug)]
 pub enum RsaMechanism {
     /// RSA mechanism using PKCS#1 OAEP MGF1_SHA256 padding. Recommended for secure production use.
     #[default]
@@ -60,8 +60,8 @@ impl RsaMechanism {
     }
 }
 
-#[derive(Derivative, Deserialize, Clone, PartialEq)]
-#[derivative(Debug)]
+#[derive(Educe, Deserialize, Clone, PartialEq)]
+#[educe(Debug)]
 pub struct Pkcs11Config {
     /// Path to the PKCS11 module.
     module: PathBuf,
@@ -71,7 +71,7 @@ pub struct Pkcs11Config {
     slot_index: u8,
 
     /// The user pin for authenticating the session.
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pin: String,
 
     /// RSA mechanism to use.

--- a/kbs/src/plugins/implementations/resource/aliyun_kms.rs
+++ b/kbs/src/plugins/implementations/resource/aliyun_kms.rs
@@ -4,18 +4,18 @@
 
 use super::backend::{ResourceDesc, StorageBackend};
 use anyhow::{Context, Result};
-use derivative::Derivative;
+use educe::Educe;
 use kms::{plugins::aliyun::AliyunKmsClient, Annotations, Getter};
 use log::info;
 use serde::Deserialize;
 
-#[derive(Derivative, Deserialize, Clone, PartialEq)]
-#[derivative(Debug)]
+#[derive(Educe, Deserialize, Clone, PartialEq)]
+#[educe(Debug)]
 pub struct AliyunKmsBackendConfig {
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     client_key: String,
     kms_instance_id: String,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     password: String,
     cert_pem: String,
 }

--- a/kbs/src/plugins/implementations/resource/vault_kv.rs
+++ b/kbs/src/plugins/implementations/resource/vault_kv.rs
@@ -4,7 +4,7 @@
 
 use super::backend::{ResourceDesc, StorageBackend};
 use anyhow::{Context, Result};
-use derivative::Derivative;
+use educe::Educe;
 use log::info;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -28,11 +28,11 @@ pub enum VaultError {
     VaultApiError { path: String, source: anyhow::Error },
 }
 
-#[derive(Derivative, Deserialize, Clone, PartialEq)]
-#[derivative(Debug)]
+#[derive(Educe, Deserialize, Clone, PartialEq)]
+#[educe(Debug)]
 pub struct VaultKvBackendConfig {
     pub vault_url: String,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub token: String,
     #[serde(default = "default_mount_path")]
     pub mount_path: String,


### PR DESCRIPTION
This commit replaces the usage of the derivative crate with educe across the entire workspace. The derivative crate is no longer actively maintained [1] (upstream is effectively dead - distros prefer not to ship unmaintained dependencies), whereas educe provides a modern, maintained, and feature-rich alternative for deriving traits with custom behavior. This does not affect the functionality.

https://github.com/mcarton/rust-derivative/issues/117 