### PR TITLE
KBS API: Add the option to register trusted TPM Attestation Key

### DIFF
--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -279,6 +279,43 @@ impl AttestationService {
             .context("query reference values")
     }
 
+    /// Register a trusted TPM Attestation Key (AK) public key.
+    /// The key is stored as a PEM file in the trusted AK keys directory.
+    pub async fn register_attestation_key(&self, key_pem: &str) -> Result<()> {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        use std::io::Write;
+
+        let trusted_ak_keys_dir = self
+            .config
+            .verifier_config
+            .as_ref()
+            .and_then(|c| c.trusted_ak_keys_dir())
+            .unwrap_or_else(|| std::path::PathBuf::from("/etc/tpm/trusted_ak_keys"));
+
+        std::fs::create_dir_all(&trusted_ak_keys_dir).with_context(|| {
+            format!(
+                "Failed to create trusted AK keys directory: {:?}",
+                trusted_ak_keys_dir
+            )
+        })?;
+
+        // Generate a deterministic filename from the key content for idempotency
+        let mut hasher = DefaultHasher::new();
+        key_pem.hash(&mut hasher);
+        let hash = hasher.finish();
+        let filename = format!("{:016x}.pub", hash);
+        let key_path = trusted_ak_keys_dir.join(&filename);
+
+        let mut file = std::fs::File::create(&key_path)
+            .with_context(|| format!("Failed to create AK key file: {:?}", key_path))?;
+        file.write_all(key_pem.as_bytes())
+            .with_context(|| format!("Failed to write AK key file: {:?}", key_path))?;
+
+        info!("Registered TPM attestation key: {}", filename);
+        Ok(())
+    }
+
     pub async fn generate_supplemental_challenge(
         &self,
         tee: Tee,

--- a/deps/verifier/src/lib.rs
+++ b/deps/verifier/src/lib.rs
@@ -68,6 +68,19 @@ pub struct VerifierConfig {
     dcap_verifier: Option<intel_dcap::QcnlConfig>,
 }
 
+impl VerifierConfig {
+    /// Get the trusted AK keys directory from TPM verifier config, if available.
+    pub fn trusted_ak_keys_dir(&self) -> Option<std::path::PathBuf> {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "tpm-verifier")] {
+                self.tpm_verifier.as_ref().map(|c| c.trusted_ak_keys_dir.clone())
+            } else {
+                None
+            }
+        }
+    }
+}
+
 pub async fn to_verifier(
     tee: &Tee,
     _config: Option<VerifierConfig>,

--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -300,6 +300,21 @@ pub(crate) async fn api(
             Ok(HttpResponse::Ok().content_type("application/json").finish())
         }
 
+        #[cfg(feature = "as")]
+        "attestation-key" if request.method() == Method::POST => {
+            core.admin.check_admin_access(&request)?;
+            let key_pem = std::str::from_utf8(&body).map_err(|_| Error::AttestationKeyError {
+                message: "Failed to parse attestation key: invalid UTF-8".to_string(),
+            })?;
+            core.attestation_service
+                .register_attestation_key(key_pem)
+                .await
+                .map_err(|e| Error::AttestationKeyError {
+                    message: format!("Failed to register attestation key: {e}"),
+                })?;
+
+            Ok(HttpResponse::Ok().content_type("application/json").finish())
+        }
         // TODO: consider to rename the api name for it is not only for
         // resource retrievement but for all plugins.
         "resource-policy" if request.method() == Method::POST => {

--- a/kbs/src/attestation/backend.rs
+++ b/kbs/src/attestation/backend.rs
@@ -121,6 +121,13 @@ pub trait Attest: Send + Sync {
             "Attestation Service does not support reference value configuration."
         ))
     }
+
+    /// Register a trusted TPM Attestation Key (AK) public key
+    async fn register_attestation_key(&self, _key_pem: &str) -> anyhow::Result<()> {
+        Err(anyhow!(
+            "Attestation Service does not support attestation key management."
+        ))
+    }
 }
 
 /// Attestation Service
@@ -478,6 +485,11 @@ impl AttestationService {
             }
             None => bail!("No reference value found for the given id: {reference_value_id}"),
         }
+    }
+
+    pub async fn register_attestation_key(&self, key_pem: &str) -> anyhow::Result<()> {
+        self.inner.register_attestation_key(key_pem).await?;
+        Ok(())
     }
 }
 

--- a/kbs/src/attestation/coco/builtin.rs
+++ b/kbs/src/attestation/coco/builtin.rs
@@ -131,6 +131,14 @@ impl Attest for BuiltInCoCoAs {
             .await?;
         Ok(rvs)
     }
+
+    async fn register_attestation_key(&self, key_pem: &str) -> anyhow::Result<()> {
+        self.inner
+            .read()
+            .await
+            .register_attestation_key(key_pem)
+            .await
+    }
 }
 
 impl BuiltInCoCoAs {

--- a/kbs/src/error.rs
+++ b/kbs/src/error.rs
@@ -76,6 +76,9 @@ pub enum Error {
     #[error("RVPS configuration failed: {message}")]
     RvpsError { message: String },
 
+    #[error("Attestation key management failed: {message}")]
+    AttestationKeyError { message: String },
+
     #[error("Serialize/Deserialize failed")]
     SerdeError(#[from] serde_json::Error),
 

--- a/tools/kbs-client/src/lib.rs
+++ b/tools/kbs-client/src/lib.rs
@@ -375,6 +375,39 @@ pub async fn get_rv(
     }
 }
 
+/// Register a trusted TPM Attestation Key (AK) public key.
+/// Input parameters:
+/// - url: KBS server root URL.
+/// - auth_key: KBS owner's authenticate private key (PEM string).
+/// - key_pem: AK public key content in PEM format.
+/// - kbs_root_certs_pem: Custom HTTPS root certificate of KBS server. It can be left blank.
+pub async fn set_attestation_key(
+    url: &str,
+    auth_key: String,
+    key_pem: Vec<u8>,
+    kbs_root_certs_pem: Vec<String>,
+) -> Result<()> {
+    let token = sign_admin_token(&auth_key)?;
+
+    let http_client = build_http_client(kbs_root_certs_pem)?;
+
+    let attestation_key_url = format!("{}/{KBS_URL_PREFIX}/attestation-key", url);
+    let res = http_client
+        .post(attestation_key_url)
+        .header("Content-Type", "application/x-pem-file")
+        .bearer_auth(token)
+        .body(key_pem)
+        .send()
+        .await?;
+
+    match res.status() {
+        reqwest::StatusCode::OK => Ok(()),
+        _ => {
+            bail!("Request Failed, Response: {:?}", res.text().await?)
+        }
+    }
+}
+
 fn build_http_client(kbs_root_certs_pem: Vec<String>) -> Result<reqwest::Client> {
     let mut client_builder =
         reqwest::Client::builder().user_agent(format!("kbs-client/{}", env!("CARGO_PKG_VERSION")));

--- a/tools/kbs-client/src/main.rs
+++ b/tools/kbs-client/src/main.rs
@@ -159,6 +159,13 @@ enum ConfigCommands {
         path: String,
     },
 
+    /// Register a trusted TPM Attestation Key (AK) public key
+    SetAttestationKey {
+        /// Path to the AK public key file (PEM format)
+        #[clap(long, value_parser)]
+        key_file: PathBuf,
+    },
+
     /// Get reference value from RVPS given reference value ID
     GetReferenceValue {
         /// The ID of the reference value.
@@ -359,6 +366,18 @@ async fn main() -> Result<()> {
                     )
                     .await?;
                     println!("Delete resource success");
+                }
+                ConfigCommands::SetAttestationKey { key_file } => {
+                    let key_bytes = std::fs::read(&key_file)
+                        .inspect_err(|_| eprintln!("Failed to read: {}", key_file.display()))?;
+                    kbs_client::set_attestation_key(
+                        &cli.url,
+                        auth_key.clone(),
+                        key_bytes,
+                        kbs_cert.clone(),
+                    )
+                    .await?;
+                    println!("Set attestation key success");
                 }
                 ConfigCommands::SetSampleReferenceValue {
                     name,


### PR DESCRIPTION
This pull request introduces support for registering trusted TPM Attestation Key (AK) public keys, exposing new API and CLI commands for registering these keys. 
The implementation follows a similar pattern to register reference value.