### PR TITLE
deps/key-value-storage: fix lint warning about needless borrow

### DIFF
--- a/deps/key-value-storage/src/local_json/mod.rs
+++ b/deps/key-value-storage/src/local_json/mod.rs
@@ -80,7 +80,7 @@ impl KeyValueStorage for LocalJson {
         })?;
         let mut items: HashMap<String, String> = serde_json::from_slice(&file)
             .map_err(|e| KeyValueStorageError::MalformedValue { source: e.into() })?;
-        let value_b64 = URL_SAFE.encode(&value);
+        let value_b64 = URL_SAFE.encode(value);
         if parameters.overwrite && items.contains_key(key) {
             return Err(KeyValueStorageError::SetKeyFailed {
                 source: anyhow::anyhow!("key already exists"),


### PR DESCRIPTION
```
Error:   --> deps/key-value-storage/src/local_json/mod.rs:83:41
   |
83 |         let value_b64 = URL_SAFE.encode(&value);
   |                                         ^^^^^^ help: change this to: `value`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
   = note: `-D clippy::needless-borrows-for-generic-args` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_borrows_for_generic_args)]`
```