### PR TITLE
verifier: update link to NVIDIA license

### DIFF
--- a/deps/verifier/src/nvidia/README.md
+++ b/deps/verifier/src/nvidia/README.md
@@ -7,7 +7,7 @@ The policy can then compare these measurements with reference values.
 
 The `remote` verifier uses the NVIDIA NRAS service to validate the evidence.
 To use this, the user should first enter into a licensing agreement with NVIDIA.
-The agreement is described [here](https://docs.nvidia.com/attestation/technical-docs-nras/latest/nras_license.html)
+The agreement is described [here](https://docs.nvidia.com/attestation/cloud-services/latest/license.html)
 and has provisions for research and development.
 When the `remote` verifier is enabled, NRAS handles evaluating the evidence
 against reference values.


### PR DESCRIPTION
The license for NVIDIA attestation offerings has moved. Update the link.

Fixes #1085