### PR TITLE
workflows: Use IBM Actions Z runners for s390x CI jobs

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,5 +1,5 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels:
-    - s390x
+    - ubuntu-24.04-s390x
     - s390x-large

--- a/.github/workflows/build-as-image.yml
+++ b/.github/workflows/build-as-image.yml
@@ -50,7 +50,7 @@ jobs:
         - target_arch: s390x
           target_platform: linux/s390x
           build_platform: linux/s390x
-          instance: s390x
+          instance: ubuntu-24.04-s390x
           verifier: snp-verifier,nvidia-verifier,se-verifier
         - target_arch: aarch64
           target_platform: linux/arm64

--- a/.github/workflows/build-kbs-client-image.yml
+++ b/.github/workflows/build-kbs-client-image.yml
@@ -26,7 +26,7 @@ jobs:
           - arch: x86_64
             instance: ubuntu-24.04
           - arch: s390x
-            instance: s390x
+            instance: ubuntu-24.04-s390x
           - arch: aarch64
             instance: ubuntu-24.04-arm
     runs-on: ${{ matrix.instance }}

--- a/.github/workflows/build-kbs-image.yml
+++ b/.github/workflows/build-kbs-image.yml
@@ -60,7 +60,7 @@ jobs:
           - target_arch: s390x
             target_platform: linux/s390x
             build_platform: linux/s390x
-            instance: s390x
+            instance: ubuntu-24.04-s390x
           - target_arch: aarch64
             target_platform: linux/arm64
             build_platform: linux/arm64

--- a/.github/workflows/build-trustee-cli.yml
+++ b/.github/workflows/build-trustee-cli.yml
@@ -26,7 +26,7 @@ jobs:
           - arch: x86_64
             instance: ubuntu-24.04
           - arch: s390x
-            instance: s390x
+            instance: ubuntu-24.04-s390x
           - arch: aarch64
             instance: ubuntu-24.04-arm
     runs-on: ${{ matrix.instance }}

--- a/.github/workflows/push-kbs-client-to-ghcr.yml
+++ b/.github/workflows/push-kbs-client-to-ghcr.yml
@@ -16,7 +16,7 @@ jobs:
           - arch: x86_64
             instance: ubuntu-24.04
           - arch: s390x
-            instance: s390x
+            instance: ubuntu-24.04-s390x
           - arch: aarch64
             instance: ubuntu-24.04-arm
     runs-on: ${{ matrix.instance }}

--- a/.github/workflows/push-trustee-cli-to-ghcr.yml
+++ b/.github/workflows/push-trustee-cli-to-ghcr.yml
@@ -16,7 +16,7 @@ jobs:
           - arch: x86_64
             instance: ubuntu-24.04
           - arch: s390x
-            instance: s390x
+            instance: ubuntu-24.04-s390x
           - arch: aarch64
             instance: ubuntu-24.04-arm
     runs-on: ${{ matrix.instance }}


### PR DESCRIPTION
Switch all self-hosted runners labeled 's390x' to IBM Actions Z runners.

IBM Actions Z runners currently do not support nested virtualization, so keep the existing configuration for the runner labeled 's390x-large'.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>