### PR TITLE
Fix kbs Makefile, FEATURES variable may contain spaces

### DIFF
--- a/.github/workflows/kbs-rust.yml
+++ b/.github/workflows/kbs-rust.yml
@@ -70,6 +70,18 @@ jobs:
       working-directory: kbs
       run: make AS_TYPE=intel-trust-authority-as
 
+    - name: KBS Build [background-check-kbs with ALIYUN, NEBULA_CA_PLUGIN, VAULT]
+      working-directory: kbs
+      run: make background-check-kbs ALIYUN=true NEBULA_CA_PLUGIN=true VAULT=true
+
+    - name: KBS Build [passport-issuer-kbs with ALIYUN, NEBULA_CA_PLUGIN, VAULT]
+      working-directory: kbs
+      run: make passport-issuer-kbs ALIYUN=true NEBULA_CA_PLUGIN=true VAULT=true
+
+    - name: KBS Build [passport-resource-kbs with ALIYUN, NEBULA_CA_PLUGIN, VAULT]
+      working-directory: kbs
+      run: make passport-resource-kbs ALIYUN=true NEBULA_CA_PLUGIN=true VAULT=true
+
     - name: Lint
       working-directory: kbs
       run: make lint TEST_FEATURES=${{ matrix.test_features }}

--- a/kbs/Makefile
+++ b/kbs/Makefile
@@ -43,21 +43,21 @@ COCO_AS_INTEGRATION_TYPE ?= builtin
 INSTALL_DESTDIR ?= /usr/local/bin
 
 ifeq ($(AS_TYPE), coco-as)
-  AS_FEATURE += $(AS_TYPE)-$(COCO_AS_INTEGRATION_TYPE),
+  AS_FEATURE := $(AS_TYPE)-$(COCO_AS_INTEGRATION_TYPE)
 else ifneq ($(AS_TYPE), )
-  AS_FEATURE += $(AS_TYPE),
+  AS_FEATURE := $(AS_TYPE)
 endif
 
 ifeq ($(ALIYUN), true)
-  FEATURES += aliyun
+  FEATURES := $(FEATURES),aliyun
 endif
 
 ifeq ($(NEBULA_CA_PLUGIN), true)
-  FEATURES += nebula-ca-plugin
+  FEATURES := $(FEATURES),nebula-ca-plugin
 endif
 
 ifeq ($(VAULT), true)
-  FEATURES += vault
+  FEATURES := $(FEATURES),vault
 endif
 
 ifeq ($(CLI_FEATURES),sample_only)
@@ -76,7 +76,7 @@ build: background-check-kbs
 
 .PHONY: background-check-kbs
 background-check-kbs:
-	$(CARGO_ENV) cargo build -p kbs --locked --release --no-default-features --features $(FEATURES),$(AS_FEATURE) $(TARGET_FLAG)
+	$(CARGO_ENV) cargo build -p kbs --locked --release --no-default-features --features $(AS_FEATURE),$(FEATURES) $(TARGET_FLAG)
 
 .PHONY: passport-issuer-kbs
 passport-issuer-kbs:


### PR DESCRIPTION
In Makefile, the += operator will add an extra space. The spaces in the FEATURES variable causes cargo build to fail. Just use FEATURES := $(FEATURES),xxx instead.

CI add different KBS build cases to test Makefile.