### PR TITLE
workflows: Set timeout for KBS lint/format/test

### DIFF
--- a/.github/workflows/test-rust-ci.yml
+++ b/.github/workflows/test-rust-ci.yml
@@ -63,6 +63,7 @@ jobs:
           softhsm2-util --init-token --free --label "Trustee pkcs11 test" --so-pin 12345678 --pin 12345678
 
       - name: Run KBS lint/format/test
+        timeout-minutes: 10
         env:
           SOFTHSM2_CONF: '${{ runner.temp }}/softhsm/softhsm2.conf'
         run: make test-kbs-unit TEST_FEATURES=${{ matrix.test_features }}


### PR DESCRIPTION
The `Run KBS/lint/format/test` step was observed running longer than 1 hour. The default timeout for a single workflow step is 6 hours, while the expected runtime for this step is under 5 minutes. Set an explicit timeout accordingly.

Example run: https://github.com/confidential-containers/trustee/actions/runs/23529279959/job/68489297233

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>