### PR TITLE
kbs-client: warn user if AS policy id is not set, use cpu as default

### DIFF
--- a/tools/kbs-client/src/lib.rs
+++ b/tools/kbs-client/src/lib.rs
@@ -15,6 +15,7 @@ use kbs_protocol::KbsClientCapabilities;
 use serde::Serialize;
 use serde_json::json;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::warn;
 
 const KBS_URL_PREFIX: &str = "kbs/v0";
 const ADMIN_TOKEN_EXPIRY_SECS: u64 = 7200;
@@ -155,7 +156,7 @@ pub struct SetPolicyInput {
 /// - auth_key: KBS owner's authenticate private key (PEM string).
 /// - policy_bytes: Policy file content in `Vec<u8>`.
 /// - [policy_type]: Policy type. Default value is "rego".
-/// - [policy_id]: Policy ID. Default value is "default".
+/// - [policy_id]: Policy ID. Default value is "default_cpu".
 /// - kbs_root_certs_pem: Custom HTTPS root certificate of KBS server. It can be left blank.
 pub async fn set_attestation_policy(
     url: &str,
@@ -170,9 +171,16 @@ pub async fn set_attestation_policy(
     let http_client = build_http_client(kbs_root_certs_pem)?;
 
     let set_policy_url = format!("{}/{KBS_URL_PREFIX}/attestation-policy", url);
+    let policy_id = match policy_id {
+        Some(policy_id) => policy_id,
+        None => {
+            warn!("no policy_id set; using default_cpu");
+            "default_cpu".to_string()
+        }
+    };
     let post_input = SetPolicyInput {
         r#type: policy_type.unwrap_or("rego".to_string()),
-        policy_id: policy_id.unwrap_or("default".to_string()),
+        policy_id,
         policy: URL_SAFE_NO_PAD.encode(policy_bytes.clone()),
     };
 


### PR DESCRIPTION
"default" is a no-op change with set-attestation-policy since the policies use <TEE class> these days.

warn users if they don't set --id to specify the target TEE class.

Use "default_cpu" instead of "default" as the default.