### PR TITLE
Revert "tools: drop verifier dependencies from trustee-cli image"

### DIFF
--- a/tools/trustee-cli/Dockerfile
+++ b/tools/trustee-cli/Dockerfile
@@ -19,7 +19,7 @@ RUN if [ "${ARCH}" = "aarch64" ]; then apt-get install -y libc-bin; fi
 
 RUN if [ "${ARCH}" = "x86_64" ]; then curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
     gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
-    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | \
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu noble main' | \
     tee /etc/apt/sources.list.d/intel-sgx.list; fi && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -56,7 +56,7 @@ RUN apt-get update && \
     gnupg-agent && \
     if [ "${ARCH}" = "x86_64" ]; then curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
     gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
-    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu noble main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     libsgx-dcap-default-qpl \


### PR DESCRIPTION
It turns out we need these deps for the trustee-cli because the trustee-cli actually depends on the verifiers (trustee-cli can spin up a full trustee as a process, including the verifiers). This should unbreak the trustee-cli post-merge test.

Fixes: https://github.com/confidential-containers/trustee/issues/1160

cc @mythi 

This reverts commit 9abce393febd42c811ee69c4ec1da5b992888d81.