### PR TITLE
kbs-client: fixup get-reference-value

### DIFF
--- a/tools/kbs-client/src/lib.rs
+++ b/tools/kbs-client/src/lib.rs
@@ -307,16 +307,17 @@ pub async fn set_sample_rv(
     }
 }
 
-pub async fn get_rvs(
+pub async fn get_rv(
     url: String,
     auth_key: String,
     kbs_root_certs_pem: Vec<String>,
+    reference_value_id: String,
 ) -> Result<String> {
     let token = sign_admin_token(&auth_key)?;
 
     let http_client = build_http_client(kbs_root_certs_pem)?;
 
-    let reference_value_url = format!("{}/{KBS_URL_PREFIX}/reference-value", url);
+    let reference_value_url = format!("{}/{KBS_URL_PREFIX}/reference-value/{reference_value_id}", url);
 
     let res = http_client
         .get(reference_value_url)

--- a/tools/kbs-client/src/main.rs
+++ b/tools/kbs-client/src/main.rs
@@ -151,8 +151,12 @@ enum ConfigCommands {
         resource_file: PathBuf,
     },
 
-    /// List reference values registered with RVPS
-    GetReferenceValues,
+    /// Get reference value from RVPS given reference value ID
+    GetReferenceValue {
+        /// The ID of the reference value.
+        #[clap(long, value_parser)]
+        id: String,
+    },
 
     /// Add a sample reference value to the RVPS.
     /// The request will be proxied through the KBS
@@ -369,9 +373,9 @@ async fn main() -> Result<()> {
                     .await?;
                     println!("Reference Values Updated");
                 }
-                ConfigCommands::GetReferenceValues => {
+                ConfigCommands::GetReferenceValue { id } => {
                     let values =
-                        kbs_client::get_rvs(cli.url, auth_key.clone(), kbs_cert.clone()).await?;
+                        kbs_client::get_rv(cli.url, auth_key.clone(), kbs_cert.clone(), id).await?;
                     println!("{:?}", values);
                 }
             }


### PR DESCRIPTION
Looks like we forgot to update get_reference_value(s) when we change the RV interface to get individual reference values by ID.

Currently get-reference-values will fail (trying to get a reference value with the id `\`). Instead, add an argument to provide the RV ID.