### PR TITLE
verifier: intel_dcap: add PlatformInfo parsing and move to use it

### DIFF
--- a/deps/verifier/src/az_tdx_vtpm/mod.rs
+++ b/deps/verifier/src/az_tdx_vtpm/mod.rs
@@ -13,7 +13,9 @@ use super::az_snp_vtpm::{
 use super::tdx::claims::generate_parsed_claim;
 use super::tdx::quote::{parse_tdx_quote, parse_tdx_quote_certification, Quote as TdQuote};
 use super::{TeeClass, TeeEvidence, TeeEvidenceParsedClaim, Verifier};
-use crate::intel_dcap::{ecdsa_quote_verification, extend_using_custom_claims};
+use crate::intel_dcap::{
+    ecdsa_quote_verification, extend_using_custom_claims, pck::parse_platform_info,
+};
 use crate::{InitDataHash, ReportData};
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
@@ -66,8 +68,9 @@ impl Verifier for AzTdxVtpm {
         let pck_certs = parse_tdx_quote_certification(evidence.td_quote(), &td_quote)?
             .qe_certification_data
             .certificates;
+        let platform_info = parse_platform_info(&pck_certs)?;
 
-        let mut claim = generate_parsed_claim(td_quote, None, Some(&pck_certs))?;
+        let mut claim = generate_parsed_claim(td_quote, None, &platform_info)?;
         extend_claim(&mut claim, &tpm_quote)?;
         extend_using_custom_claims(&mut claim, custom_claims)?;
 

--- a/deps/verifier/src/intel_dcap/pck.rs
+++ b/deps/verifier/src/intel_dcap/pck.rs
@@ -8,11 +8,13 @@
 //! and are present in both TDX and SGX PCK certificate chains.
 //! See "Intel® SGX PCK Certificate and Certificate Revocation List Profile Specification".
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use asn1_rs::{oid, DerSequence, Enumerated, FromDer, Oid};
 use x509_parser::prelude::*;
 
 const DCAP_SGX_EXTENSIONS: Oid<'static> = oid!(1.2.840 .113741 .1 .13 .1);
+const PCK_PLATFORM_CA_CN: &str = "Intel SGX PCK Platform CA";
+const PCK_PROCESSOR_CA_CN: &str = "Intel SGX PCK Processor CA";
 
 #[derive(Debug, PartialEq, DerSequence)]
 struct OidAndString<'a> {
@@ -92,68 +94,221 @@ struct SgxExtension<'a> {
     pceid: OidAndString<'a>,
     fmspc: OidAndString<'a>,
     sgxtype: OidAndEnum<'a>,
-    platform_instance: OidAndString<'a>,
-    configuration: ConfigSequence<'a>,
+    /// Absent in Processor CA-signed certs.
+    platform_instance: Option<OidAndString<'a>>,
+    /// Absent in Processor CA-signed certs.
+    configuration: Option<ConfigSequence<'a>>,
+}
+
+/// Owned platform information extracted from the SGX extensions of a PCK certificate chain.
+///
+/// SGX extensions are DER-encoded under OID 1.2.840.113741.1.13.1 and present in
+/// both TDX and SGX PCK certificate chains.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PlatformInfo {
+    /// FMSPC (Family-Model-Stepping-Platform-CustomSKU) identifier.
+    pub fmspc: [u8; 6],
+    /// PCE (Provisioning Certification Enclave) identifier.
+    pub pceid: [u8; 2],
+    /// 16 SGX TCB SVN components.
+    pub tcb_components: [u8; 16],
+    /// PCE security version number.
+    pub pcesvn: u16,
+    /// CPU security version number.
+    pub cpusvn: [u8; 16],
+    /// SGX type: 0 = Standard, 1 = Scalable, 2 = ScalableWithIntegrity.
+    pub sgx_type: u8,
+    /// `true` for Platform CA-signed certs, `false` for Processor CA-signed certs.
+    pub is_platform_ca: bool,
+    /// Present only in Platform CA-signed certs; `None` for Processor CA-signed certs.
+    pub platform_instance_id: Option<[u8; 16]>,
+    /// Present only in Platform CA-signed certs; `None` for Processor CA-signed certs.
+    pub dynamic_platform: Option<bool>,
+    pub cached_keys: Option<bool>,
+    pub smt_enabled: Option<bool>,
+}
+
+/// A parsed PCK certificate chain with named positions.
+/// The Intel cert chain ordering is leaf (index 0), intermediate CA, root CA.
+struct PckCertificateChain {
+    leaf: Pem,
+    intermediate: Pem,
+    _root: Pem,
 }
 
 /// Parse all PEM-encoded certificates from a PCK certificate chain.
-/// The Intel cert chain ordering is leaf (index 0), intermediate CA, root CA.
-pub(crate) fn parse_pck_pem_certs(pem_certs: &[u8]) -> Result<Vec<Pem>> {
-    Pem::iter_from_buffer(pem_certs)
+fn parse_pck_pem_certs(pem_certs: &[u8]) -> Result<PckCertificateChain> {
+    let [leaf, intermediate, root] = Pem::iter_from_buffer(pem_certs)
         .collect::<Result<Vec<Pem>, _>>()
         .context("failed to parse PCK PEM certificate chain")
+        .and_then(|pems| {
+            pems.try_into().map_err(|v: Vec<Pem>| {
+                anyhow!(
+                    "PCK cert chain must contain exactly 3 certificates (leaf, intermediate CA, root CA), got {}",
+                    v.len()
+                )
+            })
+        })?;
+
+    Ok(PckCertificateChain {
+        leaf,
+        intermediate,
+        _root: root,
+    })
 }
 
-/// Extract the `platform_instance_id` from an already-parsed PCK leaf certificate.
-/// Returns `Ok(None)` if the SGX extensions OID is absent (Processor CA-signed certs).
-/// The `platform_instance` field is only present in Platform CA-signed PCK certs.
-pub(crate) fn platform_instance_id_from_pck_leaf_cert(
-    cert: &X509Certificate,
-) -> Result<Option<[u8; 16]>> {
-    let ext = cert
+/// Parse the SGX extensions from a PCK certificate chain and return owned platform information.
+///
+/// The CA type is derived from the intermediate cert subject CN, which also determines
+/// which SGX extension fields are present. Absent SGX extensions is an error — PCK
+/// leaf certificates are always expected to carry them.
+pub(crate) fn parse_platform_info(pem_certs: &[u8]) -> Result<PlatformInfo> {
+    let chain = parse_pck_pem_certs(pem_certs)?;
+
+    let intermediate = chain
+        .intermediate
+        .parse_x509()
+        .context("failed to parse PCK intermediate CA cert")?;
+
+    let is_platform_ca = intermediate
+        .subject()
+        .iter_common_name()
+        .next()
+        .context("PCK intermediate CA cert has no Common Name")?
+        .as_str()
+        .context("PCK intermediate CA CN is not valid UTF-8")
+        .and_then(|cn| match cn {
+            PCK_PLATFORM_CA_CN => Ok(true),
+            PCK_PROCESSOR_CA_CN => Ok(false),
+            other => bail!("unexpected PCK intermediate CA CN: {other}"),
+        })?;
+
+    let leaf = chain
+        .leaf
+        .parse_x509()
+        .context("failed to parse PCK leaf cert")?;
+
+    let ext = leaf
         .tbs_certificate
         .get_extension_unique(&DCAP_SGX_EXTENSIONS)
-        .context("failed to look up SGX extensions OID")?;
+        .context("failed to look up SGX extensions OID")?
+        .context("SGX extensions OID not found in PCK leaf cert")?;
 
-    let ext_value = match ext {
-        Some(e) => e.value,
-        None => return Ok(None),
+    let (rem, sgx) =
+        SgxExtension::from_der(ext.value).context("failed to parse SGX extension DER")?;
+
+    if !rem.is_empty() {
+        bail!("SGX extension has {} unexpected trailing bytes", rem.len());
+    }
+
+    let tcb = &sgx.tcb.tcbs;
+
+    let fmspc: [u8; 6] = sgx.fmspc.s.try_into().context("fmspc is not 6 bytes")?;
+    let pceid: [u8; 2] = sgx.pceid.s.try_into().context("pceid is not 2 bytes")?;
+
+    let tcb_components = [
+        tcb.comp1.val,
+        tcb.comp2.val,
+        tcb.comp3.val,
+        tcb.comp4.val,
+        tcb.comp5.val,
+        tcb.comp6.val,
+        tcb.comp7.val,
+        tcb.comp8.val,
+        tcb.comp9.val,
+        tcb.comp10.val,
+        tcb.comp11.val,
+        tcb.comp12.val,
+        tcb.comp13.val,
+        tcb.comp14.val,
+        tcb.comp15.val,
+        tcb.comp16.val,
+    ];
+
+    let cpusvn: [u8; 16] = tcb.cpusvn.s.try_into().context("cpusvn is not 16 bytes")?;
+    let sgx_type = sgx.sgxtype.e.0 as u8;
+
+    // Cross-check: the CA type from the intermediate cert must agree with the presence
+    // of platform_instance and configuration in the leaf cert's SGX extensions.
+    let (platform_instance_id, dynamic_platform, cached_keys, smt_enabled) = match is_platform_ca {
+        true => {
+            let pi = sgx
+                .platform_instance
+                .as_ref()
+                .context("Platform PCK cert is missing platform_instance")?;
+
+            let cfg_seq = sgx
+                .configuration
+                .as_ref()
+                .context("Platform PCK cert is missing configuration")?;
+
+            let cfg = &cfg_seq.configs;
+
+            let bytes: [u8; 16] =
+                pi.s.try_into()
+                    .context("platform_instance is not 16 bytes")?;
+
+            // The GUID is stored little-endian in the OCTET STRING; convert to big-endian.
+            let piid = u128::from_le_bytes(bytes).to_be_bytes();
+
+            (
+                Some(piid),
+                Some(cfg.dynamic_platform.b),
+                Some(cfg.cached_keys.b),
+                Some(cfg.smt_enabled.b),
+            )
+        }
+        false => {
+            if sgx.platform_instance.is_some() || sgx.configuration.is_some() {
+                bail!("Processor CA cert unexpectedly contains platform_instance or configuration");
+            }
+            (None, None, None, None)
+        }
     };
 
-    let (_, parsed) =
-        SgxExtension::from_der(ext_value).context("failed to parse SGX extension DER")?;
-
-    let bytes: [u8; 16] = parsed
-        .platform_instance
-        .s
-        .try_into()
-        .context("platform_instance is not 16 bytes")?;
-
-    // The GUID is stored little-endian in the OCTET STRING; convert to big-endian.
-    Ok(Some(u128::from_le_bytes(bytes).to_be_bytes()))
+    Ok(PlatformInfo {
+        fmspc,
+        pceid,
+        tcb_components,
+        pcesvn: tcb.pcesvn.val,
+        cpusvn,
+        sgx_type,
+        is_platform_ca,
+        platform_instance_id,
+        dynamic_platform,
+        cached_keys,
+        smt_enabled,
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_pck_pem_certs, platform_instance_id_from_pck_leaf_cert};
+    use super::parse_platform_info;
     use crate::tdx::quote::{parse_tdx_quote, parse_tdx_quote_certification};
 
     #[test]
-    fn parse_platform_instance_id() {
+    fn parse_platform_info_platform_ca() {
         let quote_bin = std::fs::read("./test_data/tdx_quote_4.dat").expect("read quote failed");
         let quote = parse_tdx_quote(&quote_bin).expect("parse quote");
-        let pck_certs_pem = parse_tdx_quote_certification(&quote_bin, &quote)
+        let certs = parse_tdx_quote_certification(&quote_bin, &quote)
             .expect("parse cert chain")
             .qe_certification_data
             .certificates;
 
-        let certs = parse_pck_pem_certs(&pck_certs_pem).expect("parse PEM certs");
-        let leaf = certs[0].parse_x509().expect("parse leaf cert");
+        let info = parse_platform_info(&certs).expect("parse platform info");
 
-        let piid = platform_instance_id_from_pck_leaf_cert(&leaf)
-            .expect("extract platform_instance_id")
-            .expect("platform_instance_id not present");
-
-        assert_eq!(hex::encode(piid), "82548d228d94d5e204a95b354dc61a02");
+        assert!(info.is_platform_ca);
+        assert_eq!(
+            hex::encode(
+                info.platform_instance_id
+                    .expect("platform_instance_id not present")
+            ),
+            "82548d228d94d5e204a95b354dc61a02"
+        );
+        assert_eq!(info.fmspc.len(), 6);
+        assert_eq!(info.pceid.len(), 2);
+        assert!(info.dynamic_platform.is_some());
+        assert!(info.cached_keys.is_some());
+        assert!(info.smt_enabled.is_some());
     }
 }

--- a/deps/verifier/src/tdx/claims.rs
+++ b/deps/verifier/src/tdx/claims.rs
@@ -12,11 +12,7 @@ use bitflags::{bitflags, Flags};
 use serde_json::{Map, Value};
 
 use super::quote::Quote;
-use crate::{
-    intel_dcap::pck::{parse_pck_pem_certs, platform_instance_id_from_pck_leaf_cert},
-    tdx::quote::QuoteV5Body,
-    TeeEvidenceParsedClaim,
-};
+use crate::{intel_dcap::pck::PlatformInfo, tdx::quote::QuoteV5Body, TeeEvidenceParsedClaim};
 use eventlog::CcEventLog;
 
 macro_rules! parse_claim {
@@ -34,7 +30,7 @@ macro_rules! parse_claim {
 pub fn generate_parsed_claim(
     quote: Quote,
     cc_eventlog: Option<CcEventLog>,
-    pck_certs: Option<&[u8]>,
+    platform_info: &PlatformInfo,
 ) -> Result<TeeEvidenceParsedClaim> {
     let mut quote_map = Map::new();
     let mut quote_body = Map::new();
@@ -145,12 +141,8 @@ pub fn generate_parsed_claim(
     parse_claim!(claims, "report_data", quote.report_data());
     parse_claim!(claims, "init_data", quote.mr_config_id());
 
-    if let Some(certs) = pck_certs {
-        let pems = parse_pck_pem_certs(certs)?;
-        let leaf = pems[0].parse_x509()?;
-        if let Some(piid) = platform_instance_id_from_pck_leaf_cert(&leaf)? {
-            parse_claim!(claims, "platform_instance_id", &piid[..]);
-        }
+    if let Some(piid) = platform_info.platform_instance_id {
+        parse_claim!(claims, "platform_instance_id", &piid[..]);
     }
 
     Ok(Value::Object(claims) as TeeEvidenceParsedClaim)
@@ -260,7 +252,11 @@ mod tests {
     use assert_json_diff::assert_json_eq;
     use serde_json::Value;
 
-    use crate::tdx::{claims::PlatformConfigInfoError, quote::parse_tdx_quote};
+    use crate::intel_dcap::pck::parse_platform_info;
+    use crate::tdx::{
+        claims::PlatformConfigInfoError,
+        quote::{parse_tdx_quote, parse_tdx_quote_certification},
+    };
 
     use super::{generate_parsed_claim, TdShimPlatformConfigInfo};
 
@@ -273,7 +269,13 @@ mod tests {
         let ccel_bin = std::fs::read("./test_data/CCEL_data").expect("read ccel failed");
         let quote = parse_tdx_quote(&quote_bin).expect("parse quote");
         let ccel = CcEventLog::try_from(ccel_bin).expect("parse ccel");
-        let claims = generate_parsed_claim(quote, Some(ccel), None).expect("parse claim failed");
+        let pck_certs = parse_tdx_quote_certification(&quote_bin, &quote)
+            .expect("parse cert data")
+            .qe_certification_data
+            .certificates;
+        let platform_info = parse_platform_info(&pck_certs).expect("parse platform info");
+        let claims =
+            generate_parsed_claim(quote, Some(ccel), &platform_info).expect("parse claim failed");
         let expected_json_str =
             std::fs::read_to_string("./test_data/parse_tdx_claims_expected.json")
                 .expect("read expected json output failed");

--- a/deps/verifier/src/tdx/mod.rs
+++ b/deps/verifier/src/tdx/mod.rs
@@ -6,7 +6,9 @@ use tracing::{debug, error, info, instrument, warn};
 use crate::tdx::claims::generate_parsed_claim;
 
 use super::*;
-use crate::intel_dcap::{ecdsa_quote_verification, extend_using_custom_claims};
+use crate::intel_dcap::{
+    ecdsa_quote_verification, extend_using_custom_claims, pck::parse_platform_info,
+};
 use async_trait::async_trait;
 use base64::Engine;
 use quote::{parse_tdx_quote, parse_tdx_quote_certification};
@@ -130,8 +132,9 @@ async fn verify_evidence(
     let pck_certs = parse_tdx_quote_certification(&quote_bin, &quote)?
         .qe_certification_data
         .certificates;
+    let platform_info = parse_platform_info(&pck_certs)?;
 
-    let mut claim = generate_parsed_claim(quote, ccel_option, Some(&pck_certs))?;
+    let mut claim = generate_parsed_claim(quote, ccel_option, &platform_info)?;
     extend_using_custom_claims(&mut claim, custom_claims)?;
 
     Ok(claim)
@@ -146,12 +149,20 @@ mod tests {
 
     #[test]
     fn test_generate_parsed_claim() {
+        use crate::intel_dcap::pck::parse_platform_info;
+        use crate::tdx::quote::parse_tdx_quote_certification;
+
         let ccel_bin = fs::read("./test_data/CCEL_data").unwrap();
         let ccel = CcEventLog::try_from(ccel_bin).unwrap();
         let quote_bin = fs::read("./test_data/tdx_quote_4.dat").unwrap();
         let quote = parse_tdx_quote(&quote_bin).unwrap();
+        let pck_certs = parse_tdx_quote_certification(&quote_bin, &quote)
+            .unwrap()
+            .qe_certification_data
+            .certificates;
+        let platform_info = parse_platform_info(&pck_certs).unwrap();
 
-        let parsed_claim = generate_parsed_claim(quote, Some(ccel), None);
+        let parsed_claim = generate_parsed_claim(quote, Some(ccel), &platform_info);
         assert!(parsed_claim.is_ok());
 
         let _ = fs::write(

--- a/deps/verifier/test_data/parse_tdx_claims_expected.json
+++ b/deps/verifier/test_data/parse_tdx_claims_expected.json
@@ -107,5 +107,6 @@
       "index": 2,
       "type_name": "EV_PLATFORM_CONFIG_FLAGS"
     }
-  ]
+  ],
+  "platform_instance_id": "82548d228d94d5e204a95b354dc61a02"
 }


### PR DESCRIPTION
#1289 focused on platfom instance ID but new needs came in shortly after so just expose full Platform Info to callers. 

PlatformInfo is a struct carrying all fields from the SGX extension (OID 1.2.840.113741.1.13.1) of a PCK certificate: fmspc, pceid, 16 TCB SVN components, pcesvn, cpusvn, sgx_type, and the Platform CA-only fields (platform_instance_id, dynamic_platform, cached_keys, smt_enabled).

parse_platform_info() takes raw PEM bytes from the QE certification data field and parses all three certs in the chain. The CA type (is_platform_ca) is derived from the intermediate cert subject CN and cross-checked against the presence of platform_instance and configuration in the leaf cert's SGX extensions.

generate_parsed_claim() is updated to take Option<&PlatformInfo> instead of raw cert bytes; tdx/mod.rs and az_tdx_vtpm/mod.rs call parse_platform_info() before invoking it. The old
platform_instance_id_from_pck_leaf_cert() is removed.

Assisted-by: Copilot:claude-sonnet-4.6