### PR TITLE
ci: decouple push jobs to another workflow file

### DIFF
--- a/.github/workflows/build-and-push-staged-images.yml
+++ b/.github/workflows/build-and-push-staged-images.yml
@@ -17,10 +17,9 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
-    uses: ./.github/workflows/workflow-call-build-staged-images.yml
+    uses: ./.github/workflows/workflow-call-build-staged-images-pr.yml
     with:
       image_group: all
-      push: false
 
   build_staged_images_push:
     name: Build staged images (all) [push]
@@ -28,10 +27,9 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: ./.github/workflows/workflow-call-build-staged-images.yml
+    uses: ./.github/workflows/workflow-call-build-staged-images-push.yml
     with:
       image_group: all
-      push: true
       ghcr_token: ${{ github.token }}
 
   publish_manifests:

--- a/.github/workflows/workflow-call-build-staged-images-pr.yml
+++ b/.github/workflows/workflow-call-build-staged-images-pr.yml
@@ -1,0 +1,224 @@
+name: Build Staged Images (PR)
+
+on:
+  workflow_call:
+    inputs:
+      image_group:
+        description: "Which image set to build: kbs | as | kbs-client | rvps | all"
+        type: string
+        required: false
+        default: all
+
+permissions: {}
+
+jobs:
+  kbs:
+    if: inputs.image_group == 'kbs' || inputs.image_group == 'all'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: built-in AS
+            tag: kbs
+            docker_file: kbs/docker/Dockerfile
+            platform: linux/amd64
+            instance: ubuntu-24.04
+            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64
+          - name: built-in AS
+            tag: kbs
+            docker_file: kbs/docker/Dockerfile
+            platform: linux/s390x
+            instance: ubuntu-24.04-s390x
+            build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x
+          - name: built-in AS
+            tag: kbs
+            docker_file: kbs/docker/Dockerfile
+            platform: linux/arm64
+            instance: ubuntu-24.04-arm
+            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64
+          - name: gRPC AS
+            tag: kbs-grpc-as
+            docker_file: kbs/docker/coco-as-grpc/Dockerfile
+            platform: linux/amd64
+            instance: ubuntu-24.04
+            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64
+          - name: gRPC AS
+            tag: kbs-grpc-as
+            docker_file: kbs/docker/coco-as-grpc/Dockerfile
+            platform: linux/s390x
+            instance: ubuntu-24.04-s390x
+            build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x
+          - name: gRPC AS
+            tag: kbs-grpc-as
+            docker_file: kbs/docker/coco-as-grpc/Dockerfile
+            platform: linux/arm64
+            instance: ubuntu-24.04-arm
+            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64
+          - name: Intel Trust Authority AS
+            tag: kbs-ita-as
+            docker_file: kbs/docker/intel-trust-authority/Dockerfile
+            platform: linux/amd64
+            instance: ubuntu-24.04
+            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64
+          - name: Intel Trust Authority AS
+            tag: kbs-ita-as
+            docker_file: kbs/docker/intel-trust-authority/Dockerfile
+            platform: linux/s390x
+            instance: ubuntu-24.04-s390x
+            build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x
+          - name: RHEL UBI AS
+            tag: rhel-ubi
+            docker_file: kbs/docker/rhel-ubi/Dockerfile
+            platform: linux/amd64
+            instance: ubuntu-24.04
+            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64
+    runs-on: ${{ matrix.instance }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Build ${{ matrix.tag }}
+        uses: ./.github/actions/build-single-image
+        with:
+          ghcr_token: ""
+          docker_file: ${{ matrix.docker_file }}
+          tag: ${{ matrix.tag }}
+          platform: ${{ matrix.platform }}
+          build_args: ${{ matrix.build_args }}
+          push: false
+
+  as:
+    if: inputs.image_group == 'as' || inputs.image_group == 'all'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: gRPC CoCo-AS
+            tag: coco-as-grpc
+            docker_file: attestation-service/docker/as-grpc/Dockerfile
+            platform: linux/amd64
+            instance: ubuntu-24.04
+            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64 --build-arg VERIFIER=all-verifier
+          - name: gRPC CoCo-AS
+            tag: coco-as-grpc
+            docker_file: attestation-service/docker/as-grpc/Dockerfile
+            platform: linux/s390x
+            instance: ubuntu-24.04-s390x
+            build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x --build-arg VERIFIER=snp-verifier,nvidia-verifier,se-verifier
+          - name: gRPC CoCo-AS
+            tag: coco-as-grpc
+            docker_file: attestation-service/docker/as-grpc/Dockerfile
+            platform: linux/arm64
+            instance: ubuntu-24.04-arm
+            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64 --build-arg VERIFIER=cca-verifier
+          - name: RESTful CoCo-AS
+            tag: coco-as-restful
+            docker_file: attestation-service/docker/as-restful/Dockerfile
+            platform: linux/amd64
+            instance: ubuntu-24.04
+            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64 --build-arg VERIFIER=all-verifier
+          - name: RESTful CoCo-AS
+            tag: coco-as-restful
+            docker_file: attestation-service/docker/as-restful/Dockerfile
+            platform: linux/s390x
+            instance: ubuntu-24.04-s390x
+            build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x --build-arg VERIFIER=snp-verifier,nvidia-verifier,se-verifier
+          - name: RESTful CoCo-AS
+            tag: coco-as-restful
+            docker_file: attestation-service/docker/as-restful/Dockerfile
+            platform: linux/arm64
+            instance: ubuntu-24.04-arm
+            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64 --build-arg VERIFIER=cca-verifier
+    runs-on: ${{ matrix.instance }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Build ${{ matrix.tag }}
+        uses: ./.github/actions/build-single-image
+        with:
+          ghcr_token: ""
+          docker_file: ${{ matrix.docker_file }}
+          tag: ${{ matrix.tag }}
+          platform: ${{ matrix.platform }}
+          build_args: ${{ matrix.build_args }}
+          push: false
+
+  rvps:
+    if: inputs.image_group == 'rvps' || inputs.image_group == 'all'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: RVPS
+            tag: rvps
+            docker_file: rvps/docker/Dockerfile
+            platform: linux/amd64
+            instance: ubuntu-24.04
+            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64
+          - name: RVPS
+            tag: rvps
+            docker_file: rvps/docker/Dockerfile
+            platform: linux/s390x
+            instance: ubuntu-24.04-s390x
+            build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x
+          - name: RVPS
+            tag: rvps
+            docker_file: rvps/docker/Dockerfile
+            platform: linux/arm64
+            instance: ubuntu-24.04-arm
+            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64
+    runs-on: ${{ matrix.instance }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Build ${{ matrix.tag }}
+        uses: ./.github/actions/build-single-image
+        with:
+          ghcr_token: ""
+          docker_file: ${{ matrix.docker_file }}
+          tag: ${{ matrix.tag }}
+          platform: ${{ matrix.platform }}
+          build_args: ${{ matrix.build_args }}
+          push: false
+
+  kbs-client:
+    if: inputs.image_group == 'kbs-client' || inputs.image_group == 'all'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tag: kbs-client-image
+            docker_file: kbs/docker/kbs-client-image/Dockerfile
+            instance: ubuntu-24.04
+          - tag: kbs-client-image
+            docker_file: kbs/docker/kbs-client-image/Dockerfile
+            instance: ubuntu-24.04-s390x
+          - tag: kbs-client-image
+            docker_file: kbs/docker/kbs-client-image/Dockerfile
+            instance: ubuntu-24.04-arm
+    runs-on: ${{ matrix.instance }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Build ${{ matrix.tag }}
+        uses: ./.github/actions/build-single-image
+        with:
+          ghcr_token: ""
+          docker_file: ${{ matrix.docker_file }}
+          tag: ${{ matrix.tag }}
+          push: false

--- a/.github/workflows/workflow-call-build-staged-images-push.yml
+++ b/.github/workflows/workflow-call-build-staged-images-push.yml
@@ -1,4 +1,4 @@
-name: Build Staged Images
+name: Build Staged Images (Push)
 
 on:
   workflow_call:
@@ -34,87 +34,6 @@ jobs:
             echo "Error: ghcr_token input must be provided when 'push' is true."
             exit 1
           fi
-  kbs:
-    if: (inputs.image_group == 'kbs' || inputs.image_group == 'all') && !inputs.push
-    needs: validate-inputs
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: built-in AS
-            tag: kbs
-            docker_file: kbs/docker/Dockerfile
-            platform: linux/amd64
-            instance: ubuntu-24.04
-            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64
-          - name: built-in AS
-            tag: kbs
-            docker_file: kbs/docker/Dockerfile
-            platform: linux/s390x
-            instance: ubuntu-24.04-s390x
-            build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x
-          - name: built-in AS
-            tag: kbs
-            docker_file: kbs/docker/Dockerfile
-            platform: linux/arm64
-            instance: ubuntu-24.04-arm
-            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64
-
-          - name: gRPC AS
-            tag: kbs-grpc-as
-            docker_file: kbs/docker/coco-as-grpc/Dockerfile
-            platform: linux/amd64
-            instance: ubuntu-24.04
-            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64
-          - name: gRPC AS
-            tag: kbs-grpc-as
-            docker_file: kbs/docker/coco-as-grpc/Dockerfile
-            platform: linux/s390x
-            instance: ubuntu-24.04-s390x
-            build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x
-          - name: gRPC AS
-            tag: kbs-grpc-as
-            docker_file: kbs/docker/coco-as-grpc/Dockerfile
-            platform: linux/arm64
-            instance: ubuntu-24.04-arm
-            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64
-
-          - name: Intel Trust Authority AS
-            tag: kbs-ita-as
-            docker_file: kbs/docker/intel-trust-authority/Dockerfile
-            platform: linux/amd64
-            instance: ubuntu-24.04
-            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64
-          - name: Intel Trust Authority AS
-            tag: kbs-ita-as
-            docker_file: kbs/docker/intel-trust-authority/Dockerfile
-            platform: linux/s390x
-            instance: ubuntu-24.04-s390x
-            build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x
-
-          - name: RHEL UBI AS
-            tag: rhel-ubi
-            docker_file: kbs/docker/rhel-ubi/Dockerfile
-            platform: linux/amd64
-            instance: ubuntu-24.04
-            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64
-    runs-on: ${{ matrix.instance }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Build ${{ matrix.tag }}
-        uses: ./.github/actions/build-single-image
-        with:
-          ghcr_token: ""
-          docker_file: ${{ matrix.docker_file }}
-          tag: ${{ matrix.tag }}
-          platform: ${{ matrix.platform }}
-          build_args: ${{ matrix.build_args }}
-          push: false
 
   kbs-push:
     if: (inputs.image_group == 'kbs' || inputs.image_group == 'all') && inputs.push
@@ -198,68 +117,6 @@ jobs:
           platform: ${{ matrix.platform }}
           build_args: ${{ matrix.build_args }}
           push: true
-  
-  as:
-    if: (inputs.image_group == 'as' || inputs.image_group == 'all') && !inputs.push
-    needs: validate-inputs
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: gRPC CoCo-AS
-            tag: coco-as-grpc
-            docker_file: attestation-service/docker/as-grpc/Dockerfile
-            platform: linux/amd64
-            instance: ubuntu-24.04
-            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64 --build-arg VERIFIER=all-verifier
-          - name: gRPC CoCo-AS
-            tag: coco-as-grpc
-            docker_file: attestation-service/docker/as-grpc/Dockerfile
-            platform: linux/s390x
-            instance: ubuntu-24.04-s390x
-            build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x --build-arg VERIFIER=snp-verifier,nvidia-verifier,se-verifier
-          - name: gRPC CoCo-AS
-            tag: coco-as-grpc
-            docker_file: attestation-service/docker/as-grpc/Dockerfile
-            platform: linux/arm64
-            instance: ubuntu-24.04-arm
-            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64 --build-arg VERIFIER=cca-verifier
-
-          - name: RESTful CoCo-AS
-            tag: coco-as-restful
-            docker_file: attestation-service/docker/as-restful/Dockerfile
-            platform: linux/amd64
-            instance: ubuntu-24.04
-            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64 --build-arg VERIFIER=all-verifier
-          - name: RESTful CoCo-AS
-            tag: coco-as-restful
-            docker_file: attestation-service/docker/as-restful/Dockerfile
-            platform: linux/s390x
-            instance: ubuntu-24.04-s390x
-            build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x --build-arg VERIFIER=snp-verifier,nvidia-verifier,se-verifier
-          - name: RESTful CoCo-AS
-            tag: coco-as-restful
-            docker_file: attestation-service/docker/as-restful/Dockerfile
-            platform: linux/arm64
-            instance: ubuntu-24.04-arm
-            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64 --build-arg VERIFIER=cca-verifier
-    runs-on: ${{ matrix.instance }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Build ${{ matrix.tag }}
-        uses: ./.github/actions/build-single-image
-        with:
-          ghcr_token: ""
-          docker_file: ${{ matrix.docker_file }}
-          tag: ${{ matrix.tag }}
-          platform: ${{ matrix.platform }}
-          build_args: ${{ matrix.build_args }}
-          push: false
 
   as-push:
     if: (inputs.image_group == 'as' || inputs.image_group == 'all') && inputs.push
@@ -324,49 +181,6 @@ jobs:
           build_args: ${{ matrix.build_args }}
           push: true
 
-  rvps:
-    if: (inputs.image_group == 'rvps' || inputs.image_group == 'all') && !inputs.push
-    needs: validate-inputs
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: RVPS
-            tag: rvps
-            docker_file: rvps/docker/Dockerfile
-            platform: linux/amd64
-            instance: ubuntu-24.04
-            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64
-          - name: RVPS
-            tag: rvps
-            docker_file: rvps/docker/Dockerfile
-            platform: linux/s390x
-            instance: ubuntu-24.04-s390x
-            build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x
-          - name: RVPS
-            tag: rvps
-            docker_file: rvps/docker/Dockerfile
-            platform: linux/arm64
-            instance: ubuntu-24.04-arm
-            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64
-    runs-on: ${{ matrix.instance }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Build ${{ matrix.tag }}
-        uses: ./.github/actions/build-single-image
-        with:
-          ghcr_token: ""
-          docker_file: ${{ matrix.docker_file }}
-          tag: ${{ matrix.tag }}
-          platform: ${{ matrix.platform }}
-          build_args: ${{ matrix.build_args }}
-          push: false
-
   rvps-push:
     if: (inputs.image_group == 'rvps' || inputs.image_group == 'all') && inputs.push
     needs: validate-inputs
@@ -410,38 +224,6 @@ jobs:
           platform: ${{ matrix.platform }}
           build_args: ${{ matrix.build_args }}
           push: true
-
-  kbs-client:
-    if: (inputs.image_group == 'kbs-client' || inputs.image_group == 'all') && !inputs.push
-    needs: validate-inputs
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - tag: kbs-client-image
-            docker_file: kbs/docker/kbs-client-image/Dockerfile
-            instance: ubuntu-24.04
-          - tag: kbs-client-image
-            docker_file: kbs/docker/kbs-client-image/Dockerfile
-            instance: ubuntu-24.04-s390x
-          - tag: kbs-client-image
-            docker_file: kbs/docker/kbs-client-image/Dockerfile
-            instance: ubuntu-24.04-arm
-    runs-on: ${{ matrix.instance }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Build ${{ matrix.tag }}
-        uses: ./.github/actions/build-single-image
-        with:
-          ghcr_token: ""
-          docker_file: ${{ matrix.docker_file }}
-          tag: ${{ matrix.tag }}
-          push: false
 
   kbs-client-push:
     if: (inputs.image_group == 'kbs-client' || inputs.image_group == 'all') && inputs.push


### PR DESCRIPTION
GitHub Action will do permission check before the actual execution. Even if we explicitly define the push job only runs when `push` is true, it will report error like

```
The workflow is not valid. .github/workflows/build-and-push-staged-images.yml (Line: 15, Col: 3): Error calling workflow 'confidential-containers/trustee/.github/workflows/workflow-call-build-staged-images.yml@8700ba6069d48b4f7092b21a962bc3431938aa52'. The nested job 'kbs-push' is requesting 'packages: write', but is only allowed 'packages: none'. .github/workflows/build-and-push-staged-images.yml (Line: 15, Col: 3): Error calling workflow 'confidential-containers/trustee/.github/workflows/workflow-call-build-staged-images.yml@8700ba6069d48b4f7092b21a962bc3431938aa52'. The nested job 'as-push' is requesting 'packages: write', but is only allowed 'packages: none'.
```

Thus we split the push and PR jobs to different callable workflow, and mark them with different permissions to avoid this.