### PR TITLE
verifier: bump az-{snp,tdx}-vtpm crates to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,8 +813,9 @@ dependencies = [
 
 [[package]]
 name = "az-cvm-vtpm"
-version = "0.8.0"
-source = "git+https://github.com/kinvolk/azure-cvm-tooling?rev=83cd2a3#83cd2a37b56904495138c02160c22c3b5cae1857"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de89af1208d16b05ef093680a32a6d8e4dce9146caf30ae6aa6181777907285a"
 dependencies = [
  "jsonwebkey 0.3.5",
  "memoffset",
@@ -841,21 +842,22 @@ dependencies = [
  "serde",
  "sev 6.3.1",
  "thiserror 2.0.17",
- "ureq",
+ "ureq 2.12.1",
 ]
 
 [[package]]
 name = "az-snp-vtpm"
-version = "0.8.0"
-source = "git+https://github.com/kinvolk/azure-cvm-tooling?rev=83cd2a3#83cd2a37b56904495138c02160c22c3b5cae1857"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3d6071c96b6306e616d98ff18b8f13de2b55f16f494094f16e22f26d985311"
 dependencies = [
- "az-cvm-vtpm 0.8.0",
+ "az-cvm-vtpm 0.8.1",
  "clap",
  "openssl",
  "serde",
  "sev 7.1.0",
  "thiserror 2.0.17",
- "ureq",
+ "ureq 3.2.0",
 ]
 
 [[package]]
@@ -870,21 +872,22 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
- "ureq",
+ "ureq 2.12.1",
  "zerocopy 0.8.27",
 ]
 
 [[package]]
 name = "az-tdx-vtpm"
-version = "0.8.0"
-source = "git+https://github.com/kinvolk/azure-cvm-tooling?rev=83cd2a3#83cd2a37b56904495138c02160c22c3b5cae1857"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68381aac2d985b3482b67aa9766b0a5c97afcb7e794815871b824d7766cca56b"
 dependencies = [
- "az-cvm-vtpm 0.8.0",
+ "az-cvm-vtpm 0.8.1",
  "base64-url",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
- "ureq",
+ "ureq 3.2.0",
  "zerocopy 0.8.27",
 ]
 
@@ -1495,6 +1498,7 @@ dependencies = [
  "cookie 0.18.1",
  "document-features",
  "idna",
+ "indexmap 2.12.0",
  "log",
  "publicsuffix",
  "serde",
@@ -2975,7 +2979,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.4",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3512,7 +3516,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "attestation-service",
- "az-cvm-vtpm 0.8.0",
+ "az-cvm-vtpm 0.8.1",
  "base64 0.22.1",
  "cfg-if",
  "chrono",
@@ -5418,7 +5422,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.4",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5650,7 +5654,6 @@ version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -7388,12 +7391,41 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "once_cell",
- "rustls",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "url",
- "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+dependencies = [
+ "base64 0.22.1",
+ "cookie_store",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf-8",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.3.1",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -7407,6 +7439,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -7488,9 +7526,9 @@ dependencies = [
  "asn1-rs",
  "assert-json-diff",
  "async-trait",
- "az-cvm-vtpm 0.8.0",
- "az-snp-vtpm 0.8.0",
- "az-tdx-vtpm 0.8.0",
+ "az-cvm-vtpm 0.8.1",
+ "az-snp-vtpm 0.8.1",
+ "az-tdx-vtpm 0.8.1",
  "base64 0.22.1",
  "bincode 1.3.3",
  "bitflags 2.10.0",
@@ -7670,12 +7708,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.11"
+name = "webpki-root-certs"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
- "webpki-roots 1.0.4",
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,4 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 [patch.crates-io]
-az-snp-vtpm = { git = "https://github.com/kinvolk/azure-cvm-tooling", rev = "83cd2a3" }
-az-tdx-vtpm = { git = "https://github.com/kinvolk/azure-cvm-tooling", rev = "83cd2a3" }
-az-cvm-vtpm = { git = "https://github.com/kinvolk/azure-cvm-tooling", rev = "83cd2a3" }
 sev = { git = "https://github.com/virtee/sev", rev = "d487809188c3c92e397bc92e2cb2a85eb982c980" }

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -35,13 +35,13 @@ anyhow.workspace = true
 thiserror.workspace = true
 asn1-rs = { version = "0.7.1", optional = true }
 async-trait.workspace = true
-az-snp-vtpm = { version = "0.8.0", default-features = false, features = [
+az-snp-vtpm = { version = "0.8.1", default-features = false, features = [
     "verifier",
 ], optional = true }
-az-cvm-vtpm = { version = "0.8.0", default-features = false, features = [
+az-cvm-vtpm = { version = "0.8.1", default-features = false, features = [
     "verifier",
 ], optional = true }
-az-tdx-vtpm = { version = "0.8.0", default-features = false, features = [
+az-tdx-vtpm = { version = "0.8.1", default-features = false, features = [
     "verifier",
 ], optional = true }
 base64 = "0.22.1"

--- a/deps/verifier/src/az_snp_vtpm/mod.rs
+++ b/deps/verifier/src/az_snp_vtpm/mod.rs
@@ -132,7 +132,7 @@ impl Verifier for AzSnpVtpm {
             .context("Failed to deserialize Azure vTPM SEV-SNP evidence")?;
 
         let hcl_report = HclReport::new(evidence.hcl_report().into())?;
-        let tpm_quote = &evidence.tpm_quote()?;
+        let tpm_quote = &evidence.tpm_quote();
         verify_tpm_signature(tpm_quote, &hcl_report)?;
 
         verify_tpm_nonce(tpm_quote, expected_report_data)?;

--- a/deps/verifier/src/az_tdx_vtpm/compat.rs
+++ b/deps/verifier/src/az_tdx_vtpm/compat.rs
@@ -6,7 +6,6 @@
 //! Compatibility layer for legacy (v0) evidence format conversion.
 
 use super::super::az_snp_vtpm::TpmQuote;
-use anyhow::Result;
 use az_tdx_vtpm::vtpm::Quote;
 use serde::{Deserialize, Serialize};
 use serde_with::base64::{Base64, UrlSafe};
@@ -55,13 +54,10 @@ impl Evidence {
         }
     }
 
-    pub(super) fn tpm_quote(&self) -> Result<TpmQuote> {
+    pub(super) fn tpm_quote(&self) -> TpmQuote {
         match self {
-            Evidence::V0(v0) => {
-                let tpm_quote: TpmQuote = v0.tpm_quote.clone().try_into()?;
-                Ok(tpm_quote)
-            }
-            Evidence::V1(v1) => Ok(v1.tpm_quote.clone()),
+            Evidence::V0(v0) => v0.tpm_quote.clone().into(),
+            Evidence::V1(v1) => v1.tpm_quote.clone(),
         }
     }
 }

--- a/deps/verifier/src/az_tdx_vtpm/mod.rs
+++ b/deps/verifier/src/az_tdx_vtpm/mod.rs
@@ -47,7 +47,7 @@ impl Verifier for AzTdxVtpm {
             .context("Failed to deserialize Azure vTPM TDX evidence")?;
 
         let hcl_report = HclReport::new(evidence.hcl_report().into())?;
-        let tpm_quote = evidence.tpm_quote()?;
+        let tpm_quote = evidence.tpm_quote();
         verify_tpm_signature(&tpm_quote, &hcl_report)?;
 
         verify_tpm_nonce(&tpm_quote, expected_report_data)?;


### PR DESCRIPTION
This crate bump will make the global patch overrides not required any more because the new revision only depends on the `snp` feature in the sev crate, which unbreaks compilation on non x86_64 targets.

Other smaller changes:

- we can remove some nuisance json roundtripping, because the crate exposes the signature for a tpm quote
- we also verify the VCEK is valid at the time of verification.