### PR TITLE
rvps: add reference value uuid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5223,6 +5223,7 @@ dependencies = [
  "tonic 0.14.2",
  "tonic-prost",
  "tonic-prost-build",
+ "uuid",
  "walkdir",
 ]
 

--- a/rvps/Cargo.toml
+++ b/rvps/Cargo.toml
@@ -44,6 +44,7 @@ tempfile.workspace = true
 tokio.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
+uuid = { version = "1", features = ["v4", "serde"] }
 
 [build-dependencies]
 shadow-rs.workspace = true


### PR DESCRIPTION
We use names to identify reference values, but this doesn't capture a particular instance of a reference value. For example, a reference value name might be "firmware_hash", but there could be many reference values with this name. Even if the name is more specific (i.e. includes a version) this is still capturing the target context of the reference value (as in what it represents in the TCB) rather than the source instance.

As such, let's introduce an rv id to uniquely identify an rv instance. To begin with, this doesn't really do anything, but in the future we can generate reference value reports that capture exactly which rv instances were used to validate a guest.

To support backwards compatibility, create a new UUID when deserializing an RV that doesn't have one. Still, update the RV version.