### PR TITLE
policy: fix hyphenisation in default policy for az_*_vtpm TEEs

### DIFF
--- a/attestation-service/src/ear_token/ear_default_policy_cpu.rego
+++ b/attestation-service/src/ear_token/ear_default_policy_cpu.rego
@@ -240,20 +240,20 @@ tdx_uefi_event_tdvfkernelparams_ok if {
 
 ##### Azure vTPM SNP
 executables := 3 if {
-	input.az_snp_vtpm
+	input["az-snp-vtpm"]
 
-	input.az_snp_vtpm.measurement in query_reference_value("measurement")
-	input.az_snp_vtpm.tpm.pcr11 in query_reference_value("snp_pcr11")
+	input["az-snp-vtpm"].measurement in query_reference_value("measurement")
+	input["az-snp-vtpm"].tpm.pcr11 in query_reference_value("snp_pcr11")
 }
 
 hardware := 2 if {
-	input.az_snp_vtpm
+	input["az-snp-vtpm"]
 
 	# Check the reported TCB to validate the ASP FW
-	input.az_snp_vtpm.reported_tcb_bootloader in query_reference_value("tcb_bootloader")
-	input.az_snp_vtpm.reported_tcb_microcode in query_reference_value("tcb_microcode")
-	input.az_snp_vtpm.reported_tcb_snp in query_reference_value("tcb_snp")
-	input.az_snp_vtpm.reported_tcb_tee in query_reference_value("tcb_tee")
+	input["az-snp-vtpm"].reported_tcb_bootloader in query_reference_value("tcb_bootloader")
+	input["az-snp-vtpm"].reported_tcb_microcode in query_reference_value("tcb_microcode")
+	input["az-snp-vtpm"].reported_tcb_snp in query_reference_value("tcb_snp")
+	input["az-snp-vtpm"].reported_tcb_tee in query_reference_value("tcb_tee")
 }
 
 # For the 'configuration' trust claim 2 stands for
@@ -261,46 +261,46 @@ hardware := 2 if {
 #
 # For this, we compare all the configuration fields.
 configuration := 2 if {
-	input.az_snp_vtpm
+	input["az-snp-vtpm"]
 
-	input.az_snp_vtpm.platform_smt_enabled in query_reference_value("smt_enabled")
-	input.az_snp_vtpm.platform_tsme_enabled in query_reference_value("tsme_enabled")
-	input.az_snp_vtpm.policy_abi_major in query_reference_value("abi_major")
-	input.az_snp_vtpm.policy_abi_minor in query_reference_value("abi_minor")
-	input.az_snp_vtpm.policy_single_socket in query_reference_value("single_socket")
-	input.az_snp_vtpm.policy_smt_allowed in query_reference_value("smt_allowed")
+	input["az-snp-vtpm"].platform_smt_enabled in query_reference_value("smt_enabled")
+	input["az-snp-vtpm"].platform_tsme_enabled in query_reference_value("tsme_enabled")
+	input["az-snp-vtpm"].policy_abi_major in query_reference_value("abi_major")
+	input["az-snp-vtpm"].policy_abi_minor in query_reference_value("abi_minor")
+	input["az-snp-vtpm"].policy_single_socket in query_reference_value("single_socket")
+	input["az-snp-vtpm"].policy_smt_allowed in query_reference_value("smt_allowed")
 }
 
 ##### Azure vTPM TDX
 executables := 3 if {
-	input.az_tdx_vtpm
+	input["az-tdx-vtpm"]
 
-	input.az_tdx_vtpm.tpm.pcr11 in query_reference_value("tdx_pcr11")
+	input["az-tdx-vtpm"].tpm.pcr11 in query_reference_value("tdx_pcr11")
 }
 
 hardware := 2 if {
-	input.az_tdx_vtpm
+	input["az-tdx-vtpm"]
 
 	# Check the quote is a TDX quote signed by Intel SGX Quoting Enclave
-	input.az_tdx_vtpm.quote.header.tee_type == "81000000"
-	input.az_tdx_vtpm.quote.header.vendor_id == "939a7233f79c4ca9940a0db3957f0607"
+	input["az-tdx-vtpm"].quote.header.tee_type == "81000000"
+	input["az-tdx-vtpm"].quote.header.vendor_id == "939a7233f79c4ca9940a0db3957f0607"
 
 	# Check TDX Module hash
 	# input.tdx.quote.body.mr_seam in query_reference_value("mr_seam")
 	#
 	# Check OVMF code hash
-	input.az_tdx_vtpm.quote.body.mr_td in query_reference_value("mr_td")
+	input["az-tdx-vtpm"].quote.body.mr_td in query_reference_value("mr_td")
 
 	# Check TCB status (covers quote.body.tcb_svn claim check)
-	input.az_tdx_vtpm.tcb_status == "UpToDate"
+	input["az-tdx-vtpm"].tcb_status == "UpToDate"
 
 	# Check minimum TCB date (See TDX section for details.)
 }
 
 configuration := 2 if {
-	input.az_tdx_vtpm
+	input["az-tdx-vtpm"]
 
-	input.az_tdx_vtpm.quote.body.xfam in query_reference_value("xfam")
+	input["az-tdx-vtpm"].quote.body.xfam in query_reference_value("xfam")
 }
 
 ##### TPM


### PR DESCRIPTION
Fixes #1323

The hyphenisation was removed in b7cd1ea281 and the policy has not been adjusted accordingly.