### PR TITLE
remove unused dependencies and consolidate workspace versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,6 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
 dependencies = [
- "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -596,14 +595,11 @@ dependencies = [
  "cfg-if",
  "clap",
  "ear 0.4.0 (git+https://github.com/veraison/rust-ear.git?rev=3d5fa46)",
- "futures",
  "hex",
  "jsonwebtoken 10.3.0",
  "kbs-types",
- "lazy_static",
  "openssl",
  "prost 0.14.3",
- "rand 0.8.5",
  "reference-value-provider-service",
  "regorus",
  "rsa",
@@ -3253,7 +3249,6 @@ dependencies = [
 name = "integration-tests"
 version = "0.1.0"
 dependencies = [
- "actix-rt",
  "actix-web",
  "anyhow",
  "attestation-service",
@@ -3561,7 +3556,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_qs",
  "serde_with",
  "serial_test",
  "sha2",
@@ -4772,7 +4766,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "strum",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -5267,7 +5260,6 @@ dependencies = [
  "assert-json-diff",
  "async-trait",
  "base64 0.22.1",
- "cfg-if",
  "chrono",
  "clap",
  "config",
@@ -5980,17 +5972,6 @@ dependencies = [
  "ryu",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3faaf9e727533a19351a43cc5a8de957372163c7d35cc48c90b75cdda13c352"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -7546,7 +7527,6 @@ dependencies = [
  "az-snp-vtpm 0.8.1",
  "az-tdx-vtpm 0.8.1",
  "base64 0.22.1",
- "bincode 1.3.3",
  "bitflags 2.10.0",
  "ccatoken",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,12 @@ tempfile = "3.24.0"
 tonic = "0.14"
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
+rand = "0.8.5"
+rsa = { version = "0.9.10", features = ["sha2"] }
+time = { version = "0.3.41", features = ["std"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
+uuid = { version = "1.21.0", features = ["v4"] }
 
 [patch.crates-io]
 sev = { git = "https://github.com/virtee/sev", rev = "d487809188c3c92e397bc92e2cb2a85eb982c980" }

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -43,17 +43,14 @@ canon-json = "0.2.1"
 cfg-if.workspace = true
 clap = { workspace = true, optional = true }
 ear.workspace = true
-futures = "0.3.17"
 hex.workspace = true
 jsonwebtoken.workspace = true
 kbs-types.workspace = true
-lazy_static.workspace = true
 openssl.workspace = true
 prost = { workspace = true, optional = true }
-rand = "0.8.5"
 reference-value-provider-service.path = "../rvps"
 regorus.workspace = true
-rsa = { version = "0.9.10", features = ["sha2"] }
+rsa.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_variant = "0.1.2"
@@ -61,7 +58,7 @@ sha2.workspace = true
 shadow-rs.workspace = true
 strum.workspace = true
 tempfile.workspace = true
-time = { version = "0.3.40", features = ["std"] }
+time.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true
@@ -69,7 +66,7 @@ tonic = { workspace = true, optional = true }
 tonic-prost = { workspace = true, optional = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true
-uuid = { version = "1.21.0", features = ["v4"] }
+uuid.workspace = true
 verifier = { path = "../deps/verifier", default-features = false }
 actix-cors = { version = "0.7", optional = true }
 

--- a/deps/policy-engine/Cargo.toml
+++ b/deps/policy-engine/Cargo.toml
@@ -16,7 +16,6 @@ regorus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -44,9 +44,8 @@ az-cvm-vtpm = { version = "0.8.1", default-features = false, features = [
 az-tdx-vtpm = { version = "0.8.1", default-features = false, features = [
     "verifier",
 ], optional = true }
-base64 = "0.22.1"
-bincode = "1.3.3"
-cfg-if = "1.0.4"
+base64.workspace = true
+cfg-if.workspace = true
 codicon = { version = "3.0", optional = true }
 csv-rs = { git = "https://github.com/openanolis/csv-rs", rev = "b67a07e", optional = true, default-features = false, features = [
     "network",
@@ -85,7 +84,7 @@ reqwest.workspace = true
 reqwest-middleware = "0.4.2"
 http-cache-reqwest = { version = "0.16.0", default-features = false, features = ["manager-moka"] }
 bitflags = { version = "2.10.0", features = ["serde"] }
-time = "0.3.41"
+time.workspace = true
 nvml-wrapper = { version = "0.11.0", optional = true, default-features = false, features = [
     "serde",
 ] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -11,7 +11,6 @@ kbs = { path = "../kbs" }
 reference-value-provider-service = { path = "../rvps" }
 
 actix-web.workspace = true
-actix-rt = "2.11.0"
 anyhow.workspace = true
 base64.workspace = true
 env_logger.workspace = true

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -68,13 +68,12 @@ p256 = { workspace = true, features = ["ecdh"] }
 p521 = { workspace = true, features = ["ecdh"] }
 prometheus = "0.14.0"
 prost = { workspace = true, optional = true }
-rand = "0.8.5"
+rand.workspace = true
 regex = "1.12.2"
 regorus.workspace = true
 reqwest = { workspace = true, features = ["json"] }
-rsa = { version = "0.9.10", features = ["sha2"] }
+rsa.workspace = true
 scc = "2"
-serde_qs.workspace = true
 semver = "1.0.16"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
@@ -83,11 +82,11 @@ sha2.workspace = true
 strum.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-time = { version = "0.3.40", features = ["std"] }
+time.workspace = true
 tokio.workspace = true
 tonic = { workspace = true, optional = true }
 tonic-prost = { workspace = true, optional = true }
-uuid = { version = "1.21.0", features = ["serde", "v4"] }
+uuid = { workspace = true, features = ["serde"] }
 openssl.workspace = true
 az-cvm-vtpm = { version = "0.8.0", default-features = false, optional = true }
 vaultrs = { version = "0.7.4", optional = true }
@@ -115,8 +114,8 @@ josekit = "0.10.3"
 tempfile.workspace = true
 rstest.workspace = true
 reference-value-provider-service.path = "../rvps"
-serial_test = "3.0"
-toml = "0.9"
+serial_test.workspace = true
+toml.workspace = true
 
 [build-dependencies]
 tonic-prost-build.workspace = true

--- a/kbs/src/admin/error.rs
+++ b/kbs/src/admin/error.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use log::error;
 use strum::AsRefStr;
 use thiserror::Error;
 

--- a/kbs/src/attestation/error.rs
+++ b/kbs/src/attestation/error.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use log::error;
 use strum::AsRefStr;
 use thiserror::Error;
 

--- a/kbs/src/policy_engine/error.rs
+++ b/kbs/src/policy_engine/error.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use log::error;
 use strum::AsRefStr;
 use thiserror::Error;
 

--- a/kbs/src/token/error.rs
+++ b/kbs/src/token/error.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use log::error;
 use strum::AsRefStr;
 use thiserror::Error;
 

--- a/rvps/Cargo.toml
+++ b/rvps/Cargo.toml
@@ -25,7 +25,6 @@ required-features = [ "bin" ]
 anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true
-cfg-if.workspace = true
 chrono = { workspace = true, features = [ "serde" ] }
 clap = { workspace = true, optional = true }
 config.workspace = true

--- a/tools/kbs-client/Cargo.toml
+++ b/tools/kbs-client/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true
-clap = { version = "4.5.59", features = ["derive"] }
+clap.workspace = true
 env_logger.workspace = true
 jwt-simple.workspace = true
 kbs_protocol = { workspace = true, default-features = false, features = ["background_check", "passport"] }


### PR DESCRIPTION
- Remove 4 unused dependencies (futures, rand from attestation-service, bincode from verifier, actix-rt from integration-tests)
- Consolidate base64, cfg-if, clap, serial_test, and toml to use workspace versions.
- Promote rsa, uuid, time, and rand to workspace-level dependencies for consistency across crates.
- Remove unused `use log::error` imports in kbs error modules.