### PR TITLE
Add RVPS storage override support

### DIFF
--- a/attestation-service/docs/config.md
+++ b/attestation-service/docs/config.md
@@ -60,8 +60,11 @@ If `type` is set to `BuiltIn`, the following extra properties can be set:
 | Property | Type | Description | Required | Default |
 |----------|------|-------------|----------|---------|
 | `extractors` | Object | Optional configuration for provenance extractors | No | None |
+| `storage` | [StorageBackendConfig][4] | Optional RVPS-specific storage configuration. If provided, overrides the unified `storage_backend` for RVPS only. If omitted, falls back to the unified `storage_backend`. | No | None |
 
-**Note:** Storage configuration for BuiltIn RVPS is now managed through the unified `storage_backend` configuration (see [Storage Backend Configuration](#storage-backend-configuration)). The BuiltIn RVPS will use the `reference_value` namespace from the unified storage backend.
+> [!NOTE]
+> **Storage Configuration:** By default, BuiltIn RVPS uses the unified `storage_backend` configuration (see [Storage Backend Configuration](#storage-backend-configuration)) with the `reference_value` namespace. However, you can optionally provide a `storage` field to configure RVPS-specific storage that differs from other components.
+> This allows you to use different storage backends for different components (e.g., LocalFs for KBS and AS policies, but LocalJson for RVPS reference values).
 
 For detailed information about extractors configuration, including available extractors and their options, see the [RVPS README](../../rvps/README.md#extractors-configuration).
 
@@ -217,6 +220,35 @@ Running with a built-in RVPS with extractor configuration:
         "type": "BuiltIn",
         "extractors": {
             "swid_extractor": {}
+        }
+    },
+    "attestation_token_broker": {
+        "duration_min": 5
+    }
+}
+```
+
+Running with a built-in RVPS with RVPS-specific storage configuration:
+
+```json
+{
+    "storage_backend": {
+        "storage_type": "LocalFs",
+        "backends": {
+            "local_fs": {
+                "dir_path": "/var/lib/attestation-service/storage"
+            }
+        }
+    },
+    "rvps_config": {
+        "type": "BuiltIn",
+        "storage": {
+            "storage_type": "LocalJson",
+            "backends": {
+                "local_json": {
+                    "file_dir_path": "/var/lib/rvps/references"
+                }
+            }
         }
     },
     "attestation_token_broker": {

--- a/attestation-service/src/config.rs
+++ b/attestation-service/src/config.rs
@@ -88,7 +88,7 @@ mod tests {
 
     #[rstest]
     #[case("./tests/configs/example1.json", Config {
-        rvps_config: RvpsConfig::BuiltIn { extractors: None },
+        rvps_config: RvpsConfig::BuiltIn { extractors: None, storage: None },
         attestation_token_broker: EarTokenConfiguration {
             duration_min: 5,
             issuer_name: "test".into(),
@@ -111,7 +111,7 @@ mod tests {
         },
     })]
     #[case("./tests/configs/example2.json", Config {
-        rvps_config: RvpsConfig::BuiltIn { extractors: None },
+        rvps_config: RvpsConfig::BuiltIn { extractors: None, storage: None },
         attestation_token_broker: EarTokenConfiguration {
             duration_min: 5,
             issuer_name: "test".into(),

--- a/attestation-service/src/rvps/mod.rs
+++ b/attestation-service/src/rvps/mod.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use key_value_storage::{KeyValueStorageStructConfig, KeyValueStorageType};
+use key_value_storage::{KeyValueStorageStructConfig, KeyValueStorageType, StorageBackendConfig};
 pub use reference_value_provider_service::config::Config as RvpsCrateConfig;
 use reference_value_provider_service::extractors::ExtractorsConfig;
 use serde::Deserialize;
@@ -60,6 +60,12 @@ pub trait RvpsApi {
 pub enum RvpsConfig {
     BuiltIn {
         extractors: Option<ExtractorsConfig>,
+
+        /// Optional storage backend configuration for RVPS.
+        /// If provided, overrides the unified storage_backend for RVPS storage.
+        /// If None, falls back to the unified storage_backend.
+        #[serde(default)]
+        storage: Option<StorageBackendConfig>,
     },
     #[cfg(feature = "rvps-grpc")]
     GrpcRemote(grpc::RvpsRemoteConfig),
@@ -67,7 +73,10 @@ pub enum RvpsConfig {
 
 impl Default for RvpsConfig {
     fn default() -> Self {
-        Self::BuiltIn { extractors: None }
+        Self::BuiltIn {
+            extractors: None,
+            storage: None,
+        }
     }
 }
 
@@ -80,10 +89,37 @@ pub async fn initialize_rvps_client(
     storage_config: &KeyValueStorageStructConfig,
 ) -> Result<RvpsClient> {
     match config {
-        RvpsConfig::BuiltIn { extractors } => {
+        RvpsConfig::BuiltIn {
+            extractors,
+            storage,
+        } => {
             info!("launch a built-in RVPS.");
+
+            // Use RVPS-specific storage if provided, otherwise fall back to defaults
+            let (actual_storage_type, actual_storage_config) = match storage {
+                Some(rvps_storage) => {
+                    info!(
+                        "Using RVPS-specific storage configuration: {:?}",
+                        rvps_storage.storage_type
+                    );
+                    (rvps_storage.storage_type, &rvps_storage.backends)
+                }
+                None => {
+                    info!(
+                        "Using unified storage configuration for RVPS: {:?}",
+                        storage_type
+                    );
+                    (storage_type, storage_config)
+                }
+            };
+
             Ok(Arc::new(Mutex::new(
-                builtin::BuiltinRvps::new(extractors.clone(), storage_type, storage_config).await?,
+                builtin::BuiltinRvps::new(
+                    extractors.clone(),
+                    actual_storage_type,
+                    actual_storage_config,
+                )
+                .await?,
             )) as RvpsClient)
         }
         #[cfg(feature = "rvps-grpc")]

--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -148,7 +148,10 @@ impl TestHarness {
 
         // Setup RVPS either remotely or builtin
         let rvps_config = match &test_parameters.rvps_type {
-            RvpsType::Builtin => RvpsConfig::BuiltIn { extractors: None },
+            RvpsType::Builtin => RvpsConfig::BuiltIn {
+                extractors: None,
+                storage: None,
+            },
             RvpsType::Remote => {
                 info!("Starting Remote RVPS");
                 let service = Rvps::new(RVPSConfig {

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -127,8 +127,11 @@ If `type` is set to `BuiltIn`, the following extra properties can be set:
 | Property | Type | Description | Required | Default |
 |----------|------|-------------|----------|---------|
 | `extractors` | Object | Optional configuration for provenance extractors | No | None |
+| `storage` | Object | Optional RVPS-specific storage configuration (same format as `storage_backend`). If provided, overrides the unified `storage_backend` for RVPS only. If omitted, falls back to the unified `storage_backend`. | No | None |
 
-**Note:** Storage configuration for BuiltIn RVPS is now managed through the unified `storage_backend` configuration (see [Storage Backend Configuration](#storage-backend-configuration)). The BuiltIn RVPS will use the `reference_value` namespace from the unified storage backend.
+> [!NOTE]
+> **Storage Configuration:** By default, BuiltIn RVPS uses the unified `storage_backend` configuration (see [Storage Backend Configuration](#storage-backend-configuration)) with the `reference_value` namespace. However, you can optionally provide a `storage` field to configure RVPS-specific storage that differs from other components.
+> This allows you to use different storage backends for different components (e.g., LocalFs for KBS resources, but LocalJson for RVPS reference values).
 
 For detailed information about extractors configuration, including available extractors and their options, see the [RVPS README](../../rvps/README.md#extractors-configuration).
 
@@ -397,7 +400,6 @@ duration_min = 5
 
 [attestation_service.rvps_config]
 type = "BuiltIn"
-# Note: storage will be overridden by storage_backend if provided
 # Optional: configure extractors
 # [attestation_service.rvps_config.extractors]
 # swid_extractor = {}
@@ -405,7 +407,52 @@ type = "BuiltIn"
 [[plugins]]
 name = "resource"
 type = "kvstorage"
-# Note: When using kvstorage, storage will be overridden by storage_backend if provided
+```
+
+### Using RVPS-Specific Storage Configuration
+
+You can configure RVPS to use a different storage backend than the rest of KBS:
+
+```toml
+[http_server]
+sockets = ["0.0.0.0:8080"]
+insecure_http = true
+
+[admin]
+type = "InsecureAllowAll"
+
+[attestation_token]
+
+# Unified storage backend for most components (LocalFs)
+[storage_backend]
+storage_type = "LocalFs"
+
+[storage_backend.backends.local_fs]
+dir_path = "/opt/confidential-containers/storage"
+
+[attestation_service]
+type = "coco_as_builtin"
+
+[attestation_service.attestation_token_broker]
+duration_min = 5
+
+[attestation_service.rvps_config]
+type = "BuiltIn"
+
+# RVPS-specific storage override (LocalJson)
+[attestation_service.rvps_config.storage]
+storage_type = "LocalJson"
+
+[attestation_service.rvps_config.storage.backends.local_json]
+file_dir_path = "/var/lib/rvps/references"
+
+# Optional: configure extractors
+[attestation_service.rvps_config.extractors]
+swid_extractor = {}
+
+[[plugins]]
+name = "resource"
+type = "kvstorage"
 ```
 
 ### Using a remote CoCo AS

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -354,7 +354,7 @@ mod tests {
             attestation_service:
                 crate::attestation::config::AttestationServiceConfig::CoCoASBuiltIn(
                     crate::attestation::coco::builtin::Config {
-                        rvps_config: RvpsConfig::BuiltIn { extractors: None },
+                        rvps_config: RvpsConfig::BuiltIn { extractors: None, storage: None },
                         attestation_token_broker: EarTokenConfiguration {
                             duration_min: 5,
                             ..Default::default()
@@ -496,7 +496,7 @@ mod tests {
             attestation_service:
                 crate::attestation::config::AttestationServiceConfig::CoCoASBuiltIn(
                     crate::attestation::coco::builtin::Config {
-                        rvps_config: RvpsConfig::BuiltIn { extractors: None },
+                        rvps_config: RvpsConfig::BuiltIn { extractors: None, storage: None },
                         attestation_token_broker: EarTokenConfiguration {
                             duration_min: 5,
                             ..Default::default()

--- a/rvps/README.md
+++ b/rvps/README.md
@@ -237,6 +237,54 @@ In this mode, the RVPS will work as a crate inside the Attestation Service binar
 
 ![](./diagrams/rvps-native.svg)
 
+> [!NOTE]
+> **Storage Configuration:** By default, RVPS in native mode uses the unified `storage_backend` configuration (see [Storage Backend Configuration](#storage-backend-configuration)) with the `reference_value` namespace. However, you can optionally provide a `storage` field to configure RVPS-specific storage that differs from other components.
+> This allows you to use different storage backends for different components (e.g., LocalFs for KBS resources, but LocalJson for RVPS reference values).
+
+**Example with shared storage (default behavior):**
+
+```json
+{
+    "storage_backend": {
+        "storage_type": "LocalFs",
+        "backends": {
+            "local_fs": {
+                "dir_path": "/var/lib/attestation-service/storage"
+            }
+        }
+    },
+    "rvps_config": {
+        "type": "BuiltIn"
+    }
+}
+```
+
+**Example with RVPS-specific storage override:**
+
+```json
+{
+    "storage_backend": {
+        "storage_type": "LocalFs",
+        "backends": {
+            "local_fs": {
+                "dir_path": "/var/lib/attestation-service/storage"
+            }
+        }
+    },
+    "rvps_config": {
+        "type": "BuiltIn",
+        "storage": {
+            "storage_type": "LocalJson",
+            "backends": {
+                "local_json": {
+                    "file_dir_path": "/var/lib/rvps/references"
+                }
+            }
+        }
+    }
+}
+```
+
 ### gRPC Mode
 
 In this mode, the Attestation Service will connect to a remote RVPS. This requires the Attestation Service to be built with feature `rvps-grpc`.


### PR DESCRIPTION
It partially addresses issue #1273, by providing the option to override the RVPS storage. If RVPS storage not provided, it fallbacks to the general storage configuration.