### PR TITLE
ci: Ensure cmake is installed for kbs-client-image build

### DIFF
--- a/kbs/docker/kbs-client-image/Dockerfile
+++ b/kbs/docker/kbs-client-image/Dockerfile
@@ -5,7 +5,7 @@ FROM docker.io/library/rust@sha256:e51d0265072d2d9d5d320f6a44dde6b9ef13653b03509
 WORKDIR /usr/src/kbs
 COPY . .
 
-RUN apt-get update && apt-get install -y pkg-config libssl-dev git sudo
+RUN apt-get update && apt-get install -y pkg-config libssl-dev git sudo cmake
 
 # Build KBS Client
 RUN cd kbs && make cli-static-linux && \


### PR DESCRIPTION
We missed to ensure cmake installation for kbs-client-image build in #1200. We got the same [compilation error](https://github.com/confidential-containers/trustee/actions/runs/22697452039/job/65806960544) on s390x runners. This PR installs the package explicitly for the build.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>