### PR TITLE
nvidia: use alias for remote verifier type

### DIFF
--- a/deps/verifier/src/nvidia/mod.rs
+++ b/deps/verifier/src/nvidia/mod.rs
@@ -56,7 +56,9 @@ pub struct NvidiaVerifierConfig {
 #[serde(tag = "type")]
 pub enum NvidiaVerifierType {
     #[default]
+    #[serde(alias = "local")]
     Local,
+    #[serde(alias = "remote")]
     Remote(NvidiaRemoteVerifierConfig),
 }
 


### PR DESCRIPTION
Avoid having to pass capitalized NVIDIA_VERIFIER_MODE strings to deploy KBS.

I am trying to integrate the latest version of trustee into kata-containers: https://github.com/kata-containers/kata-containers/pull/12648/changes

After adjusting the `NVIDIA_VERIFIER_MODE` variable, I still got CI errors such as in https://github.com/kata-containers/kata-containers/actions/runs/22917620305/job/66510316119?pr=12648:
```
Error: invalid config: unknown variant `local`, expected `Local` or `Remote` for key `attestation_service`
```

Looks like this contract "broke" yesterday via: https://github.com/confidential-containers/trustee/commit/8733c99f18acd39c4d24a14013b2636deab03114

If you don't like the serialization alias, we would at least need to change `kbs\config\kubernetes\deploy-kbs.sh`, for instance, assigning `Local` as the default value for `NVIDIA_VERIFIER_MODE` when no value is present (or ensure the value is either local or remote and capitalize the first value).

Oddly enough, even after adjusting `NVIDIA_VERIFIER_MODE` to `Remote` in kata-containers, the NVIDIA GPU SNP CI failed: https://github.com/kata-containers/kata-containers/actions/runs/22917620305/job/66510316119?pr=12648
```
Error: invalid config: unknown variant `remote`, expected `Local` or `Remote` for key `attestation_service`
```

Bluntly starting at the code, I don't see where the capitalization got lost. I don't see a trace on kata side and on `deploy-kbs.sh` side, the capital R version should have been utilized.
