### PR TITLE
ci: fix publishment workflow

### DIFF
--- a/.github/workflows/workflow-call-build-staged-images-push.yml
+++ b/.github/workflows/workflow-call-build-staged-images-push.yml
@@ -8,36 +8,16 @@ on:
         type: string
         required: false
         default: all
-      push:
-        description: 'Whether to push built images to GHCR'
-        type: boolean
-        required: false
-        default: false
       ghcr_token:
-        description: "Token for GHCR push (required when push is true)"
+        description: "Token for GHCR push"
         type: string
-        required: false
-        default: ""
+        required: true
 
 permissions: {}
 
 jobs:
-  validate-inputs:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Ensure ghcr_token is set when push is enabled
-        if: ${{ inputs.push }}
-        env:
-          GHCR_TOKEN_INPUT: ${{ inputs.ghcr_token }}
-        run: |
-          if [ -z "${GHCR_TOKEN_INPUT}" ]; then
-            echo "Error: ghcr_token input must be provided when 'push' is true."
-            exit 1
-          fi
-
   kbs-push:
-    if: (inputs.image_group == 'kbs' || inputs.image_group == 'all') && inputs.push
-    needs: validate-inputs
+    if: (inputs.image_group == 'kbs' || inputs.image_group == 'all')
     permissions:
       contents: read
       packages: write
@@ -119,8 +99,7 @@ jobs:
           push: true
 
   as-push:
-    if: (inputs.image_group == 'as' || inputs.image_group == 'all') && inputs.push
-    needs: validate-inputs
+    if: (inputs.image_group == 'as' || inputs.image_group == 'all')
     permissions:
       contents: read
       packages: write
@@ -182,8 +161,7 @@ jobs:
           push: true
 
   rvps-push:
-    if: (inputs.image_group == 'rvps' || inputs.image_group == 'all') && inputs.push
-    needs: validate-inputs
+    if: (inputs.image_group == 'rvps' || inputs.image_group == 'all')
     permissions:
       contents: read
       packages: write
@@ -226,8 +204,7 @@ jobs:
           push: true
 
   kbs-client-push:
-    if: (inputs.image_group == 'kbs-client' || inputs.image_group == 'all') && inputs.push
-    needs: validate-inputs
+    if: (inputs.image_group == 'kbs-client' || inputs.image_group == 'all')
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
delete useless parameter `push` and make the ghcr_token to required for push pipeline.

For another error https://github.com/confidential-containers/trustee/actions/runs/23595355809/job/68710560200