### PR TITLE
ci: Ensure cmake is installed for kbs-client build

### DIFF
--- a/kbs/docker/kbs-client/Dockerfile
+++ b/kbs/docker/kbs-client/Dockerfile
@@ -4,7 +4,7 @@ ARG ARCH=x86_64
 WORKDIR /usr/src/kbs
 COPY . .
 
-RUN apt-get update && apt install -y pkg-config libssl-dev git sudo
+RUN apt-get update && apt install -y pkg-config libssl-dev git sudo cmake
 
 ENV OS_ARCH=${ARCH}
 RUN if [ $(uname -m) != ${ARCH} ]; then \


### PR DESCRIPTION
The following error occurred on s390x during `cargo build` for kbs-client:

```
  --- stderr
  Missing dependency: cmake
```

Install the package explicitly for all architectures.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>