### PR TITLE
KBS/AS: add unified storage overwriting logic

### DIFF
--- a/attestation-service/config.json
+++ b/attestation-service/config.json
@@ -2,9 +2,7 @@
     "work_dir": "/var/lib/attestation-service/",
     "rvps_config": {
         "type": "BuiltIn",
-        "storage": {
-            "type": "LocalFs"
-        }
+        "storage_type": "LocalFs"
     },
     "attestation_token_broker": {
         "duration_min": 5

--- a/attestation-service/docs/config.md
+++ b/attestation-service/docs/config.md
@@ -60,10 +60,10 @@ If `type` is set to `BuiltIn`, the following extra properties can be set:
 | Property | Type | Description | Required | Default |
 |----------|------|-------------|----------|---------|
 | `extractors` | Object | Optional configuration for provenance extractors | No | None |
-| `storage` | [StorageBackendConfig][4] | Optional RVPS-specific storage configuration. If provided, overrides the unified `storage_backend` for RVPS only. If omitted, falls back to the unified `storage_backend`. | No | None |
+| `storage_type` | String | Optional RVPS-specific storage type override. If provided, overrides `storage_backend.storage_type` for RVPS only. Backend-specific parameters are still reused from `storage_backend.backends`. | No | None |
 
 > [!NOTE]
-> **Storage Configuration:** By default, BuiltIn RVPS uses the unified `storage_backend` configuration (see [Storage Backend Configuration](#storage-backend-configuration)) with the `reference_value` namespace. However, you can optionally provide a `storage` field to configure RVPS-specific storage that differs from other components.
+> **Storage Configuration:** By default, BuiltIn RVPS uses the unified `storage_backend` configuration (see [Storage Backend Configuration](#storage-backend-configuration)) with the `reference_value` namespace. However, you can optionally provide a `storage_type` field to override only the storage type used by RVPS.
 > This allows you to use different storage backends for different components (e.g., LocalFs for KBS and AS policies, but LocalJson for RVPS reference values).
 
 For detailed information about extractors configuration, including available extractors and their options, see the [RVPS README](../../rvps/README.md#extractors-configuration).
@@ -228,7 +228,7 @@ Running with a built-in RVPS with extractor configuration:
 }
 ```
 
-Running with a built-in RVPS with RVPS-specific storage configuration:
+Running with a built-in RVPS with RVPS-specific storage type override:
 
 ```json
 {
@@ -237,19 +237,15 @@ Running with a built-in RVPS with RVPS-specific storage configuration:
         "backends": {
             "local_fs": {
                 "dir_path": "/var/lib/attestation-service/storage"
+            },
+            "local_json": {
+                "file_dir_path": "/var/lib/rvps/references"
             }
         }
     },
     "rvps_config": {
         "type": "BuiltIn",
-        "storage": {
-            "storage_type": "LocalJson",
-            "backends": {
-                "local_json": {
-                    "file_dir_path": "/var/lib/rvps/references"
-                }
-            }
-        }
+        "storage_type": "LocalJson"
     },
     "attestation_token_broker": {
         "duration_min": 5

--- a/attestation-service/src/config.rs
+++ b/attestation-service/src/config.rs
@@ -88,7 +88,7 @@ mod tests {
 
     #[rstest]
     #[case("./tests/configs/example1.json", Config {
-        rvps_config: RvpsConfig::BuiltIn { extractors: None, storage: None },
+        rvps_config: RvpsConfig::BuiltIn { extractors: None, storage_type: None },
         attestation_token_broker: EarTokenConfiguration {
             duration_min: 5,
             issuer_name: "test".into(),
@@ -111,7 +111,7 @@ mod tests {
         },
     })]
     #[case("./tests/configs/example2.json", Config {
-        rvps_config: RvpsConfig::BuiltIn { extractors: None, storage: None },
+        rvps_config: RvpsConfig::BuiltIn { extractors: None, storage_type: None },
         attestation_token_broker: EarTokenConfiguration {
             duration_min: 5,
             issuer_name: "test".into(),

--- a/attestation-service/src/rvps/mod.rs
+++ b/attestation-service/src/rvps/mod.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use key_value_storage::{KeyValueStorageStructConfig, KeyValueStorageType, StorageBackendConfig};
+use key_value_storage::{KeyValueStorageStructConfig, KeyValueStorageType};
 pub use reference_value_provider_service::config::Config as RvpsCrateConfig;
 use reference_value_provider_service::extractors::ExtractorsConfig;
 use serde::Deserialize;
@@ -65,7 +65,7 @@ pub enum RvpsConfig {
         /// If provided, overrides the unified storage_backend for RVPS storage.
         /// If None, falls back to the unified storage_backend.
         #[serde(default)]
-        storage: Option<StorageBackendConfig>,
+        storage_type: Option<KeyValueStorageType>,
     },
     #[cfg(feature = "rvps-grpc")]
     GrpcRemote(grpc::RvpsRemoteConfig),
@@ -75,7 +75,7 @@ impl Default for RvpsConfig {
     fn default() -> Self {
         Self::BuiltIn {
             extractors: None,
-            storage: None,
+            storage_type: None,
         }
     }
 }
@@ -85,41 +85,22 @@ pub type RvpsClient = Arc<Mutex<dyn RvpsApi + Send + Sync>>;
 #[instrument(skip_all, name = "Initialize RVPS")]
 pub async fn initialize_rvps_client(
     config: &RvpsConfig,
-    storage_type: KeyValueStorageType,
+    unified_storage_type: KeyValueStorageType,
     storage_config: &KeyValueStorageStructConfig,
 ) -> Result<RvpsClient> {
     match config {
         RvpsConfig::BuiltIn {
             extractors,
-            storage,
+            storage_type,
         } => {
             info!("launch a built-in RVPS.");
 
             // Use RVPS-specific storage if provided, otherwise fall back to defaults
-            let (actual_storage_type, actual_storage_config) = match storage {
-                Some(rvps_storage) => {
-                    info!(
-                        "Using RVPS-specific storage configuration: {:?}",
-                        rvps_storage.storage_type
-                    );
-                    (rvps_storage.storage_type, &rvps_storage.backends)
-                }
-                None => {
-                    info!(
-                        "Using unified storage configuration for RVPS: {:?}",
-                        storage_type
-                    );
-                    (storage_type, storage_config)
-                }
-            };
+            let actual_storage_type = storage_type.unwrap_or(unified_storage_type);
 
             Ok(Arc::new(Mutex::new(
-                builtin::BuiltinRvps::new(
-                    extractors.clone(),
-                    actual_storage_type,
-                    actual_storage_config,
-                )
-                .await?,
+                builtin::BuiltinRvps::new(extractors.clone(), actual_storage_type, storage_config)
+                    .await?,
             )) as RvpsClient)
         }
         #[cfg(feature = "rvps-grpc")]

--- a/attestation-service/tests/configs/example_with_tpm_verifier.json
+++ b/attestation-service/tests/configs/example_with_tpm_verifier.json
@@ -2,9 +2,7 @@
     "work_dir": "/var/lib/attestation-service/",
     "rvps_config": {
         "type": "BuiltIn",
-        "storage": {
-            "type": "LocalFs"
-        }
+        "storage_type": "LocalFs"
     },
     "attestation_token_broker": {
         "type": "Ear",

--- a/deps/verifier/src/tpm/README.md
+++ b/deps/verifier/src/tpm/README.md
@@ -17,9 +17,7 @@ For JSON configuration:
   "work_dir": "/var/lib/attestation-service/",
   "rvps_config": {
     "type": "BuiltIn",
-    "storage": {
-      "type": "LocalFs"
-    }
+    "storage_type": "LocalFs"
   },
   "attestation_token_broker": {
     "type": "Ear",

--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -150,7 +150,7 @@ impl TestHarness {
         let rvps_config = match &test_parameters.rvps_type {
             RvpsType::Builtin => RvpsConfig::BuiltIn {
                 extractors: None,
-                storage: None,
+                storage_type: None,
             },
             RvpsType::Remote => {
                 info!("Starting Remote RVPS");
@@ -229,6 +229,7 @@ impl TestHarness {
                         rvps_config,
                         attestation_token_broker: attestation_token_config,
                         verifier_config: None,
+                        storage_type: None,
                     },
                 ),
                 timeout: 5,

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -127,10 +127,10 @@ If `type` is set to `BuiltIn`, the following extra properties can be set:
 | Property | Type | Description | Required | Default |
 |----------|------|-------------|----------|---------|
 | `extractors` | Object | Optional configuration for provenance extractors | No | None |
-| `storage` | Object | Optional RVPS-specific storage configuration (same format as `storage_backend`). If provided, overrides the unified `storage_backend` for RVPS only. If omitted, falls back to the unified `storage_backend`. | No | None |
+| `storage_type` | String | Optional RVPS-specific storage type override. If provided, overrides `storage_backend.storage_type` for RVPS only. Backend-specific parameters are still reused from `storage_backend.backends`. | No | None |
 
 > [!NOTE]
-> **Storage Configuration:** By default, BuiltIn RVPS uses the unified `storage_backend` configuration (see [Storage Backend Configuration](#storage-backend-configuration)) with the `reference_value` namespace. However, you can optionally provide a `storage` field to configure RVPS-specific storage that differs from other components.
+> **Storage Configuration:** By default, BuiltIn RVPS uses the unified `storage_backend` configuration (see [Storage Backend Configuration](#storage-backend-configuration)) with the `reference_value` namespace. However, you can optionally provide a `storage_type` field to override only the storage type used by RVPS.
 > This allows you to use different storage backends for different components (e.g., LocalFs for KBS resources, but LocalJson for RVPS reference values).
 
 For detailed information about extractors configuration, including available extractors and their options, see the [RVPS README](../../rvps/README.md#extractors-configuration).
@@ -430,6 +430,9 @@ storage_type = "LocalFs"
 [storage_backend.backends.local_fs]
 dir_path = "/opt/confidential-containers/storage"
 
+[storage_backend.backends.local_json]
+file_dir_path = "/var/lib/rvps/references"
+
 [attestation_service]
 type = "coco_as_builtin"
 
@@ -439,12 +442,9 @@ duration_min = 5
 [attestation_service.rvps_config]
 type = "BuiltIn"
 
-# RVPS-specific storage override (LocalJson)
-[attestation_service.rvps_config.storage]
+# RVPS-specific storage type override (LocalJson)
+# Backend-specific parameters are still read from [storage_backend.backends]
 storage_type = "LocalJson"
-
-[attestation_service.rvps_config.storage.backends.local_json]
-file_dir_path = "/var/lib/rvps/references"
 
 # Optional: configure extractors
 [attestation_service.rvps_config.extractors]

--- a/kbs/docs/self-signed-https.md
+++ b/kbs/docs/self-signed-https.md
@@ -90,8 +90,7 @@ policy_engine = "opa"
     [attestation_service.rvps_config]
     type = "BuiltIn"
 
-    [attestation_service.rvps_config.storage]
-    type = "LocalFs"
+    storage_type = "LocalFs"
 
 [[plugins]]
 name = "resource"

--- a/kbs/src/attestation/coco/builtin.rs
+++ b/kbs/src/attestation/coco/builtin.rs
@@ -9,7 +9,7 @@ use attestation_service::{
     HashAlgorithm, InitDataInput, RuntimeData, VerificationRequest,
 };
 use kbs_types::{Challenge, Tee};
-use key_value_storage::StorageBackendConfig;
+use key_value_storage::{KeyValueStorageType, StorageBackendConfig};
 use serde::Deserialize;
 use tokio::sync::RwLock;
 
@@ -28,6 +28,12 @@ pub struct Config {
     /// Optional configuration for verifier modules
     #[serde(default)]
     pub verifier_config: Option<VerifierConfig>,
+
+    /// Optional storage backend configuration for CoCo AS.
+    /// If provided, overrides the unified storage_backend for CoCo AS storage.
+    /// If None, falls back to the unified storage_backend.
+    #[serde(default)]
+    pub storage_type: Option<KeyValueStorageType>,
 }
 
 impl Config {
@@ -35,11 +41,15 @@ impl Config {
         &self,
         storage_backend_config: &StorageBackendConfig,
     ) -> attestation_service::config::Config {
+        let mut storage_backend = storage_backend_config.clone();
+        if let Some(storage_type) = self.storage_type {
+            storage_backend.storage_type = storage_type;
+        }
         attestation_service::config::Config {
             rvps_config: self.rvps_config.clone(),
             attestation_token_broker: self.attestation_token_broker.clone(),
             verifier_config: self.verifier_config.clone(),
-            storage_backend: storage_backend_config.clone(),
+            storage_backend,
         }
     }
 }

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -209,6 +209,7 @@ mod tests {
             attestation_service:
                 crate::attestation::config::AttestationServiceConfig::CoCoASBuiltIn(
                     crate::attestation::coco::builtin::Config {
+                        storage_type: None,
                         rvps_config: RvpsConfig::GrpcRemote(RvpsRemoteConfig {
                             address: "http://127.0.0.1:50003".into(),
                         }),
@@ -354,7 +355,8 @@ mod tests {
             attestation_service:
                 crate::attestation::config::AttestationServiceConfig::CoCoASBuiltIn(
                     crate::attestation::coco::builtin::Config {
-                        rvps_config: RvpsConfig::BuiltIn { extractors: None, storage: None },
+                        storage_type: None,
+                        rvps_config: RvpsConfig::BuiltIn { extractors: None, storage_type: None },
                         attestation_token_broker: EarTokenConfiguration {
                             duration_min: 5,
                             ..Default::default()
@@ -496,7 +498,8 @@ mod tests {
             attestation_service:
                 crate::attestation::config::AttestationServiceConfig::CoCoASBuiltIn(
                     crate::attestation::coco::builtin::Config {
-                        rvps_config: RvpsConfig::BuiltIn { extractors: None, storage: None },
+                        storage_type: None,
+                        rvps_config: RvpsConfig::BuiltIn { extractors: None, storage_type: None },
                         attestation_token_broker: EarTokenConfiguration {
                             duration_min: 5,
                             ..Default::default()

--- a/rvps/README.md
+++ b/rvps/README.md
@@ -238,7 +238,7 @@ In this mode, the RVPS will work as a crate inside the Attestation Service binar
 ![](./diagrams/rvps-native.svg)
 
 > [!NOTE]
-> **Storage Configuration:** By default, RVPS in native mode uses the unified `storage_backend` configuration (see [Storage Backend Configuration](#storage-backend-configuration)) with the `reference_value` namespace. However, you can optionally provide a `storage` field to configure RVPS-specific storage that differs from other components.
+> **Storage Configuration:** By default, RVPS in native mode uses the unified `storage_backend` configuration (see [Storage Backend Configuration](#storage-backend-configuration)) with the `reference_value` namespace. However, you can optionally provide a `storage_type` field in `rvps_config` to override only the storage type used by RVPS.
 > This allows you to use different storage backends for different components (e.g., LocalFs for KBS resources, but LocalJson for RVPS reference values).
 
 **Example with shared storage (default behavior):**
@@ -259,7 +259,7 @@ In this mode, the RVPS will work as a crate inside the Attestation Service binar
 }
 ```
 
-**Example with RVPS-specific storage override:**
+**Example with RVPS-specific storage type override:**
 
 ```json
 {
@@ -268,19 +268,15 @@ In this mode, the RVPS will work as a crate inside the Attestation Service binar
         "backends": {
             "local_fs": {
                 "dir_path": "/var/lib/attestation-service/storage"
+            },
+            "local_json": {
+                "file_dir_path": "/var/lib/rvps/references"
             }
         }
     },
     "rvps_config": {
         "type": "BuiltIn",
-        "storage": {
-            "storage_type": "LocalJson",
-            "backends": {
-                "local_json": {
-                    "file_dir_path": "/var/lib/rvps/references"
-                }
-            }
-        }
+        "storage_type": "LocalJson"
     }
 }
 ```


### PR DESCRIPTION
This is a patch based on #1312. We could use a global storage config, and set concrete overwrite with types.

This commit also updates related documents and examples.

cc @lmilleri 