### PR TITLE
se-verifier: Handle report data properly for IBM SEL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,7 @@ dependencies = [
  "picky-asn1 0.10.1",
  "picky-asn1-der 0.5.4",
  "picky-asn1-x509 0.15.2",
- "s390_pv",
+ "s390_pv 0.10.0",
  "scroll",
  "serde",
  "serde_json",
@@ -1948,7 +1948,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2125,6 +2125,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,7 +2180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3937,7 +3949,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5462,7 +5474,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5529,7 +5541,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5574,10 +5586,29 @@ dependencies = [
  "log",
  "openssl",
  "openssl-sys",
- "s390_pv_core",
+ "s390_pv_core 0.10.0",
  "serde",
  "thiserror 1.0.69",
  "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "s390_pv"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b3164010c1c8f2555721d3c2297158fc957e751d383b4e617610b40bf40ac6"
+dependencies = [
+ "byteorder",
+ "curl",
+ "enum_dispatch",
+ "foreign-types",
+ "log",
+ "openssl",
+ "openssl-sys",
+ "s390_pv_core 0.12.0",
+ "serde",
+ "thiserror 2.0.18",
+ "zerocopy 0.8.31",
 ]
 
 [[package]]
@@ -5592,6 +5623,21 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "s390_pv_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba83bc04ef65f9a404af077f4e6b84d59569ae2ce6c473a923105059df79ec54"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "regex",
+ "serde",
+ "thiserror 2.0.18",
+ "zerocopy 0.8.31",
 ]
 
 [[package]]
@@ -6528,7 +6574,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7301,7 +7347,7 @@ dependencies = [
  "reqwest 0.13.2",
  "reqwest-middleware",
  "rstest",
- "s390_pv",
+ "s390_pv 0.12.0",
  "scroll",
  "serde",
  "serde_json",
@@ -7578,7 +7624,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/attestation-service/docs/tcb_claims.md
+++ b/attestation-service/docs/tcb_claims.md
@@ -134,13 +134,13 @@ The claim inherit the fields from the SEV-SNP claim with and additional `tpm` hi
 
 Note: The TD Report and TD Quote are fetched during early boot in this TEE. Kernel, Initrd and rootfs are measured into the vTPM's registers.
 
-## IBM Secure Execution (SE)
+## IBM Secure Execution for Linux (SEL)
 - `se.version`: The version this quote structure.
 - `se.cuid`: The unique ID of the attested guest (configuration uniqe ID).
 - `se.tag`: SE header tag.
 - `se.image_phkh`: SE image public host key hash
 - `se.attestation_phkh`: SE attestation public host key hash
-- `se.user_data`: Optional custom attestation owner data, could be key:value pairs collected on guest.
+- `se.user_data`: Optional custom attestation owner data collected on guest (e.g., `runtime_data_digest`)
 
 ## NVIDIA
 

--- a/attestation-service/src/ear_token/ear_default_policy_cpu.rego
+++ b/attestation-service/src/ear_token/ear_default_policy_cpu.rego
@@ -318,8 +318,23 @@ configuration := 0 if {
 	input.tpm
 }
 
-##### SE TODO
+##### IBM Secure Execution for Linux (SEL)
+# Only field existence is checked. No value check is necessary.
+# The SE verifier performs cryptographic verification including
+# measurements, signatures, and user_data binding.
+# If the field exists, it means the verifaction is successful.
+# This is a 'trust-the-verifier' approach.
+executables := 3 if {
+	input.se
+}
 
+hardware := 2 if {
+	input.se
+}
+
+configuration := 2 if {
+	input.se
+}
 
 #################################
 # EXTENSIONS

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -68,7 +68,7 @@ jsonwebkey = "0.4.0"
 jsonwebtoken = { workspace = true, default-features = false, optional = true }
 kbs-types.workspace = true
 openssl = { version = "0.10.77", optional = true }
-pv = { version = "0.10.0", package = "s390_pv", optional = true }
+pv = { version = "0.12.0", package = "s390_pv", optional = true }
 scroll = { version = "0.13.0", default-features = false, features = [
     "derive",
 ], optional = true }

--- a/deps/verifier/src/lib.rs
+++ b/deps/verifier/src/lib.rs
@@ -208,6 +208,20 @@ pub enum InitDataHash<'a> {
     NotProvided,
 }
 
+/// Trait for converting types to hex strings
+pub trait ToHex {
+    fn to_hex(&self) -> String;
+}
+
+impl ToHex for ReportData<'_> {
+    fn to_hex(&self) -> String {
+        match self {
+            ReportData::Value(bytes) => hex::encode(bytes),
+            ReportData::NotProvided => String::new(),
+        }
+    }
+}
+
 #[async_trait]
 pub trait Verifier {
     /// Verify the hardware signature.

--- a/deps/verifier/src/se/ibmse.rs
+++ b/deps/verifier/src/se/ibmse.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::{TeeEvidence, TeeEvidenceParsedClaim};
-use anyhow::{anyhow, bail, Context, Result};
+use crate::{ReportData, TeeEvidence, TeeEvidenceParsedClaim, ToHex};
+use anyhow::{anyhow, Context, Result};
 use core::result::Result::Ok;
 use openssl::encrypt::{Decrypter, Encrypter};
 use openssl::pkey::{PKey, Private, Public};
@@ -19,6 +19,7 @@ use pv::uv::ConfigUid;
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, hex::Hex, serde_as};
 use std::{env, fs};
+use thiserror::Error;
 use tracing::{debug, info, warn};
 
 const DEFAULT_CERTS_OFFLINE_VERIFICATION: &str = "false";
@@ -62,6 +63,42 @@ fn list_files_in_folder(dir: &str) -> Result<Vec<String>> {
     }
 
     Ok(file_paths)
+}
+
+/// Error types for SE verifier operations
+#[derive(Error, Debug)]
+pub enum SeError {
+    #[error(
+        "USER_DATA content mismatch in IBM SEL evidence, expected: {expected:?}, got: {actual:?}"
+    )]
+    UserDataMismatch { expected: Vec<u8>, actual: Vec<u8> },
+
+    #[error("Failed to verify the measurement")]
+    MeasurementVerificationFailed,
+
+    #[error("Failed to decrypt measurement key")]
+    DecryptMeasurementKey(#[source] anyhow::Error),
+
+    #[error("Failed to decrypt request nonce")]
+    DecryptRequestNonce(#[source] anyhow::Error),
+
+    #[error("Failed to convert nonce from Vec<u8> to [u8; 16], must have exactly 16 elements")]
+    InvalidNonceLength,
+
+    #[error("Failed to get image_public_host_key_hash")]
+    MissingImagePublicHostKeyHash,
+
+    #[error("Failed to get attestation_public_host_key_hash")]
+    MissingAttestationPublicHostKeyHash,
+
+    #[error("Failed to deserialize evidence")]
+    DeserializeEvidence(#[source] serde_json::Error),
+
+    #[error("Failed to build json value from SE claims")]
+    BuildJsonClaims(#[source] serde_json::Error),
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 #[repr(C)]
@@ -114,6 +151,9 @@ pub struct SeAttestationRequest {
     encr_request_nonce: Vec<u8>,
     #[serde_as(as = "Base64")]
     image_hdr_tags: BootHdrTags,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<Base64>")]
+    runtime_data_digest: Option<Vec<u8>>,
 }
 
 #[derive(Debug)]
@@ -168,22 +208,42 @@ impl SeVerifierImpl {
         Ok(encrypted)
     }
 
-    pub fn evaluate(&self, evidence: TeeEvidence) -> Result<TeeEvidenceParsedClaim> {
+    pub fn evaluate(
+        &self,
+        evidence: TeeEvidence,
+        expected_report_data: &ReportData,
+    ) -> Result<TeeEvidenceParsedClaim> {
         info!("IBM SE verify API called.");
 
         // evidence is serialized SeAttestationResponse String bytes
-        let se_response: SeAttestationResponse = serde_json::from_value(evidence)?;
+        let se_response: SeAttestationResponse =
+            serde_json::from_value(evidence).map_err(SeError::DeserializeEvidence)?;
 
         let meas_key = self
             .decrypt(&se_response.encr_measurement_key)
-            .context("decrypt Measurement Key")?;
+            .map_err(SeError::DecryptMeasurementKey)?;
         let nonce = self
             .decrypt(&se_response.encr_request_nonce)
-            .context("decrypt Request Nonce")?;
+            .map_err(SeError::DecryptRequestNonce)?;
 
-        let nonce_array: [u8; 16] = nonce
-            .try_into()
-            .map_err(|_| anyhow!("Failed to convert nonce from Vec<u8> to [u8; 16], It must have exactly 16 elements."))?;
+        let nonce_array: [u8; 16] = nonce.try_into().map_err(|_| SeError::InvalidNonceLength)?;
+
+        // Validate runtime_data_digest if provided
+        if let ReportData::Value(expected_report_data) = expected_report_data {
+            let report_data = se_response
+                .user_data
+                .get(..48)
+                .context("Failed to get report_data section from USER_DATA")?;
+            if report_data != *expected_report_data {
+                return Err(SeError::UserDataMismatch {
+                    expected: expected_report_data.to_vec(),
+                    actual: report_data.to_vec(),
+                }
+                .into());
+            }
+        } else {
+            info!("No expected runtime_data_digest provided for IBM SEL verification, skipping user_data validation");
+        }
 
         let meas_key = PKey::hmac(&meas_key)?;
         let items = AttestationItems::new(
@@ -200,7 +260,7 @@ impl SeVerifierImpl {
         if !measurement.eq_secure(&se_response.measurement) {
             debug!("Recieved: {:?}", se_response.measurement);
             debug!("Calculated: {:?}", measurement.as_ref());
-            bail!("Failed to verify the measurement!");
+            return Err(SeError::MeasurementVerificationFailed.into());
         }
 
         let mut att_flags = AttestationFlags::default();
@@ -210,21 +270,21 @@ impl SeVerifierImpl {
         debug!("additional_data: {:?}", add_data);
         let image_phkh = add_data
             .image_public_host_key_hash()
-            .ok_or(anyhow!("Failed to get image_public_host_key_hash."))?;
+            .ok_or(SeError::MissingImagePublicHostKeyHash)?;
         let attestation_phkh = add_data
             .attestation_public_host_key_hash()
-            .ok_or(anyhow!("Failed to get attestation_public_host_key_hash."))?;
+            .ok_or(SeError::MissingAttestationPublicHostKeyHash)?;
 
         let claims = SeAttestationClaims {
             cuid: se_response.cuid,
-            report_data: String::from_utf8(se_response.user_data.clone())?,
+            report_data: expected_report_data.to_hex(),
             version: AttestationVersion::One as u32,
             image_phkh: image_phkh.to_vec(),
             attestation_phkh: attestation_phkh.to_vec(),
             tag: *se_response.image_hdr_tags.tag(),
         };
 
-        serde_json::to_value(claims).context("build json value from the se claims")
+        Ok(serde_json::to_value(claims).map_err(SeError::BuildJsonClaims)?)
     }
 
     pub async fn generate_supplemental_challenge(&self, _tee_parameters: String) -> Result<String> {
@@ -294,7 +354,7 @@ impl SeVerifierImpl {
             arcb.add_hostkey(c.public_key()?);
         }
 
-        let encr_ctx = ReqEncrCtx::random(SymKeyType::Aes256)?;
+        let encr_ctx = ReqEncrCtx::random(SymKeyType::Aes256Gcm)?;
         let request_blob = arcb.encrypt(&encr_ctx)?;
         let conf_data = arcb.confidential_data();
         let encr_measurement_key = self.encrypt(conf_data.measurement_key())?;
@@ -316,9 +376,200 @@ impl SeVerifierImpl {
             encr_measurement_key,
             encr_request_nonce,
             image_hdr_tags,
+            runtime_data_digest: None,
         };
 
         let challenge = serde_json::to_string(&se_attestation_request)?;
         Ok(challenge)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openssl::pkey::PKey;
+    use openssl::rsa::Rsa;
+    use pv::request::BootHdrTags;
+    use pv::uv::ConfigUid;
+
+    // Helper to generate test RSA key pair
+    fn generate_test_keypair() -> (PKey<Private>, PKey<Public>) {
+        let rsa = Rsa::generate(2048).expect("Failed to generate RSA key");
+        let private_key = PKey::from_rsa(rsa.clone()).expect("Failed to create private key");
+        // Extract public key from the RSA key
+        let public_key = PKey::from_rsa(
+            Rsa::from_public_components(
+                rsa.n().to_owned().expect("Failed to get n"),
+                rsa.e().to_owned().expect("Failed to get e"),
+            )
+            .expect("Failed to create public RSA"),
+        )
+        .expect("Failed to create public key");
+        (private_key, public_key)
+    }
+
+    // Helper to create a test SeVerifierImpl with generated keys
+    fn create_test_verifier() -> SeVerifierImpl {
+        let (private_key, public_key) = generate_test_keypair();
+        SeVerifierImpl {
+            private_key,
+            public_key,
+        }
+    }
+
+    // Helper to create a dummy BootHdrTags for testing
+    fn create_dummy_boot_hdr_tags() -> BootHdrTags {
+        // BootHdrTags::new signature: (pld: [u8; 64], ald: [u8; 64], tld: [u8; 64], tag: [u8; 16])
+        let pld = [0u8; 64];
+        let ald = [0u8; 64];
+        let tld = [0u8; 64];
+        let tag = [0u8; 16];
+        BootHdrTags::new(pld, ald, tld, tag)
+    }
+
+    // Helper to create a dummy ConfigUid for testing
+    fn create_dummy_config_uid() -> ConfigUid {
+        // ConfigUid is a type alias for [u8; 16]
+        [0u8; 16]
+    }
+
+    /// Test user_data validation when report_data is provided and matches
+    #[test]
+    fn test_user_data_validation_success() {
+        let verifier = create_test_verifier();
+
+        // Create test data - SHA-384 is 48 bytes
+        let report_data = vec![0x05; 48];
+
+        // Build user_data: first 48 bytes are report_data, rest can be anything
+        let mut user_data = report_data.clone();
+        user_data.extend_from_slice(&[0xAA; 16]); // Add some extra data
+
+        let nonce = vec![0x09; 16];
+        let meas_key = vec![0x0A; 32];
+
+        let encr_nonce = verifier.encrypt(&nonce).expect("Failed to encrypt nonce");
+        let encr_key = verifier.encrypt(&meas_key).expect("Failed to encrypt key");
+
+        let response = SeAttestationResponse {
+            measurement: vec![0x0B; 64],
+            additional_data: vec![],
+            user_data,
+            cuid: create_dummy_config_uid(),
+            encr_measurement_key: encr_key,
+            encr_request_nonce: encr_nonce,
+            image_hdr_tags: create_dummy_boot_hdr_tags(),
+        };
+
+        let evidence = serde_json::to_value(&response).expect("Failed to serialize");
+        let expected_report_data = ReportData::Value(&report_data);
+
+        let result = verifier.evaluate(evidence, &expected_report_data);
+
+        // Should fail at measurement verification (we don't have valid measurement),
+        // but NOT at user_data validation
+        assert!(result.is_err(), "Should fail at measurement verification");
+        let err = result.unwrap_err();
+
+        // Check that the error is NOT a UserDataMismatch
+        if let Some(se_error) = err.downcast_ref::<SeError>() {
+            assert!(
+                !matches!(se_error, SeError::UserDataMismatch { .. }),
+                "Should not fail at USER_DATA validation, got: {:?}",
+                se_error
+            );
+        }
+    }
+
+    /// Test user_data validation when user_data doesn't match expected values
+    #[test]
+    fn test_user_data_validation_mismatch() {
+        let verifier = create_test_verifier();
+
+        // Create test data - SHA-384 is 48 bytes
+        let report_data = vec![0x05; 48];
+
+        // Build user_data with WRONG report_data in first 48 bytes
+        let mut user_data = vec![0xFF; 48]; // Wrong report data
+        user_data.extend_from_slice(&[0xAA; 16]); // Add some extra data
+
+        let nonce = vec![0x09; 16];
+        let meas_key = vec![0x0A; 32];
+
+        let encr_nonce = verifier.encrypt(&nonce).expect("Failed to encrypt nonce");
+        let encr_key = verifier.encrypt(&meas_key).expect("Failed to encrypt key");
+
+        let response = SeAttestationResponse {
+            measurement: vec![0x0B; 64],
+            additional_data: vec![],
+            user_data,
+            cuid: create_dummy_config_uid(),
+            encr_measurement_key: encr_key,
+            encr_request_nonce: encr_nonce,
+            image_hdr_tags: create_dummy_boot_hdr_tags(),
+        };
+
+        let evidence = serde_json::to_value(&response).expect("Failed to serialize");
+        let expected_report_data = ReportData::Value(&report_data);
+
+        let result = verifier.evaluate(evidence, &expected_report_data);
+
+        assert!(result.is_err(), "Should fail with mismatched user_data");
+        let err = result.unwrap_err();
+
+        // Check that the error IS a UserDataMismatch
+        let se_error = err
+            .downcast_ref::<SeError>()
+            .expect("Error should be an SeError");
+        assert!(
+            matches!(se_error, SeError::UserDataMismatch { .. }),
+            "Error should be UserDataMismatch, got: {:?}",
+            se_error
+        );
+    }
+
+    /// Test user_data validation when no expected values are provided
+    #[test]
+    fn test_user_data_validation_no_expected_values() {
+        let verifier = create_test_verifier();
+
+        // Build user_data with some report_data
+        let report_data = vec![0x05; 48];
+        let mut user_data = report_data.clone();
+        user_data.extend_from_slice(&[0xBB; 16]);
+
+        let nonce = vec![0x09; 16];
+        let meas_key = vec![0x0A; 32];
+
+        let encr_nonce = verifier.encrypt(&nonce).expect("Failed to encrypt nonce");
+        let encr_key = verifier.encrypt(&meas_key).expect("Failed to encrypt key");
+
+        let response = SeAttestationResponse {
+            measurement: vec![0x0B; 64],
+            additional_data: vec![],
+            user_data,
+            cuid: create_dummy_config_uid(),
+            encr_measurement_key: encr_key,
+            encr_request_nonce: encr_nonce,
+            image_hdr_tags: create_dummy_boot_hdr_tags(),
+        };
+
+        let evidence = serde_json::to_value(&response).expect("Failed to serialize");
+        let expected_report_data = ReportData::NotProvided;
+
+        let result = verifier.evaluate(evidence, &expected_report_data);
+
+        // Should fail at measurement verification, but NOT at user_data validation
+        assert!(result.is_err(), "Should fail at measurement verification");
+        let err = result.unwrap_err();
+
+        // Check that the error is NOT a UserDataMismatch
+        if let Some(se_error) = err.downcast_ref::<SeError>() {
+            assert!(
+                !matches!(se_error, SeError::UserDataMismatch { .. }),
+                "Should not fail at USER_DATA validation when no expected values provided, got: {:?}",
+                se_error
+            );
+        }
     }
 }

--- a/deps/verifier/src/se/mod.rs
+++ b/deps/verifier/src/se/mod.rs
@@ -33,10 +33,7 @@ impl Verifier for SeVerifier {
         if let InitDataHash::Value(_) = expected_init_data_hash {
             warn!("IBM SE verifier does not support verify init data hash, will ignore the input `init_data_hash`.");
         }
-        if let ReportData::Value(_) = expected_report_data {
-            warn!("IBM SE verifier does not support verify report data hash, will ignore the input `report_data`.");
-        }
-        let claims = se_verifier.evaluate(evidence)?;
+        let claims = se_verifier.evaluate(evidence, expected_report_data)?;
         Ok(vec![(claims, "cpu".to_string())])
     }
 


### PR DESCRIPTION
IBM SEL hasn’t handled the report data properly and does not include initdata in the parsed claim. 
Plus, the attestation outcome is `Contraindicated` because there is no appraisal section in the attestation policy for the TEE. 
This PR resolves the issue. Please refer to the individual commit messages for details.

Depends-on: https://github.com/confidential-containers/guest-components/pull/1417

Assisted-by: IBM Bob
Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com> 