### PR TITLE
KBS: rename repository config from 'type' to 'storage_backend_type'

### DIFF
--- a/kbs/config/docker-compose/kbs-config.toml
+++ b/kbs/config/docker-compose/kbs-config.toml
@@ -18,7 +18,7 @@ public_key_path = "/opt/confidential-containers/kbs/user-keys/public.pub"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"
 
 [storage_backend]
 storage_type = "LocalFs"

--- a/kbs/config/kbs-config-grpc.toml
+++ b/kbs/config/kbs-config-grpc.toml
@@ -21,4 +21,4 @@ dir_path = "/opt/confidential-containers/storage"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"

--- a/kbs/config/kbs-config-intel-trust-authority.toml
+++ b/kbs/config/kbs-config-intel-trust-authority.toml
@@ -22,4 +22,4 @@ dir_path = "/opt/confidential-containers/storage"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"

--- a/kbs/config/kbs-config.toml
+++ b/kbs/config/kbs-config.toml
@@ -33,13 +33,13 @@ dir_path = "/opt/confidential-containers/storage"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"
 
 # Example configuration for HashiCorp Vault KV v1 backend
 # Supports both read and write operations with HTTPS support
 # [[plugins]]
 # name = "resource"
-# type = "Vault"
+# storage_backend_type = "Vault"
 # vault_url = "http://vault.example.com:8200"
 # token = "hvs.your-vault-token-here"
 # mount_path = "secret"  # Optional, defaults to "secret"

--- a/kbs/config/kubernetes/base/kbs-config.toml
+++ b/kbs/config/kubernetes/base/kbs-config.toml
@@ -25,7 +25,7 @@ public_key_path = "/kbs/kbs.pem"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"
 
 [storage_backend]
 storage_type = "LocalFs"

--- a/kbs/config/kubernetes/ita/kbs-config.toml
+++ b/kbs/config/kubernetes/ita/kbs-config.toml
@@ -22,7 +22,7 @@ public_key_path = "/kbs/kbs.pem"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"
 
 [storage_backend]
 storage_type = "LocalFs"

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -275,9 +275,9 @@ This is also called "Repository" in old versions. The properties to be configure
 |----------|--------|---------------------------------------------------------------|----------|------------|
 | `type`| String | Storage type for resources: `kvstorage`, `Aliyun`, `Vault` | No       | `kvstorage`|
 
-When `type = "kvstorage"` (default), the resource plugin uses the unified [storage backend](#storage-backend-configuration) with namespace `repository`. Configure storage in the `[storage_backend]` section only.
+When `storage_backend_type = "kvstorage"` (default), the resource plugin uses the unified [storage backend](#storage-backend-configuration) with namespace `repository`. Configure storage in the `[storage_backend]` section only.
 
-When `type = "Aliyun"`:
+When `storage_backend_type = "Aliyun"`:
 
 | Property          | Type   | Description                       | Required | Example                                             |
 |-------------------|--------|-----------------------------------|----------|-----------------------------------------------------|
@@ -286,7 +286,7 @@ When `type = "Aliyun"`:
 | `password`        | String | AAP client key password           | Yes      | `8f9989c18d27...`                                   |
 | `cert_pem`        | String | CA cert for the KMS instance      | Yes      | `-----BEGIN CERTIFICATE----- ...`                   |
 
-When `type = "Vault"`:
+When `storage_backend_type = "Vault"`:
 
 | Property     | Type          | Required | Description                                 | Default    |
 |--------------|---------------|----------|---------------------------------------------|------------|
@@ -406,7 +406,7 @@ type = "BuiltIn"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"
 ```
 
 ### Using RVPS-Specific Storage Configuration
@@ -452,7 +452,7 @@ swid_extractor = {}
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"
 ```
 
 ### Using a remote CoCo AS
@@ -476,7 +476,7 @@ dir_path = "/opt/confidential-containers/storage"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"
 ```
 
 Running with Intel Trust Authority attestation service:
@@ -514,7 +514,7 @@ dir_path = "/opt/confidential-containers/storage"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"
 ```
 
 Using Nebula CA plugin:
@@ -546,7 +546,7 @@ dir_path = "/opt/confidential-containers/storage"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"
 
 [[plugins]]
 name = "nebula-ca"
@@ -583,5 +583,5 @@ dir_path = "./work/storage"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"
 ```

--- a/kbs/docs/vault_kv.md
+++ b/kbs/docs/vault_kv.md
@@ -72,7 +72,7 @@ Add the Vault configuration to your KBS config file (e.g., `kbs-config.toml`):
 ```toml
 [[plugins]]
 name = "resource"
-type = "Vault"
+storage_backend_type = "Vault"
 vault_url = "https://vault.example.com:8200"
 token = "hvs.your-vault-token-here"
 mount_path = "kv"                              # Optional, defaults to "secret"
@@ -109,7 +109,7 @@ The backend supports secure HTTPS communication with comprehensive TLS configura
 ```toml
 [[plugins]]
 name = "resource"
-type = "Vault"
+storage_backend_type = "Vault"
 vault_url = "https://vault.example.com:8200"
 token = "hvs.your-vault-token-here"
 verify_ssl = true
@@ -122,7 +122,7 @@ For enterprise environments with custom certificate authorities:
 ```toml
 [[plugins]]
 name = "resource"
-type = "Vault"
+storage_backend_type = "Vault"
 vault_url = "https://vault.mycompany.com:8200"
 token = "hvs.your-vault-token-here"
 verify_ssl = true
@@ -137,7 +137,7 @@ ca_certs = [
 ```toml
 [[plugins]]
 name = "resource"
-type = "Vault"
+storage_backend_type = "Vault"
 vault_url = "http://vault-dev.mycompany.com:8200"
 token = "hvs.your-vault-token-here"
 verify_ssl = false

--- a/kbs/src/plugins/implementations/resource/backend.rs
+++ b/kbs/src/plugins/implementations/resource/backend.rs
@@ -77,7 +77,7 @@ impl fmt::Display for ResourceDesc {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Default)]
-#[serde(tag = "type")]
+#[serde(tag = "storage_backend_type")]
 pub enum RepositoryConfig {
     #[serde(alias = "kvstorage")]
     #[default]

--- a/kbs/test/config/kbs.toml
+++ b/kbs/test/config/kbs.toml
@@ -39,4 +39,4 @@ public_key_path = "./work/kbs.pem"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"

--- a/kbs/test/config/resource-kbs.toml
+++ b/kbs/test/config/resource-kbs.toml
@@ -20,4 +20,4 @@ dir_path = "./work/storage"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"

--- a/kbs/test_data/configs/coco-as-builtin-3.toml
+++ b/kbs/test_data/configs/coco-as-builtin-3.toml
@@ -23,4 +23,4 @@ type = "Simple"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"

--- a/kbs/test_data/configs/coco-as-grpc-1.toml
+++ b/kbs/test_data/configs/coco-as-grpc-1.toml
@@ -26,4 +26,4 @@ item = "value1"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"

--- a/kbs/test_data/configs/intel-ta-1.toml
+++ b/kbs/test_data/configs/intel-ta-1.toml
@@ -28,4 +28,4 @@ item = "value1"
 
 [[plugins]]
 name = "resource"
-type = "kvstorage"
+storage_backend_type = "kvstorage"


### PR DESCRIPTION
After our kvstorage reshuffle, the config for a plugin looks like this.
```
[[plugins]]
name = "resource"
type = "kvstorage"
```

It's confusing that type field is specifying the storage type but seems a plugin name.

This commit changes the name `type` to `backend_storage_type` to explicitly show what it means.

Close #1318