### PR TITLE
kbs/plugins: add provisioner plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.10.1",
+ "rand 0.10.2",
  "sha1 0.11.0",
  "smallvec",
  "tokio",
@@ -2127,7 +2127,7 @@ dependencies = [
  "openssl",
  "p256",
  "p521",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand 0.8.6",
  "rsa",
  "serde",
@@ -3179,7 +3179,7 @@ dependencies = [
  "google-cloud-wkt",
  "http 1.4.0",
  "pin-project",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -4346,6 +4346,7 @@ dependencies = [
  "polyval 0.6.2",
  "prometheus",
  "prost",
+ "rand 0.10.2",
  "reference-value-provider-service",
  "regex",
  "regorus",
@@ -4517,7 +4518,7 @@ dependencies = [
  "openssl",
  "prost",
  "protos",
- "rand 0.10.1",
+ "rand 0.10.2",
  "reqwest 0.13.4",
  "resource_uri",
  "serde",
@@ -5935,9 +5936,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -6187,7 +6188,7 @@ dependencies = [
  "num-bigint 0.5.1",
  "num-traits",
  "parking_lot 0.12.5",
- "rand 0.10.1",
+ "rand 0.10.2",
  "regex",
  "serde",
  "serde_json",
@@ -8461,6 +8462,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.10.1",
+ "rand 0.10.2",
  "sha1 0.11.0",
  "smallvec",
  "tokio",
@@ -2124,7 +2124,7 @@ dependencies = [
  "openssl",
  "p256",
  "p521",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand 0.8.6",
  "rsa",
  "serde",
@@ -3168,7 +3168,7 @@ dependencies = [
  "google-cloud-wkt",
  "http 1.4.0",
  "pin-project",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -4333,6 +4333,7 @@ dependencies = [
  "polyval 0.6.2",
  "prometheus",
  "prost",
+ "rand 0.10.2",
  "reference-value-provider-service",
  "regex",
  "regorus",
@@ -4468,7 +4469,7 @@ dependencies = [
  "openssl",
  "prost",
  "protos",
- "rand 0.10.1",
+ "rand 0.10.2",
  "reqwest 0.13.4",
  "resource_uri",
  "serde",
@@ -5889,9 +5890,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -6132,7 +6133,7 @@ dependencies = [
  "num-bigint 0.5.1",
  "num-traits",
  "parking_lot 0.12.5",
- "rand 0.10.1",
+ "rand 0.10.2",
  "regex",
  "serde",
  "serde_json",
@@ -8389,6 +8390,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5865,7 +5865,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.2",
  "lru-slab",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash 2.1.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ regorus = { version = "0.11.0", default-features = false, features = [
     "time",
     "std",
 ] }
+rand = "0.10.2"
 reqwest = { version = "0.13", default-features = false, features = ["json"] }
 rstest = "0.26.1"
 serde = { version = "1.0", features = ["derive"] }
@@ -74,7 +75,7 @@ rsa = { version = "0.9.10", features = ["sha2"] }
 time = { version = "0.3.47", features = ["std"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
-uuid = { version = "1.23.3", features = ["v4"] }
+uuid = { version = "1.23.3", features = ["v4", "v5"] }
 zeroize = "1"
 
 [patch.crates-io]

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -85,6 +85,7 @@ zeroize.workspace = true
 policy-engine.path = "../deps/policy-engine"
 prometheus = "0.14.0"
 prost = { workspace = true, optional = true }
+rand.workspace = true
 regex = "1.12.4"
 regorus.workspace = true
 reqwest = { workspace = true, features = ["default-tls"] }

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -91,6 +91,7 @@ zeroize.workspace = true
 policy-engine.path = "../deps/policy-engine"
 prometheus = "0.14.0"
 prost = { workspace = true, optional = true }
+rand.workspace = true
 regex = "1.12.4"
 regorus.workspace = true
 reqwest = { workspace = true, features = ["default-tls"] }

--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -396,7 +396,7 @@ pub(crate) async fn api(
                 // Plugin calls need to be authorized by the admin auth
                 core.admin.check_admin_access(&request)?;
                 let response = plugin
-                    .handle(&body, &query, resource_path, request.method())
+                    .handle(&body, &query, resource_path, request.method(), None)
                     .await
                     .map_err(|e| Error::PluginInternalError { source: e })?;
 
@@ -446,8 +446,11 @@ pub(crate) async fn api(
                 }
                 KBS_POLICY_APPROVALS.inc();
 
+                let init_data = claims
+                    .pointer("/submods/cpu0/ear.veraison.annotated-evidence/init_data_claims");
+
                 let response = plugin
-                    .handle(&body, &query, resource_path, request.method())
+                    .handle(&body, &query, resource_path, request.method(), init_data)
                     .await
                     .map_err(|e| Error::PluginInternalError { source: e })?;
 

--- a/kbs/src/plugins/implementations/external_plugin.rs
+++ b/kbs/src/plugins/implementations/external_plugin.rs
@@ -387,6 +387,7 @@ impl ClientPlugin for ExternalPlugin {
         query: &HashMap<String, String>,
         path: &[&str],
         method: &Method,
+        _init_data: Option<&serde_json::Value>,
     ) -> Result<Vec<u8>> {
         let (backend, sub_path) = self.backend_for(path)?;
         backend.handle(body, query, sub_path, method).await

--- a/kbs/src/plugins/implementations/mod.rs
+++ b/kbs/src/plugins/implementations/mod.rs
@@ -6,6 +6,7 @@
 pub mod nebula_ca;
 #[cfg(feature = "pkcs11")]
 pub mod pkcs11;
+pub mod provisioner;
 pub mod resource;
 pub mod sample;
 
@@ -16,6 +17,7 @@ pub mod external_plugin;
 pub use nebula_ca::{NebulaCaPlugin, NebulaCaPluginConfig};
 #[cfg(feature = "pkcs11")]
 pub use pkcs11::{Pkcs11Backend, Pkcs11Config};
+pub use provisioner::{Provisioner, ProvisionerConfig};
 pub use resource::{RepositoryConfig, ResourceStorage};
 pub use sample::{Sample, SampleConfig};
 

--- a/kbs/src/plugins/implementations/nebula_ca.rs
+++ b/kbs/src/plugins/implementations/nebula_ca.rs
@@ -401,6 +401,7 @@ impl ClientPlugin for NebulaCaPlugin {
         query: &HashMap<String, String>,
         path: &[&str],
         method: &Method,
+        _init_data: Option<&serde_json::Value>,
     ) -> Result<Vec<u8>> {
         if path.len() != 1 {
             bail!("Illegal path. Only one path segment is supported");

--- a/kbs/src/plugins/implementations/pkcs11.rs
+++ b/kbs/src/plugins/implementations/pkcs11.rs
@@ -128,6 +128,7 @@ impl ClientPlugin for Pkcs11Backend {
         _query: &HashMap<String, String>,
         path: &[&str],
         method: &Method,
+        _init_data: Option<&serde_json::Value>,
     ) -> Result<Vec<u8>> {
         let desc = path.join("/");
 

--- a/kbs/src/plugins/implementations/provisioner/README.md
+++ b/kbs/src/plugins/implementations/provisioner/README.md
@@ -1,0 +1,75 @@
+# Provisioner Plugin
+
+The provisioner plugin automates LUKS key generation and resource creation for
+confidential VMs. It is designed to work with a provisioner operator (or hook
+sidecar) that calls the plugin before the VM boots to obtain the values needed
+to bind the VM to its encryption key.
+
+## Flow
+
+1. The operator sends `POST /kbs/v0/provisioner/provision` with the VM identity.
+2. The plugin derives a deterministic UUID from the VM identity and generates a
+   random LUKS encryption key.
+3. The key is persisted in the KBS storage backend so the guest can retrieve
+   it after attestation via the plugin.
+4. The plugin returns a JSON response containing the values that the operator
+   must inject into the VM.
+
+On boot, the guest attests to the KBS and fetches the key through the
+`/kbs/v0/provisioner/...` path. In the guest, `systemd-repart` uses the key to
+encrypt the disk and `systemd-cryptsetup` uses it to decrypt the disk on
+subsequent boots.
+
+## Provision Response
+
+The JSON response returned to the operator:
+
+```json
+{
+  "uuid": "c007d2cc-5f14-41e5-a202-8d15f6f68607",
+  "resource_path": "default/c007d2cc-5f14-41e5-a202-8d15f6f68607/root"
+}
+```
+
+### Fields
+- **`uuid`**: Deterministic identifier for the VM, used by the operator to
+  construct initdata and for deprovision operations.
+- **`resource_path`**: KBS resource path where the LUKS key is stored. The
+  operator embeds this in the guest's initdata so the guest knows where to
+  fetch its key after attestation.
+
+## Resource Format
+
+The resource stored in the KBS storage backend follows the
+[confdata](https://gitlab.com/berrange/cvminjector#confidential-data-format)
+TOML format that `trustee-attester` expects:
+
+```toml
+version = "0.1.0"
+
+[data]
+"io.cryptsetup.key.text.root" = "<random LUKS key>"
+```
+
+The guest retrieves this resource after attestation at
+`/kbs/v0/provisioner/default/{uuid}/root` and parses the
+`io.cryptsetup.key.text.root` field to obtain the LUKS passphrase.
+
+## Deprovision
+
+To remove a provisioned resource:
+
+```
+DELETE /kbs/v0/provisioner/provision/{uuid}
+```
+
+## Authentication
+
+The plugin uses two authentication paths depending on the caller:
+
+- **POST/DELETE** (operator): `validate_auth` returns `true`, routing
+  through KBS admin authentication. The operator is infrastructure, not a TEE.
+- **GET** (guest VM): `validate_auth` returns `false`, requiring a TEE
+  attestation token verified by the Attestation Service and evaluated against
+  the KBS resource policy. The response is JWE-encrypted with the TEE public
+  key.

--- a/kbs/src/plugins/implementations/provisioner/mod.rs
+++ b/kbs/src/plugins/implementations/provisioner/mod.rs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provisioner plugin for KBS.
+//!
+//! Generates per-VM LUKS encryption keys and stores them in a dedicated
+//! storage namespace so that attested guests can retrieve them via
+//! `GET /kbs/v0/provisioner/default/{uuid}/root`.
+//!
+//! The hook sidecar calls `POST /kbs/v0/provisioner/provision` before the VM
+//! boots and receives `{uuid, resource_path}` to inject into the VM.
+//! On boot the guest attests and fetches the key through the provisioner's
+//! own serving endpoint.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use actix_web::http::Method;
+use anyhow::{anyhow, bail, Context, Result};
+use key_value_storage::{KeyValueStorageInstance, SetParameters, StorageProvider};
+use rand::distr::{Alphanumeric, SampleString};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+const PROVISIONER_STORAGE_NAMESPACE: &str = "provisioner";
+
+// UUID v5 namespace for the provisioner plugin.
+// Derived from: Uuid::new_v5(&Uuid::NAMESPACE_URL, b"provisioner_plugin")
+const PROVISIONER_NAMESPACE: Uuid = uuid::uuid!("feab5599-6854-52bc-95f0-0241c03e620a");
+
+/// Config (deserialized from kbs-config.toml)
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+pub struct ProvisionerConfig {
+    /// Length of the random key in bytes (default 32).
+    #[serde(default = "default_key_length")]
+    pub key_length: usize,
+}
+
+fn default_key_length() -> usize {
+    32
+}
+
+pub struct Provisioner {
+    storage: KeyValueStorageInstance,
+    key_length: usize,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct ProvisionRequest {
+    vm_name: String,
+    #[serde(default = "default_namespace")]
+    namespace: String,
+}
+
+fn default_namespace() -> String {
+    "default".into()
+}
+
+#[derive(Serialize, Clone)]
+struct ProvisionResponse {
+    uuid: String,
+    resource_path: String,
+}
+
+#[derive(Serialize)]
+struct StatusResponse {
+    status: String,
+}
+
+impl Provisioner {
+    pub async fn new(
+        config: ProvisionerConfig,
+        storage_provider: Arc<dyn StorageProvider>,
+    ) -> Result<Self> {
+        let storage = storage_provider
+            .get_or_register(PROVISIONER_STORAGE_NAMESPACE)
+            .await
+            .context("Provisioner: failed to init storage backend")?;
+
+        Ok(Self {
+            storage,
+            key_length: config.key_length,
+        })
+    }
+}
+
+impl Provisioner {
+    fn generate_random_key(&self) -> String {
+        Alphanumeric.sample_string(&mut rand::rng(), self.key_length)
+    }
+
+    fn generate_confdata_toml(luks_key: &str) -> String {
+        format!(
+            "version = \"0.1.0\"\n\
+             \n\
+             [data]\n\
+             \"io.cryptsetup.key.text.root\" = \"{}\"\n",
+            luks_key
+        )
+    }
+
+    async fn handle_get_resource(
+        &self,
+        path: &[&str],
+        init_data: Option<&serde_json::Value>,
+    ) -> Result<Vec<u8>> {
+        let resource_key = path.join("/");
+
+        let Some(claims) = init_data else {
+            bail!("provisioner requires init_data for resource access");
+        };
+
+        let bound_resource = claims
+            .get("trustee.kbs.resource")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("init_data missing trustee.kbs.resource"))?;
+        let expected = format!("kbs+provisioner:///{resource_key}");
+        if bound_resource != expected {
+            bail!("init_data resource mismatch: expected {expected}, got {bound_resource}");
+        }
+
+        let data = self
+            .storage
+            .get(&resource_key)
+            .await?
+            .ok_or_else(|| anyhow!("provisioner resource not found: {resource_key}"))?;
+        Ok(data)
+    }
+
+    async fn handle_provision(&self, body: &[u8]) -> Result<Vec<u8>> {
+        let req: ProvisionRequest = serde_json::from_slice(body).context("invalid JSON body")?;
+
+        let vm_identity = format!("{}/{}", req.namespace, req.vm_name);
+
+        // Generate deterministic UUID from VM identity
+        let trustee_uuid = Uuid::new_v5(&PROVISIONER_NAMESPACE, vm_identity.as_bytes()).to_string();
+
+        let resource_path = format!("default/{trustee_uuid}/root");
+
+        if self.storage.get(&resource_path).await?.is_some() {
+            let response = ProvisionResponse {
+                uuid: trustee_uuid,
+                resource_path,
+            };
+            return Ok(serde_json::to_vec(&response)?);
+        };
+
+        let luks_key = self.generate_random_key();
+
+        let confdata_toml = Self::generate_confdata_toml(&luks_key);
+
+        self.storage
+            .set(
+                &resource_path,
+                confdata_toml.as_bytes(),
+                SetParameters { overwrite: false },
+            )
+            .await
+            .context("failed to write resource")?;
+
+        let response = ProvisionResponse {
+            uuid: trustee_uuid,
+            resource_path,
+        };
+
+        Ok(serde_json::to_vec(&response)?)
+    }
+
+    async fn handle_deprovision(&self, path: &[&str]) -> Result<Vec<u8>> {
+        let trustee_uuid = path
+            .first()
+            .ok_or_else(|| anyhow!("missing uuid in path"))?;
+        let resource_path = format!("default/{trustee_uuid}/root");
+
+        let _ = self.storage.delete(&resource_path).await;
+
+        Ok(serde_json::to_vec(&StatusResponse {
+            status: "deleted".into(),
+        })?)
+    }
+}
+
+#[async_trait::async_trait]
+impl super::super::plugin_manager::ClientPlugin for Provisioner {
+    async fn handle(
+        &self,
+        body: &[u8],
+        _query: &HashMap<String, String>,
+        path: &[&str],
+        method: &Method,
+        init_data: Option<&serde_json::Value>,
+    ) -> Result<Vec<u8>> {
+        match (method.as_str(), path.first().copied()) {
+            ("POST", Some("provision")) => self.handle_provision(body).await,
+            ("DELETE", Some("provision")) => self.handle_deprovision(&path[1..]).await,
+            ("GET", _) => self.handle_get_resource(path, init_data).await,
+            _ => bail!(
+                "unsupported: {} /kbs/v0/provisioner/{}",
+                method,
+                path.join("/")
+            ),
+        }
+    }
+
+    async fn validate_auth(
+        &self,
+        _body: &[u8],
+        _query: &HashMap<String, String>,
+        path: &[&str],
+        method: &Method,
+    ) -> Result<bool> {
+        // GET: guest fetches the resource after TEE attestation (validate_auth = false).
+        // POST/DELETE: sidecar provisions/deprovisions via admin auth (validate_auth = true).
+        match (method.as_str(), path.first().copied()) {
+            ("GET", _) => Ok(false),
+            _ => Ok(true),
+        }
+    }
+
+    async fn encrypted(
+        &self,
+        _body: &[u8],
+        _query: &HashMap<String, String>,
+        _path: &[&str],
+        method: &Method,
+    ) -> Result<bool> {
+        Ok(method.as_str() == "GET")
+    }
+}

--- a/kbs/src/plugins/implementations/resource/mod.rs
+++ b/kbs/src/plugins/implementations/resource/mod.rs
@@ -34,6 +34,7 @@ impl ClientPlugin for ResourceStorage {
         _query: &HashMap<String, String>,
         path: &[&str],
         method: &Method,
+        _init_data: Option<&serde_json::Value>,
     ) -> Result<Vec<u8>> {
         let resource_desc = path.join("/");
         match method.as_str() {

--- a/kbs/src/plugins/implementations/sample.rs
+++ b/kbs/src/plugins/implementations/sample.rs
@@ -37,6 +37,7 @@ impl ClientPlugin for Sample {
         _query: &HashMap<String, String>,
         _path: &[&str],
         _method: &Method,
+        _init_data: Option<&serde_json::Value>,
     ) -> Result<Vec<u8>> {
         Ok("sample plugin response".as_bytes().to_vec())
     }

--- a/kbs/src/plugins/plugin_manager.rs
+++ b/kbs/src/plugins/plugin_manager.rs
@@ -12,6 +12,8 @@ use serde_json::Value;
 
 use super::{sample, RepositoryConfig, ResourceStorage};
 
+use super::{Provisioner, ProvisionerConfig};
+
 #[cfg(feature = "nebula-ca-plugin")]
 use super::{NebulaCaPlugin, NebulaCaPluginConfig};
 
@@ -83,6 +85,9 @@ pub enum PluginsConfig {
     #[cfg(feature = "external-plugin")]
     #[serde(alias = "external")]
     ExternalPlugin(ExternalPluginConfig),
+
+    #[serde(alias = "provisioner")]
+    Provisioner(ProvisionerConfig),
 }
 
 impl Display for PluginsConfig {
@@ -96,6 +101,7 @@ impl Display for PluginsConfig {
             PluginsConfig::Pkcs11(_) => f.write_str("pkcs11"),
             #[cfg(feature = "external-plugin")]
             PluginsConfig::ExternalPlugin(_) => f.write_str("external"),
+            PluginsConfig::Provisioner(_) => f.write_str("provisioner"),
         }
     }
 }
@@ -136,6 +142,12 @@ impl PluginsConfig {
                     .await
                     .context("Initialize 'external' plugin failed")?;
                 Arc::new(external_plugin) as _
+            }
+            PluginsConfig::Provisioner(cfg) => {
+                let prov = Provisioner::new(cfg, storage_provider)
+                    .await
+                    .context("Initialize 'Provisioner' plugin failed")?;
+                Arc::new(prov) as _
             }
         };
 

--- a/kbs/src/plugins/plugin_manager.rs
+++ b/kbs/src/plugins/plugin_manager.rs
@@ -8,6 +8,7 @@ use actix_web::http::Method;
 use anyhow::{Context, Result};
 use key_value_storage::StorageProvider;
 use serde::Deserialize;
+use serde_json::Value;
 
 use super::{sample, RepositoryConfig, ResourceStorage};
 
@@ -36,6 +37,7 @@ pub trait ClientPlugin: Send + Sync {
         query: &HashMap<String, String>,
         path: &[&str],
         method: &Method,
+        init_data: Option<&Value>,
     ) -> Result<Vec<u8>>;
 
     /// Whether the concrete request needs to validate the admin auth.


### PR DESCRIPTION
Add a provisioner plugin that automates LUKS key generation and resource creation for confidential VMs. When a POST request is received at `kbs/v0/provisioner/provision`, the plugin:

1. Generates a UUID and a random LUKS encryption key. The UUID is generated from the VM's namespace and name. 
2. Builds an initdata.toml pointing the guest to the KBS resource path `default/{UUID}/root` where the key is stored.
3. Stores the key in the KBS storage backend so the guest can retrieve it after attestation via the existing `resource` plugin.
4. Returns a JSON response:

   struct ProvisionResponse { uuid: String, resource_path: String, }

The plugin also supports DELETE requests at
`kbs/v0/provisioner/provision/{uuid}` to remove provisioned resources.

Authentication is routed through the KBS admin auth path (validate_auth returns true) instead of requiring a TEE attestation token, since the caller is infrastructure (hook sidecar), not a TEE guest.

Note that I already did a first review using Claude.