### PR TITLE
ci: fix release cli scripts

### DIFF
--- a/.github/workflows/release-clis-to-ghcr.yml
+++ b/.github/workflows/release-clis-to-ghcr.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Build ${{ matrix.component }}
       run: |
         docker buildx build -f "${{ matrix.dockerfile }}" \
-          --build-arg ARCH="\$(uname -m)" --output ./ .
+          --build-arg ARCH="$(uname -m)" --output ./ .
 
     - name: Push ${{ matrix.component }} to ghcr.io
       run: |


### PR DESCRIPTION
The original \$ will not be executed when running the script,  thus replaced with $.

This is to fix [the errors](https://github.com/confidential-containers/trustee/actions/runs/23333751789/job/67870589671) happened after merging.