### PR TITLE
ci: add white list to link check

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,4 @@
 https://developer.hashicorp.com
 https://uefi.org/specs/UEFI/2.11/38_Confidential_Computing.html
+https://www.openpolicyagent.org
+https://confidentialcontainers.org/docs/attestation/installation/docker/


### PR DESCRIPTION
Errors happen very frequently like in https://github.com/confidential-containers/trustee/actions/runs/25042336665/job/73348459915?pr=1239 Thus we add them to white list.