### PR TITLE
kbs: fix boolean feature flags being ignored when FEATURES is passed on command line

### DIFF
--- a/kbs/Makefile
+++ b/kbs/Makefile
@@ -50,19 +50,19 @@ else ifneq ($(AS_TYPE), )
 endif
 
 ifeq ($(ALIYUN), true)
-  FEATURES := $(FEATURES),aliyun
+  override FEATURES := $(FEATURES),aliyun
 endif
 
 ifeq ($(NEBULA_CA_PLUGIN), true)
-  FEATURES := $(FEATURES),nebula-ca-plugin
+  override FEATURES := $(FEATURES),nebula-ca-plugin
 endif
 
 ifeq ($(VAULT), true)
-  FEATURES := $(FEATURES),vault
+  override FEATURES := $(FEATURES),vault
 endif
 
 ifeq ($(EXTERNAL_PLUGIN), true)
-  FEATURES := $(FEATURES),external-plugin
+  override FEATURES := $(FEATURES),external-plugin
 endif
 
 ifeq ($(CLI_FEATURES),sample_only)


### PR DESCRIPTION


GNU Make treats command-line variables as overrides, so assignments like 'FEATURES := $(FEATURES),vault' inside the Makefile are silently ignored when FEATURES is already set via the command line (e.g. FEATURES=pkcs11). Use the 'override' directive so that VAULT, ALIYUN, NEBULA_CA_PLUGIN, and EXTERNAL_PLUGIN conditionals always append to FEATURES regardless of how FEATURES was initially set.

Found by @aramirez-capacity
https://github.com/confidential-containers/trustee/pull/1288#issuecomment-4344076591