### PR TITLE
kbs: add missing cfg guard for coco-as-builtin import in tests

### DIFF
--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -136,6 +136,7 @@ mod tests {
         rvps::{grpc::RvpsRemoteConfig, RvpsConfig, RvpsCrateConfig},
     };
 
+    #[cfg(feature = "coco-as-builtin")]
     use reference_value_provider_service::storage::{local_fs, ReferenceValueStorageConfig};
 
     use rstest::rstest;


### PR DESCRIPTION
The `local_fs` and `ReferenceValueStorageConfig` imports in the config test module are only used by  `coco-as-builtin` test cases but were missing the corresponding `#[cfg(feature = "coco-as-builtin")]` guard, producing unused import warnings when building with other feature sets.
This is a cosmetic change. Does not affect functionality.