### PR TITLE
tests: fix intermittent test failure (maybe)

### DIFF
--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -45,7 +45,7 @@ use tonic::transport::Server;
 
 const KBS_URL: &str = "http://127.0.0.1:8081";
 const RVPS_URL: &str = "http://127.0.0.1:51003";
-const WAIT_TIME: u64 = 10000;
+const WAIT_TIME: u64 = 5000;
 
 const ALLOW_ALL_POLICY: &str = "
     package policy
@@ -178,6 +178,10 @@ impl TestHarness {
                     .serve("127.0.0.1:51003".parse()?);
 
                 tokio::spawn(rvps_future);
+
+                // Wait for rvps to start
+                let duration = tokio::time::Duration::from_millis(WAIT_TIME);
+                tokio::time::sleep(duration).await;
 
                 RvpsConfig::GrpcRemote(RvpsRemoteConfig {
                     address: RVPS_URL.to_string(),


### PR DESCRIPTION
We have faced intermittent failures in the integration tests for a while.

In the logs there is sometimes a mention of the attestation service tcp connection failing. Previously I had tried increasing the test wait time to give everything a chance to start. This did not fix the problem.

Thinking about it more deeply, we don't actually use a remote attestation service in the integration tests, so this isn't an issue connecting to the attestation service. Instead the logging could mean that the AS is unable to connect to the RVPS.

Looking at the logs, it seems like these errors might only happen when we are using a remote RVPS.

The timeout that I had increased previously comes after everything has been setup. Let's add another one right after we start the RVPS, but before we start the KBS (with built-in AS).