### PR TITLE
kbs: pass VAULT and EXTERNAL_PLUGIN build args to Dockerfiles

### DIFF
--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -4,6 +4,8 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} \
     AS builder
 ARG ARCH=x86_64
 ARG ALIYUN=false
+ARG VAULT=false
+ARG EXTERNAL_PLUGIN=false
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -44,7 +46,7 @@ RUN if [ "${ARCH}" = "x86_64" ]; then curl -fsSL https://download.01.org/intel-s
 WORKDIR /usr/src/trustee
 COPY . .
 
-RUN cd kbs && make AS_FEATURE=coco-as-builtin FEATURES=pkcs11 ALIYUN=${ALIYUN} ARCH=${ARCH} && \
+RUN cd kbs && make AS_FEATURE=coco-as-builtin FEATURES=pkcs11 ALIYUN=${ALIYUN} ARCH=${ARCH} VAULT=${VAULT} EXTERNAL_PLUGIN=${EXTERNAL_PLUGIN} && \
     make ARCH=${ARCH} install-kbs
 
 # ubuntu:24.04

--- a/kbs/docker/coco-as-grpc/Dockerfile
+++ b/kbs/docker/coco-as-grpc/Dockerfile
@@ -7,6 +7,8 @@ ARG ARCH=x86_64
 ARG ALIYUN=false
 ARG NEBULA_CA_PLUGIN=false
 ARG NEBULA_VERSION=v1.9.5
+ARG VAULT=false
+ARG EXTERNAL_PLUGIN=false
 
 WORKDIR /usr/src/kbs
 COPY . .
@@ -22,7 +24,7 @@ RUN if [ $(uname -m) != ${ARCH} ]; then \
     apt-get install -y libssl-dev:${OS_ARCH}; fi
 
 # Build and Install KBS
-RUN cd kbs && make AS_FEATURE=coco-as-grpc ALIYUN=${ALIYUN} ARCH=${ARCH} NEBULA_CA_PLUGIN=${NEBULA_CA_PLUGIN} && \
+RUN cd kbs && make AS_FEATURE=coco-as-grpc ALIYUN=${ALIYUN} ARCH=${ARCH} NEBULA_CA_PLUGIN=${NEBULA_CA_PLUGIN} VAULT=${VAULT} EXTERNAL_PLUGIN=${EXTERNAL_PLUGIN} && \
     make ARCH=${ARCH} install-kbs
 
 # Download and install Nebula

--- a/kbs/docker/intel-trust-authority/Dockerfile
+++ b/kbs/docker/intel-trust-authority/Dockerfile
@@ -2,6 +2,8 @@
 FROM docker.io/library/rust@sha256:e227f20ec42af3ea9a3c9c1dd1b2012aa15f12279b5e9d5fb890ca1c2bb5726c \
     AS builder
 ARG ALIYUN=false
+ARG VAULT=false
+ARG EXTERNAL_PLUGIN=false
 
 WORKDIR /usr/src/kbs
 COPY . .
@@ -9,7 +11,7 @@ COPY . .
 RUN apt-get update && apt install -y git cmake
 
 # Build and Install KBS
-RUN cd kbs && make AS_FEATURE=intel-trust-authority-as ALIYUN=${ALIYUN} && \
+RUN cd kbs && make AS_FEATURE=intel-trust-authority-as ALIYUN=${ALIYUN} VAULT=${VAULT} EXTERNAL_PLUGIN=${EXTERNAL_PLUGIN} && \
     make install-kbs
 
 # ubuntu:24.04


### PR DESCRIPTION
Helps to build them as part of docker-compose and other docker workflows