### PR TITLE
verifier: dcap: fix tcb_eval_num claim

### DIFF
--- a/deps/verifier/src/intel_dcap/claims.rs
+++ b/deps/verifier/src/intel_dcap/claims.rs
@@ -67,7 +67,7 @@ pub(crate) fn prepare_custom_claims_map(
     );
     claims_map.insert(
         "tcb_eval_num".to_string(),
-        Value::from(Number::from(supp_data.root_ca_crl_num)),
+        Value::from(Number::from(supp_data.tcb_eval_ref_num)),
     );
     claims_map.insert(
         "platform_provider_id".to_string(),


### PR DESCRIPTION
tcb_eval_num claim used wrong supplemental data entry. The correct source is tcb_eval_ref_num.