### PR TITLE
ci: preserve package-write scope in reusable image workflows

### DIFF
--- a/.github/workflows/workflow-call-build-staged-images.yml
+++ b/.github/workflows/workflow-call-build-staged-images.yml
@@ -18,9 +18,6 @@ on:
         description: 'GitHub token for GHCR'
         required: false 
 
-permissions:
-  contents: read
-
 jobs:
   validate-inputs:
     runs-on: ubuntu-24.04

--- a/.github/workflows/workflow-call-publish-staged-manifests.yml
+++ b/.github/workflows/workflow-call-publish-staged-manifests.yml
@@ -17,13 +17,8 @@ on:
         description: 'GitHub token for GHCR'
         required: true
 
-permissions:
-  contents: read
-
 jobs:
   publish:
-    permissions:
-      packages: write
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
Reusable workflows were forcing contents-read at the top level, which can narrow inherited GITHUB_TOKEN scopes and block GHCR organization package pushes on push-enabled paths. Relying on caller/job permissions keeps least privilege for PRs while allowing package publication only where explicitly granted.

Fixes errors like

https://github.com/confidential-containers/trustee/actions/runs/23468514542/job/68285934012