### PR TITLE
kbs: ita: multi GPU support

### DIFF
--- a/kbs/README.md
+++ b/kbs/README.md
@@ -4,7 +4,7 @@ The Confidential Containers Key Broker Service (KBS) facilitates remote attestat
 The KBS is an implementation of a [Relying Party](https://www.ietf.org/archive/id/draft-ietf-rats-architecture-22.html).
 The KBS itself does not validate attestation evidence. Instead, it supports different external components to verify TEE evidence in the form of plug-ins, including
 - [CoCo Attestation-Service (CoCo AS)](../attestation-service/) ([All plugins](../attestation-service/README.md#attestation-service) supported)
-- [Intel Trust Authority (ITA)](src/attestation/intel_trust_authority/) (Only supports SGX/TDX)
+- [Intel Trust Authority (ITA)](src/attestation/intel_trust_authority/) (Supports SGX/TDX/NVIDIA GPUs)
 
 # Quick Start
 

--- a/kbs/src/attestation/intel_trust_authority/mod.rs
+++ b/kbs/src/attestation/intel_trust_authority/mod.rs
@@ -143,112 +143,128 @@ pub struct IntelTrustAuthority {
     token_verifier: JwkAttestationTokenVerifier,
 }
 
+/// Build the ITA attestation request from a list of independent evidences.
+///
+/// Returns the populated request data and a URL suffix to append after [`BASE_AS_ADDR`]
+/// (e.g. [`AZURE_ADDR_SUFFIX`] for Azure TDX, or an empty string otherwise).
+fn build_attest_request(
+    evidence_to_verify: Vec<IndependentEvidence>,
+    policy_ids: Vec<String>,
+    policy_must_match: bool,
+) -> Result<(AttestReqData, String)> {
+    let mut request_data = AttestReqData {
+        policy_ids,
+        policy_must_match,
+        tdx: None,
+        sgx: None,
+        nvgpu: None,
+    };
+
+    let mut url_suffix = String::new();
+
+    for independent_evidence in evidence_to_verify {
+        match independent_evidence.tee {
+            Tee::AzTdxVtpm => {
+                url_suffix = AZURE_ADDR_SUFFIX.to_string();
+
+                let evidence = from_value::<AzItaTeeEvidence>(independent_evidence.tee_evidence)
+                    .context(format!(
+                        "Failed to deserialize TEE: {:?} Evidence",
+                        independent_evidence.tee
+                    ))?;
+
+                let hcl_report = HclReport::new(evidence.hcl_report().clone())?;
+
+                request_data.tdx = Some(DcapTeeEvidence {
+                    quote: STANDARD.encode(evidence.td_quote()),
+                    runtime_data: STANDARD.encode(hcl_report.var_data()),
+                    user_data: Some(STANDARD.encode(independent_evidence.runtime_data.to_string())),
+                    event_log: None,
+                });
+            }
+            Tee::Tdx => {
+                let mut evidence = from_value::<DcapTeeEvidence>(independent_evidence.tee_evidence)
+                    .context(format!(
+                        "Failed to deserialize TEE: {:?} Evidence",
+                        independent_evidence.tee
+                    ))?;
+
+                evidence.runtime_data =
+                    STANDARD.encode(independent_evidence.runtime_data.to_string());
+
+                request_data.tdx = Some(evidence);
+            }
+            Tee::Sgx => {
+                let mut evidence = from_value::<DcapTeeEvidence>(independent_evidence.tee_evidence)
+                    .context(format!(
+                        "Failed to deserialize TEE: {:?} Evidence",
+                        independent_evidence.tee
+                    ))?;
+
+                evidence.runtime_data =
+                    STANDARD.encode(independent_evidence.runtime_data.to_string());
+
+                request_data.sgx = Some(evidence);
+            }
+            Tee::Nvidia => {
+                let evidence = from_value::<NvDeviceEvidence>(independent_evidence.tee_evidence)
+                    .context(format!(
+                        "Failed to deserialize TEE: {:?} Evidence",
+                        independent_evidence.tee
+                    ))?;
+
+                if evidence.device_evidence_list.is_empty() {
+                    warn!(
+                        "TEE {:?} evidence has empty device list. Drop the evidence.",
+                        independent_evidence.tee
+                    );
+                    continue;
+                }
+
+                // only one GPU supported at the moment
+                let mut nvgpu = evidence.device_evidence_list[0].clone();
+
+                let runtime_data_hash =
+                    Sha512::digest(independent_evidence.runtime_data.to_string()).to_vec();
+                nvgpu.gpu_nonce = hex::encode(&runtime_data_hash[0..32]);
+
+                request_data.nvgpu = Some(NvGpuRequest {
+                    gpu_nonce,
+                    arch,
+                    evidence_list: devices
+                        .into_iter()
+                        .map(|d| NvGpuEvidenceItem {
+                            evidence: d.evidence,
+                            certificate: d.certificate,
+                        })
+                        .collect(),
+                });
+            }
+            _ => {
+                bail!(
+                    "Intel Trust Authority: TEE {0:?} is not supported.",
+                    independent_evidence.tee
+                );
+            }
+        };
+    }
+
+    Ok((request_data, url_suffix))
+}
+
 #[async_trait]
 impl Attest for IntelTrustAuthority {
     async fn verify(&self, evidence_to_verify: Vec<IndependentEvidence>) -> anyhow::Result<String> {
         let policy_ids = self.config.policy_ids.clone();
-
         let policy_must_match = match policy_ids.is_empty() {
             true => false,
             false => !self.config.allow_unmatched_policy.unwrap_or_default(),
         };
 
-        let mut request_data = AttestReqData {
-            policy_ids,
-            policy_must_match,
-            tdx: None,
-            sgx: None,
-            nvgpu: None,
-        };
+        let (request_data, url_suffix) =
+            build_attest_request(evidence_to_verify, policy_ids, policy_must_match)?;
 
-        let mut att_url = format!("{}{BASE_AS_ADDR}", &self.config.base_url);
-
-        for independent_evidence in evidence_to_verify {
-            match independent_evidence.tee {
-                Tee::AzTdxVtpm => {
-                    att_url = format!("{att_url}{AZURE_ADDR_SUFFIX}");
-
-                    let evidence = from_value::<AzItaTeeEvidence>(
-                        independent_evidence.tee_evidence,
-                    )
-                    .context(format!(
-                        "Failed to deserialize TEE: {:?} Evidence",
-                        independent_evidence.tee
-                    ))?;
-
-                    let hcl_report = HclReport::new(evidence.hcl_report().clone())?;
-
-                    request_data.tdx = Some(DcapTeeEvidence {
-                        quote: STANDARD.encode(evidence.td_quote()),
-                        runtime_data: STANDARD.encode(hcl_report.var_data()),
-                        user_data: Some(
-                            STANDARD.encode(independent_evidence.runtime_data.to_string()),
-                        ),
-                        event_log: None,
-                    });
-                }
-                Tee::Tdx => {
-                    let mut evidence = from_value::<DcapTeeEvidence>(
-                        independent_evidence.tee_evidence,
-                    )
-                    .context(format!(
-                        "Failed to deserialize TEE: {:?} Evidence",
-                        independent_evidence.tee
-                    ))?;
-
-                    evidence.runtime_data =
-                        STANDARD.encode(independent_evidence.runtime_data.to_string());
-
-                    request_data.tdx = Some(evidence);
-                }
-                Tee::Sgx => {
-                    let mut evidence = from_value::<DcapTeeEvidence>(
-                        independent_evidence.tee_evidence,
-                    )
-                    .context(format!(
-                        "Failed to deserialize TEE: {:?} Evidence",
-                        independent_evidence.tee
-                    ))?;
-
-                    evidence.runtime_data =
-                        STANDARD.encode(independent_evidence.runtime_data.to_string());
-
-                    request_data.sgx = Some(evidence);
-                }
-                Tee::Nvidia => {
-                    let evidence = from_value::<NvDeviceEvidence>(
-                        independent_evidence.tee_evidence,
-                    )
-                    .context(format!(
-                        "Failed to deserialize TEE: {:?} Evidence",
-                        independent_evidence.tee
-                    ))?;
-
-                    if evidence.device_evidence_list.is_empty() {
-                        warn!(
-                            "TEE {:?} evidence has empty device list. Drop the evidence.",
-                            independent_evidence.tee
-                        );
-                        continue;
-                    }
-
-                    // only one GPU supported at the moment
-                    let mut nvgpu = evidence.device_evidence_list[0].clone();
-
-                    let runtime_data_hash =
-                        Sha512::digest(independent_evidence.runtime_data.to_string()).to_vec();
-                    nvgpu.gpu_nonce = hex::encode(&runtime_data_hash[0..32]);
-
-                    request_data.nvgpu = Some(nvgpu);
-                }
-                _ => {
-                    bail!(
-                        "Intel Trust Authority: TEE {0:?} is not supported.",
-                        independent_evidence.tee
-                    );
-                }
-            };
-        }
+        let att_url = format!("{}{BASE_AS_ADDR}{url_suffix}", &self.config.base_url);
 
         let attest_req_body = serde_json::to_string(&request_data)
             .context("Failed to serialize attestation request body")?;

--- a/kbs/src/attestation/intel_trust_authority/mod.rs
+++ b/kbs/src/attestation/intel_trust_authority/mod.rs
@@ -104,6 +104,22 @@ struct NvDeviceReportAndCert {
     arch: String,
 }
 
+/// ITA Nvidia GPU attestation request body.
+///
+/// ITA accepts `evidence_list` for both single and multi-GPU attestation.
+#[derive(Serialize, Debug)]
+struct NvGpuRequest {
+    gpu_nonce: String,
+    arch: String,
+    evidence_list: Vec<NvGpuEvidenceItem>,
+}
+
+#[derive(Serialize, Debug)]
+struct NvGpuEvidenceItem {
+    evidence: String,
+    certificate: String,
+}
+
 #[derive(Serialize, Debug)]
 struct AttestReqData {
     policy_ids: Vec<String>,
@@ -113,7 +129,7 @@ struct AttestReqData {
     #[serde(skip_serializing_if = "Option::is_none")]
     sgx: Option<DcapTeeEvidence>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    nvgpu: Option<NvDeviceReportAndCert>,
+    nvgpu: Option<NvGpuRequest>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -221,12 +237,34 @@ fn build_attest_request(
                     continue;
                 }
 
-                // only one GPU supported at the moment
-                let mut nvgpu = evidence.device_evidence_list[0].clone();
+                // Filter out unsupported archs (e.g. LS10 NVSwitch) — ITA only accepts
+                // HOPPER and BLACKWELL GPUs.
+                let devices: Vec<_> = evidence
+                    .device_evidence_list
+                    .into_iter()
+                    .filter(|d| {
+                        let ok = d.arch == "HOPPER" || d.arch == "BLACKWELL";
+                        if !ok {
+                            warn!(
+                                "ITA: unsupported Nvidia device arch {:?}, skipping it",
+                                d.arch
+                            );
+                        }
+                        ok
+                    })
+                    .collect();
+
+                if devices.is_empty() {
+                    warn!(
+                        "ITA: no supported Nvidia GPU devices after filtering, dropping evidence"
+                    );
+                    continue;
+                }
 
                 let runtime_data_hash =
                     Sha512::digest(independent_evidence.runtime_data.to_string()).to_vec();
-                nvgpu.gpu_nonce = hex::encode(&runtime_data_hash[0..32]);
+                let gpu_nonce = hex::encode(&runtime_data_hash[0..32]);
+                let arch = devices[0].arch.clone();
 
                 request_data.nvgpu = Some(NvGpuRequest {
                     gpu_nonce,


### PR DESCRIPTION
ITA accepts evidence_list for both single and multi-GPU attestation, so a single NvGpuRequest shape with gpu_nonce, arch and evidence_list covers all cases. Devices with unsupported archs (e.g. LS10 NVSwitch) are logged as a warning and filtered out.