### PR TITLE
kbs: get tid of rand dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3577,7 +3577,6 @@ dependencies = [
  "policy-engine",
  "prometheus",
  "prost",
- "rand 0.8.5",
  "reference-value-provider-service",
  "regex",
  "regorus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ tempfile = "3.27.0"
 tonic = { version = "0.14", features = ["tls-webpki-roots"] }
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
-rand = "0.8.5"
 rsa = { version = "0.9.10", features = ["sha2"] }
 time = { version = "0.3.47", features = ["std"] }
 tracing = "0.1.44"

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -69,12 +69,13 @@ p521 = { workspace = true, features = ["ecdh"] }
 policy-engine.path = "../deps/policy-engine"
 prometheus = "0.14.0"
 prost = { workspace = true, optional = true }
-rand.workspace = true
 regex = "1.12.3"
 regorus.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 rsa.workspace = true
-rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
+rustls = { version = "0.23", default-features = false, features = [
+    "ring",
+], optional = true }
 semver = "1.0.28"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/kbs/src/attestation/backend.rs
+++ b/kbs/src/attestation/backend.rs
@@ -5,12 +5,13 @@
 use std::sync::{Arc, LazyLock};
 
 use actix_web::{HttpRequest, HttpResponse};
+use aes_gcm::aead::OsRng;
 use anyhow::{anyhow, bail, Context};
 use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use kbs_types::{Attestation, Challenge, InitData, Request, Tee};
 use key_value_storage::{KeyValueStorageType, StorageBackendConfig};
-use rand::{thread_rng, Rng};
+use rsa::rand_core::RngCore;
 use semver::{BuildMetadata, Prerelease, Version, VersionReq};
 use serde::Deserialize;
 use serde_json::json;
@@ -64,9 +65,7 @@ const NONCE_SIZE_BYTES: usize = 32;
 pub async fn make_nonce() -> anyhow::Result<String> {
     let mut nonce: Vec<u8> = vec![0; NONCE_SIZE_BYTES];
 
-    thread_rng()
-        .try_fill(&mut nonce[..])
-        .map_err(anyhow::Error::from)?;
+    OsRng.fill_bytes(&mut nonce[..]);
 
     Ok(STANDARD.encode(&nonce))
 }

--- a/kbs/src/jwe.rs
+++ b/kbs/src/jwe.rs
@@ -5,7 +5,7 @@
 use core::{clone::Clone, convert::TryInto};
 
 use aes_gcm::{
-    aead::{generic_array::GenericArray, AeadMutInPlace},
+    aead::{generic_array::GenericArray, AeadMutInPlace, OsRng},
     Aes256Gcm, KeyInit, Nonce,
 };
 use aes_kw::{KeyInit as AesKwKeyInit, KwAes256};
@@ -13,8 +13,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use kbs_types::{ProtectedHeader, Response, TeePubKey};
 use p256::elliptic_curve::sec1::FromEncodedPoint;
-use rand::{rngs::OsRng, Rng};
-use rsa::{sha2::Sha256, BigUint, Oaep, Pkcs1v15Encrypt, RsaPublicKey};
+use rsa::{rand_core::RngCore, sha2::Sha256, BigUint, Oaep, Pkcs1v15Encrypt, RsaPublicKey};
 use serde_json::{json, Map};
 use tracing::warn;
 
@@ -70,11 +69,10 @@ const AES_GCM_256_ALGORITHM: &str = "A256GCM";
 #[deprecated(note = "This algorithm is no longer recommended.")]
 fn rsa_1v15(k_mod: String, k_exp: String, mut payload_data: Vec<u8>) -> Result<Response> {
     warn!("Get JWE request using deprecated kcs#1 v1.5 encryption, which has potential security issues.");
-    let mut rng = rand::thread_rng();
-
     let aes_sym_key = Aes256Gcm::generate_key(&mut OsRng);
     let mut cipher = Aes256Gcm::new(&aes_sym_key);
-    let iv = rng.gen::<[u8; 12]>();
+    let mut iv = [0u8; 12];
+    OsRng.fill_bytes(&mut iv);
     let nonce = Nonce::from_slice(&iv);
     let protected = ProtectedHeader {
         alg: RSA1_5_ALGORITHM.to_string(),
@@ -100,7 +98,7 @@ fn rsa_1v15(k_mod: String, k_exp: String, mut payload_data: Vec<u8>) -> Result<R
     let rsa_pub_key =
         RsaPublicKey::new(n, e).context("Building RSA key from modulus and exponent failed")?;
     let encrypted_key = rsa_pub_key
-        .encrypt(&mut rng, Pkcs1v15Encrypt, aes_sym_key.as_slice())
+        .encrypt(&mut OsRng, Pkcs1v15Encrypt, aes_sym_key.as_slice())
         .context("RSA encrypt sym key failed")?;
 
     Ok(Response {
@@ -115,11 +113,10 @@ fn rsa_1v15(k_mod: String, k_exp: String, mut payload_data: Vec<u8>) -> Result<R
 
 /// Use RSA-OAEP SHA-256 to encrypt the payload data.
 fn rsa_oaep256(k_mod: String, k_exp: String, mut payload_data: Vec<u8>) -> Result<Response> {
-    let mut rng = rand::thread_rng();
-
     let aes_sym_key = Aes256Gcm::generate_key(&mut OsRng);
     let mut cipher = Aes256Gcm::new(&aes_sym_key);
-    let iv = rng.gen::<[u8; 12]>();
+    let mut iv = [0u8; 12];
+    OsRng.fill_bytes(&mut iv);
     let nonce = Nonce::from_slice(&iv);
     let protected = ProtectedHeader {
         alg: RSA_OAEP256_ALGORITHM.to_string(),
@@ -146,7 +143,7 @@ fn rsa_oaep256(k_mod: String, k_exp: String, mut payload_data: Vec<u8>) -> Resul
         RsaPublicKey::new(n, e).context("Building RSA key from modulus and exponent failed")?;
     let padding = Oaep::new::<Sha256>();
     let encrypted_key = rsa_pub_key
-        .encrypt(&mut rng, padding, aes_sym_key.as_slice())
+        .encrypt(&mut OsRng, padding, aes_sym_key.as_slice())
         .context("RSA encrypt sym key failed")?;
 
     Ok(Response {
@@ -161,10 +158,8 @@ fn rsa_oaep256(k_mod: String, k_exp: String, mut payload_data: Vec<u8>) -> Resul
 
 /// Use ECDH-ES-A256KW to encrypt the payload data. The EC curve is P256.
 fn ecdh_es_a256kw_p256(x: String, y: String, mut payload_data: Vec<u8>) -> Result<Response> {
-    let mut rng = rand::thread_rng();
-
     // 1. Generate a random CEK
-    let cek = Aes256Gcm::generate_key(&mut rng);
+    let cek = Aes256Gcm::generate_key(&mut OsRng);
 
     // 2. Wrap the CEK and generate ProtectedHeader
     let x: [u8; 32] = URL_SAFE_NO_PAD
@@ -185,7 +180,7 @@ fn ecdh_es_a256kw_p256(x: String, y: String, mut payload_data: Vec<u8>) -> Resul
     let public_key = p256::PublicKey::from_encoded_point(&client_point)
         .into_option()
         .ok_or(anyhow!("invalid TEE public key"))?;
-    let encrypter_secret = p256::ecdh::EphemeralSecret::random(&mut rng);
+    let encrypter_secret = p256::ecdh::EphemeralSecret::random(&mut OsRng);
     let z = encrypter_secret
         .diffie_hellman(&public_key)
         .raw_secret_bytes()
@@ -230,7 +225,8 @@ fn ecdh_es_a256kw_p256(x: String, y: String, mut payload_data: Vec<u8>) -> Resul
     // 3. Encrypt content with CEK
     let mut cek_cipher = Aes256Gcm::new(GenericArray::from_slice(&cek));
 
-    let iv = rand::thread_rng().gen::<[u8; 12]>();
+    let mut iv = [0u8; 12];
+    OsRng.fill_bytes(&mut iv);
     let nonce = Nonce::from_slice(&iv);
     let aad = protected.generate_aad().context("Generate JWE AAD")?;
 
@@ -250,10 +246,8 @@ fn ecdh_es_a256kw_p256(x: String, y: String, mut payload_data: Vec<u8>) -> Resul
 
 /// Use ECDH-ES-A256KW to encrypt the payload data. The EC curve is P521.
 fn ecdh_es_a256kw_p521(x: String, y: String, mut payload_data: Vec<u8>) -> Result<Response> {
-    let mut rng = rand::thread_rng();
-
     // 1. Generate a random CEK
-    let cek = Aes256Gcm::generate_key(&mut rng);
+    let cek = Aes256Gcm::generate_key(&mut OsRng);
 
     // 2. Wrap the CEK and generate ProtectedHeader
     let x: [u8; 66] = URL_SAFE_NO_PAD
@@ -274,7 +268,7 @@ fn ecdh_es_a256kw_p521(x: String, y: String, mut payload_data: Vec<u8>) -> Resul
     let public_key = p521::PublicKey::from_encoded_point(&client_point)
         .into_option()
         .ok_or(anyhow!("invalid TEE public key"))?;
-    let encrypter_secret = p521::ecdh::EphemeralSecret::random(&mut rng);
+    let encrypter_secret = p521::ecdh::EphemeralSecret::random(&mut OsRng);
     let z = encrypter_secret
         .diffie_hellman(&public_key)
         .raw_secret_bytes()
@@ -319,7 +313,8 @@ fn ecdh_es_a256kw_p521(x: String, y: String, mut payload_data: Vec<u8>) -> Resul
     // 3. Encrypt content with CEK
     let mut cek_cipher = Aes256Gcm::new(GenericArray::from_slice(&cek));
 
-    let iv = rand::thread_rng().gen::<[u8; 12]>();
+    let mut iv = [0u8; 12];
+    OsRng.fill_bytes(&mut iv);
     let nonce = Nonce::from_slice(&iv);
     let aad = protected.generate_aad().context("Generate JWE AAD")?;
 
@@ -357,6 +352,7 @@ pub fn jwe(tee_pub_key: TeePubKey, payload_data: Vec<u8>) -> Result<Response> {
 mod tests {
     use core::assert_eq;
 
+    use aes_gcm::aead::OsRng;
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
     use josekit::jwe::{
         alg::{ecdh_es::EcdhEsJweAlgorithm::EcdhEsA256kw, rsaes::RsaesJweAlgorithm::RsaOaep256},
@@ -461,8 +457,7 @@ mod tests {
         let test_data = b"this is a test data";
 
         // Generate a EC key pair
-        let mut rng = rand::thread_rng();
-        let private_key = p256::SecretKey::random(&mut rng);
+        let private_key = p256::SecretKey::random(&mut OsRng);
         let point = p256::EncodedPoint::from(private_key.public_key());
         let x = point.x().unwrap();
         let y = point.y().unwrap();
@@ -502,8 +497,7 @@ mod tests {
         let test_data = b"this is a test data";
 
         // Generate a EC key pair
-        let mut rng = rand::thread_rng();
-        let private_key = p521::SecretKey::random(&mut rng);
+        let private_key = p521::SecretKey::random(&mut OsRng);
         let point = p521::EncodedPoint::from(private_key.public_key());
         let x = point.x().unwrap();
         let y = point.y().unwrap();


### PR DESCRIPTION
The rand is used in AES algorithm in KBS. AES crates provide crate-compatible functions thus we do not need rand crate explicitly.

This commit removes rand dependency.