### PR TITLE
tests: adjust timeout in integration test

### DIFF
--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -41,7 +41,7 @@ use tracing_subscriber::fmt;
 
 const KBS_URL: &str = "http://127.0.0.1:8081";
 const RVPS_URL: &str = "http://127.0.0.1:51003";
-const WAIT_TIME: u64 = 5000;
+const WAIT_TIME: u64 = 10000;
 
 const ALLOW_ALL_POLICY: &str = "
     package policy


### PR DESCRIPTION
Last time we had intermittent issues with the integration tests it was related to this timeout. Let's try increasing it. Possibly the recent changes to the config and storage backend have increased startup time.

If this doesn't change anything I will investigate more closely.