### PR TITLE
ci: deactivate az e2e tests

### DIFF
--- a/.github/workflows/kbs-e2e-azure-vtpm.yml
+++ b/.github/workflows/kbs-e2e-azure-vtpm.yml
@@ -1,9 +1,11 @@
 name: KBS e2e (Azure vTPM TEE)
 
 on:
-  push:
-    branches:
-    - main
+  workflow_dispatch:
+# reactivate once we have a token that can add runners
+#   push:
+#     branches:
+#     - main
 
 permissions:
   contents: read


### PR DESCRIPTION
we're currently not able to provision a gh token that is able to register runners for this repository. disabling the tests for the time being to reduce the noise.