### PR TITLE
Add configurable TLS security profiles

### DIFF
--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -4,7 +4,7 @@
 
 use kbs::admin::AdminConfig;
 use kbs::attestation::config::{AttestationConfig, AttestationServiceConfig};
-use kbs::config::{HttpServerConfig, TlsProfile};
+use kbs::config::{HttpServerConfig, TlsConfig};
 use kbs::config::KbsConfig;
 use kbs::token::AttestationTokenVerifierConfig;
 use kbs::ApiServer;
@@ -273,16 +273,10 @@ impl TestHarness {
             },
             http_server: HttpServerConfig {
                 sockets: vec!["127.0.0.1:8081".parse()?],
-                private_key: None,
-                certificate: None,
                 insecure_http: true,
                 payload_request_size: 2,
                 worker_count: Some(4),
-                tls_profile: TlsProfile::default(),
-                tls_min_version: None,
-                tls_max_version: None,
-                tls_ciphers: None,
-                tls_groups: None,
+                tls: TlsConfig::default(),
             },
             admin: admin_config,
             storage_backend: StorageBackendConfig {

--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -4,7 +4,7 @@
 
 use kbs::admin::AdminConfig;
 use kbs::attestation::config::{AttestationConfig, AttestationServiceConfig};
-use kbs::config::HttpServerConfig;
+use kbs::config::{HttpServerConfig, TlsProfile};
 use kbs::config::KbsConfig;
 use kbs::token::AttestationTokenVerifierConfig;
 use kbs::ApiServer;
@@ -278,6 +278,11 @@ impl TestHarness {
                 insecure_http: true,
                 payload_request_size: 2,
                 worker_count: Some(4),
+                tls_profile: TlsProfile::default(),
+                tls_min_version: None,
+                tls_max_version: None,
+                tls_ciphers: None,
+                tls_groups: None,
             },
             admin: admin_config,
             storage_backend: StorageBackendConfig {

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -27,6 +27,78 @@ The following properties can be set under the `[http_server]` section.
 | `certificate`          | String       | Path to a certificate file to be used for HTTPS. | No       | None                     |
 | `payload_request_size` | Integer      | Request payload size in mega bytes.              | No       | 2                        |
 | `worker_count`         | Integer      | Number of HTTP actix worker threads              | No       | Num of logical CPU cores |
+| `tls_profile`          | String       | TLS security profile (see [TLS Configuration](#tls-configuration)) | No | `intermediate` |
+| `tls_min_version`      | String       | Minimum TLS version: `1.2` or `1.3`              | No       | Profile-dependent        |
+| `tls_max_version`      | String       | Maximum TLS version: `1.2` or `1.3`              | No       | Profile-dependent        |
+| `tls_ciphers`          | String       | TLS cipher suites (colon-separated OpenSSL list) | No       | Profile-dependent        |
+| `tls_groups`           | String       | TLS key exchange groups (colon-separated list)   | No       | Auto-detected with PQC   |
+
+#### TLS Configuration
+
+KBS supports flexible TLS configuration through predefined security profiles and custom settings. The TLS profiles are based on [Mozilla's TLS recommendations](https://wiki.mozilla.org/Security/Server_Side_TLS).
+
+##### TLS Security Profiles
+
+Four security profiles are available via the `tls_profile` setting:
+
+| Profile         | TLS Versions | Description                                              | Use Case                          |
+|-----------------|--------------|----------------------------------------------------------|-----------------------------------|
+| `old`           | 1.2, 1.3     | Legacy compatibility with older clients                  | Maximum client compatibility      |
+| `intermediate`  | 1.2, 1.3     | Balanced security and compatibility (recommended)        | Most production deployments       |
+| `modern`        | 1.3 only     | Maximum security, TLS 1.3 only                           | High-security environments        |
+| `custom`        | Configurable | Full control over TLS parameters                         | Specialized security requirements |
+
+**Recommended:** Use `intermediate` (the default) for most deployments unless you have specific security or compatibility requirements.
+
+##### Custom TLS Configuration
+
+When using `tls_profile = "custom"`, you can explicitly configure:
+
+- **`tls_min_version`**: Minimum TLS protocol version (`"1.2"` or `"1.3"`)
+- **`tls_max_version`**: Maximum TLS protocol version (`"1.2"` or `"1.3"`)
+- **`tls_ciphers`**: Colon-separated OpenSSL cipher suite list
+  - For TLS 1.3 only (Modern profile or min=1.3): Use TLS 1.3 cipher names
+    - Example: `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256`
+    - TLS 1.3 cipher suites only specify encryption and hashing
+  - For TLS 1.2 only (max=1.2): Use TLS 1.2 cipher names
+    - Example: `ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384`
+    - TLS 1.2 cipher suites include key exchange, authentication, encryption, and hashing
+  - For both TLS 1.2 and 1.3 (Old/Intermediate): You can mix both formats in one string, separated by colons
+- **`tls_groups`**: Colon-separated list of supported groups for key exchange (applies to both TLS 1.2 and 1.3)
+  - For TLS 1.2: Configures elliptic curves for ECDHE cipher suites
+  - For TLS 1.3: Configures all key exchange (the only mechanism since cipher suites don't include it)
+  - Common classical groups: `X25519`, `X448`, `secp256r1` (P-256), `secp384r1` (P-384), `secp521r1` (P-521)
+  - PQC hybrid groups (OpenSSL 3.5+): `X25519MLKEM768`, `SecP256r1MLKEM768`, `X448MLKEM1024`, `SecP384r1MLKEM1024`
+  - Example: `X25519:secp256r1:secp384r1` (classical only)
+  - Example: `X25519MLKEM768:X25519:secp256r1` (post-quantum with classical fallback)
+  - See [OpenSSL groups documentation](https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set1_groups_list.html) for complete list
+
+> [!NOTE]
+> Custom TLS fields can be used with any profile to override specific settings. If you set custom fields with a non-custom profile, a warning will be logged, but the custom settings will take precedence.
+
+##### Post-Quantum Cryptography (PQC) Support
+
+KBS automatically detects and enables post-quantum key exchange algorithms when supported by your OpenSSL installation (3.5+). If `tls_groups` is not explicitly configured, KBS will:
+
+1. Detect the best available PQC algorithm (ML-KEM hybrid groups)
+2. Fall back to classical algorithms if PQC is unavailable
+3. Use the following priority order:
+   - `X25519MLKEM768` (preferred)
+   - `SecP256r1MLKEM768` (FIPS-compliant)
+   - `X448MLKEM1024` (high security)
+   - `SecP384r1MLKEM1024` (FIPS + high security)
+
+To explicitly configure PQC, use the `custom` profile with `tls_groups`:
+
+```toml
+[http_server]
+tls_profile = "custom"
+tls_min_version = "1.3"
+tls_max_version = "1.3"
+tls_groups = "X25519MLKEM768:X25519:secp256r1"
+```
+
+See the [TLS Configuration Examples](#tls-configuration-examples) section for complete examples.
 
 ### Attestation Token Configuration
 
@@ -590,3 +662,108 @@ dir_path = "./work/storage"
 name = "resource"
 storage_backend_type = "kvstorage"
 ```
+
+### TLS Configuration Examples
+
+#### Using the Modern Profile (TLS 1.3 Only)
+
+For high-security environments that only support modern clients:
+
+```toml
+[http_server]
+sockets = ["0.0.0.0:8080"]
+private_key = "/etc/kbs-private.key"
+certificate = "/etc/kbs-cert.pem"
+tls_profile = "modern"
+
+[attestation_service]
+type = "coco_as_grpc"
+as_addr = "http://127.0.0.1:50001"
+
+[admin]
+type = "DenyAll"
+
+[storage_backend]
+storage_type = "memory"
+```
+
+#### Using the Intermediate Profile (Default, Recommended)
+
+Balances security and compatibility with TLS 1.2 and 1.3 support:
+
+```toml
+[http_server]
+sockets = ["0.0.0.0:8080"]
+private_key = "/etc/kbs-private.key"
+certificate = "/etc/kbs-cert.pem"
+tls_profile = "intermediate"  # Can be omitted (it's the default)
+
+[attestation_service]
+type = "coco_as_grpc"
+as_addr = "http://127.0.0.1:50001"
+
+[admin]
+type = "DenyAll"
+
+[storage_backend]
+storage_type = "memory"
+```
+
+#### Using Custom TLS Configuration
+
+Full control over TLS parameters:
+
+```toml
+[http_server]
+sockets = ["0.0.0.0:8080"]
+private_key = "/etc/kbs-private.key"
+certificate = "/etc/kbs-cert.pem"
+tls_profile = "custom"
+tls_min_version = "1.2"
+tls_max_version = "1.3"
+# TLS 1.3 cipher suites (only encryption+hash; key exchange configured via tls_groups)
+tls_ciphers = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
+# Classical key exchange groups
+tls_groups = "X25519:secp256r1:secp384r1"
+
+[attestation_service]
+type = "coco_as_grpc"
+as_addr = "http://127.0.0.1:50001"
+
+[admin]
+type = "DenyAll"
+
+[storage_backend]
+storage_type = "memory"
+```
+
+#### Using Post-Quantum Cryptography (PQC)
+
+Configure TLS 1.3 with post-quantum key exchange:
+
+```toml
+[http_server]
+sockets = ["0.0.0.0:8080"]
+private_key = "/etc/kbs-private.key"
+certificate = "/etc/kbs-cert.pem"
+tls_profile = "custom"
+tls_min_version = "1.3"
+tls_max_version = "1.3"
+# TLS 1.3 cipher suites (only encryption+hash; key exchange configured via tls_groups)
+tls_ciphers = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
+# Post-quantum key exchange groups with classical fallbacks
+tls_groups = "X25519MLKEM768:X25519:secp256r1"
+
+[attestation_service]
+type = "coco_as_grpc"
+as_addr = "http://127.0.0.1:50001"
+
+[admin]
+type = "DenyAll"
+
+[storage_backend]
+storage_type = "memory"
+```
+
+> [!NOTE]
+> Post-quantum algorithms require OpenSSL 3.5 or later. If PQC algorithms are not available, KBS will log a warning and fall back to classical algorithms.

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -41,83 +41,55 @@ pub enum TlsVersion {
     Tls13,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+/// TLS/HTTPS configuration
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
 #[serde(default)]
-pub struct HttpServerConfig {
-    /// Socket addresses (IP:port) to listen on, e.g. 127.0.0.1:8080.
-    pub sockets: Vec<SocketAddr>,
-
+pub struct TlsConfig {
     /// HTTPS private key.
     pub private_key: Option<PathBuf>,
 
     /// HTTPS Certificate.
     pub certificate: Option<PathBuf>,
 
-    /// Insecure HTTP.
-    /// WARNING: Using this option makes the HTTP connection insecure.
-    pub insecure_http: bool,
-
-    /// Request payload size in MB
-    pub payload_request_size: u32,
-
-    /// Number of worker threads for the actix-web server.
-    /// If not specified, defaults to the number of logical CPU cores.
-    pub worker_count: Option<usize>,
-
     /// TLS security profile: old, intermediate, modern, or custom
-    pub tls_profile: TlsProfile,
+    #[serde(rename = "tls_profile")]
+    pub profile: TlsProfile,
 
     /// Minimum TLS version (for custom profile)
-    pub tls_min_version: Option<TlsVersion>,
+    #[serde(rename = "tls_min_version")]
+    pub min_version: Option<TlsVersion>,
 
     /// Maximum TLS version (for custom profile)
-    pub tls_max_version: Option<TlsVersion>,
+    #[serde(rename = "tls_max_version")]
+    pub max_version: Option<TlsVersion>,
 
     /// TLS cipher suites (colon-separated OpenSSL cipher list)
-    pub tls_ciphers: Option<String>,
+    #[serde(rename = "tls_ciphers")]
+    pub ciphers: Option<String>,
 
     /// TLS groups for key exchange (colon-separated list)
-    pub tls_groups: Option<String>,
+    #[serde(rename = "tls_groups")]
+    pub groups: Option<String>,
 }
 
-impl Default for HttpServerConfig {
-    fn default() -> Self {
-        Self {
-            sockets: vec![DEFAULT_SOCKET.parse().expect("unexpected parse error")],
-            private_key: None,
-            certificate: None,
-            insecure_http: DEFAULT_INSECURE_HTTP,
-            payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
-            worker_count: None,
-            tls_profile: TlsProfile::default(),
-            tls_min_version: None,
-            tls_max_version: None,
-            tls_ciphers: None,
-            tls_groups: None,
-        }
-    }
-}
-
-impl HttpServerConfig {
+impl TlsConfig {
     /// Validate TLS configuration consistency
-    pub fn validate_tls_config(&self) -> Result<()> {
+    pub fn validate(&self) -> Result<()> {
         // Warn if non-custom profile has custom fields
-        if self.tls_profile != TlsProfile::Custom
-            && (self.tls_min_version.is_some()
-                || self.tls_max_version.is_some()
-                || self.tls_ciphers.is_some()
-                || self.tls_groups.is_some())
+        if self.profile != TlsProfile::Custom
+            && (self.min_version.is_some()
+                || self.max_version.is_some()
+                || self.ciphers.is_some()
+                || self.groups.is_some())
         {
             tracing::warn!(
                 "TLS profile is {:?} but custom fields are set. Custom fields will override profile defaults.",
-                self.tls_profile
+                self.profile
             );
         }
 
         // Validate version range
-        if let (Some(min_version), Some(max_version)) =
-            (&self.tls_min_version, &self.tls_max_version)
-        {
+        if let (Some(min_version), Some(max_version)) = (&self.min_version, &self.max_version) {
             if matches!(
                 (min_version, max_version),
                 (TlsVersion::Tls13, TlsVersion::Tls12)
@@ -131,6 +103,40 @@ impl HttpServerConfig {
         }
 
         Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct HttpServerConfig {
+    /// Socket addresses (IP:port) to listen on, e.g. 127.0.0.1:8080.
+    pub sockets: Vec<SocketAddr>,
+
+    /// Insecure HTTP.
+    /// WARNING: Using this option makes the HTTP connection insecure.
+    pub insecure_http: bool,
+
+    /// Request payload size in MB
+    pub payload_request_size: u32,
+
+    /// Number of worker threads for the actix-web server.
+    /// If not specified, defaults to the number of logical CPU cores.
+    pub worker_count: Option<usize>,
+
+    /// TLS/HTTPS configuration
+    #[serde(flatten)]
+    pub tls: TlsConfig,
+}
+
+impl Default for HttpServerConfig {
+    fn default() -> Self {
+        Self {
+            sockets: vec![DEFAULT_SOCKET.parse().expect("unexpected parse error")],
+            insecure_http: DEFAULT_INSECURE_HTTP,
+            payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
+            worker_count: None,
+            tls: TlsConfig::default(),
+        }
     }
 }
 
@@ -234,12 +240,13 @@ impl TryFrom<&Path> for KbsConfig {
 
         let config: KbsConfig = c
             .try_deserialize()
-            .map_err(|e| format_config_load_error(config_path, e));
+            .map_err(|e| format_config_load_error(config_path, e))?;
 
         // Validate TLS configuration
         config
             .http_server
-            .validate_tls_config()
+            .tls
+            .validate()
             .context("TLS configuration error")?;
 
         Ok(config)
@@ -263,7 +270,7 @@ mod tests {
     use crate::{
         admin::AdminConfig,
         config::{
-            HttpServerConfig, TlsProfile, TlsVersion, DEFAULT_INSECURE_HTTP,
+            HttpServerConfig, TlsConfig, TlsProfile, TlsVersion, DEFAULT_INSECURE_HTTP,
             DEFAULT_PAYLOAD_REQUEST_SIZE, DEFAULT_SOCKET,
         },
         plugins::{
@@ -357,16 +364,18 @@ mod tests {
         },
         http_server: HttpServerConfig {
             sockets: vec!["0.0.0.0:8080".parse().unwrap()],
-            private_key: Some("/etc/kbs-private.key".into()),
-            certificate: Some("/etc/kbs-cert.pem".into()),
             insecure_http: false,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
-            tls_profile: TlsProfile::default(),
-            tls_min_version: None,
-            tls_max_version: None,
-            tls_ciphers: None,
-            tls_groups: None,
+            tls: TlsConfig {
+                private_key: Some("/etc/kbs-private.key".into()),
+                certificate: Some("/etc/kbs-cert.pem".into()),
+                profile: TlsProfile::default(),
+                min_version: None,
+                max_version: None,
+                ciphers: None,
+                groups: None,
+            },
         },
         admin: AdminConfig::DenyAll {},
         storage_backend: StorageBackendConfig {
@@ -415,16 +424,10 @@ mod tests {
         },
         http_server: HttpServerConfig {
             sockets: vec![DEFAULT_SOCKET.parse().unwrap()],
-            private_key: None,
-            certificate: None,
             insecure_http: DEFAULT_INSECURE_HTTP,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
-            tls_profile: TlsProfile::default(),
-            tls_min_version: None,
-            tls_max_version: None,
-            tls_ciphers: None,
-            tls_groups: None,
+            tls: TlsConfig::default(),
         },
         admin: AdminConfig::DenyAll {},
         storage_backend: StorageBackendConfig {
@@ -464,16 +467,18 @@ mod tests {
         },
         http_server: HttpServerConfig {
             sockets: vec!["0.0.0.0:8080".parse().unwrap()],
-            private_key: Some("/etc/kbs-private.key".into()),
-            certificate: Some("/etc/kbs-cert.pem".into()),
             insecure_http: false,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
-            tls_profile: TlsProfile::default(),
-            tls_min_version: None,
-            tls_max_version: None,
-            tls_ciphers: None,
-            tls_groups: None,
+            tls: TlsConfig {
+                private_key: Some("/etc/kbs-private.key".into()),
+                certificate: Some("/etc/kbs-cert.pem".into()),
+                profile: TlsProfile::default(),
+                min_version: None,
+                max_version: None,
+                ciphers: None,
+                groups: None,
+            },
         },
         admin: AdminConfig::DenyAll {},
         storage_backend: StorageBackendConfig {
@@ -510,16 +515,10 @@ mod tests {
         },
         http_server: HttpServerConfig {
             sockets: vec!["0.0.0.0:8080".parse().unwrap()],
-            private_key: None,
-            certificate: None,
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
-            tls_profile: TlsProfile::default(),
-            tls_min_version: None,
-            tls_max_version: None,
-            tls_ciphers: None,
-            tls_groups: None,
+            tls: TlsConfig::default(),
         },
         admin: make_token_authorization_admin_config(),
         storage_backend: StorageBackendConfig {
@@ -561,16 +560,10 @@ mod tests {
         },
         http_server: HttpServerConfig {
             sockets: vec!["0.0.0.0:8080".parse().unwrap()],
-            private_key: None,
-            certificate: None,
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
-            tls_profile: TlsProfile::default(),
-            tls_min_version: None,
-            tls_max_version: None,
-            tls_ciphers: None,
-            tls_groups: None,
+            tls: TlsConfig::default(),
         },
         admin: AdminConfig::InsecureAllowAll {},
         storage_backend: StorageBackendConfig {
@@ -608,16 +601,10 @@ mod tests {
         },
         http_server: HttpServerConfig {
             sockets: vec!["0.0.0.0:8080".parse().unwrap()],
-            private_key: None,
-            certificate: None,
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
-            tls_profile: TlsProfile::default(),
-            tls_min_version: None,
-            tls_max_version: None,
-            tls_ciphers: None,
-            tls_groups: None,
+            tls: TlsConfig::default(),
         },
         admin: AdminConfig::DenyAll {},
         storage_backend: StorageBackendConfig::default(),
@@ -755,29 +742,30 @@ type = "Simple"
             message.contains("#admin-api-configuration"),
             "expected admin doc hint in: {message}"
         );
+    }
 
     #[test]
     fn test_tls_profile_default() {
         let config = HttpServerConfig::default();
-        assert_eq!(config.tls_profile, TlsProfile::Intermediate);
+        assert_eq!(config.tls.profile, TlsProfile::Intermediate);
     }
 
     #[test]
     fn test_tls_version_range_validation_error() {
-        let mut config = HttpServerConfig::default();
-        config.tls_min_version = Some(TlsVersion::Tls13);
-        config.tls_max_version = Some(TlsVersion::Tls12);
+        let mut config = TlsConfig::default();
+        config.min_version = Some(TlsVersion::Tls13);
+        config.max_version = Some(TlsVersion::Tls12);
 
-        assert!(config.validate_tls_config().is_err());
+        assert!(config.validate().is_err());
     }
 
     #[test]
     fn test_tls_version_range_validation_ok() {
-        let mut config = HttpServerConfig::default();
-        config.tls_min_version = Some(TlsVersion::Tls12);
-        config.tls_max_version = Some(TlsVersion::Tls13);
+        let mut config = TlsConfig::default();
+        config.min_version = Some(TlsVersion::Tls12);
+        config.max_version = Some(TlsVersion::Tls13);
 
-        assert!(config.validate_tls_config().is_ok());
+        assert!(config.validate().is_ok());
     }
 
     #[rstest]
@@ -804,7 +792,7 @@ type = "Simple"
         #[case] expected_min_version: Option<TlsVersion>,
     ) {
         let config = KbsConfig::try_from(Path::new(config_path)).unwrap();
-        assert_eq!(config.http_server.tls_profile, expected_profile);
-        assert_eq!(config.http_server.tls_min_version, expected_min_version);
+        assert_eq!(config.http_server.tls.profile, expected_profile);
+        assert_eq!(config.http_server.tls.min_version, expected_min_version);
     }
 }

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -5,7 +5,7 @@
 use crate::admin::AdminConfig;
 use crate::plugins::PluginsConfig;
 use crate::token::AttestationTokenVerifierConfig;
-use anyhow::anyhow;
+use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
 use config::{Config, File};
 use const_format::concatcp;
@@ -13,10 +13,33 @@ use key_value_storage::{KeyValueStorageType, StorageBackendConfig};
 use serde::Deserialize;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use strum::AsRefStr;
 
 const DEFAULT_INSECURE_HTTP: bool = false;
 const DEFAULT_SOCKET: &str = "127.0.0.1:8080";
 const DEFAULT_PAYLOAD_REQUEST_SIZE: u32 = 2;
+
+/// TLS security profile
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum TlsProfile {
+    Old,
+    #[default]
+    Intermediate,
+    Modern,
+    Custom,
+}
+
+/// TLS protocol version
+#[derive(Clone, Debug, Deserialize, PartialEq, AsRefStr)]
+pub enum TlsVersion {
+    #[serde(rename = "1.2")]
+    #[strum(serialize = "1.2")]
+    Tls12,
+    #[serde(rename = "1.3")]
+    #[strum(serialize = "1.3")]
+    Tls13,
+}
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(default)]
@@ -40,6 +63,21 @@ pub struct HttpServerConfig {
     /// Number of worker threads for the actix-web server.
     /// If not specified, defaults to the number of logical CPU cores.
     pub worker_count: Option<usize>,
+
+    /// TLS security profile: old, intermediate, modern, or custom
+    pub tls_profile: TlsProfile,
+
+    /// Minimum TLS version (for custom profile)
+    pub tls_min_version: Option<TlsVersion>,
+
+    /// Maximum TLS version (for custom profile)
+    pub tls_max_version: Option<TlsVersion>,
+
+    /// TLS cipher suites (colon-separated OpenSSL cipher list)
+    pub tls_ciphers: Option<String>,
+
+    /// TLS groups for key exchange (colon-separated list)
+    pub tls_groups: Option<String>,
 }
 
 impl Default for HttpServerConfig {
@@ -51,7 +89,48 @@ impl Default for HttpServerConfig {
             insecure_http: DEFAULT_INSECURE_HTTP,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            tls_profile: TlsProfile::default(),
+            tls_min_version: None,
+            tls_max_version: None,
+            tls_ciphers: None,
+            tls_groups: None,
         }
+    }
+}
+
+impl HttpServerConfig {
+    /// Validate TLS configuration consistency
+    pub fn validate_tls_config(&self) -> Result<()> {
+        // Warn if non-custom profile has custom fields
+        if self.tls_profile != TlsProfile::Custom
+            && (self.tls_min_version.is_some()
+                || self.tls_max_version.is_some()
+                || self.tls_ciphers.is_some()
+                || self.tls_groups.is_some())
+        {
+            tracing::warn!(
+                "TLS profile is {:?} but custom fields are set. Custom fields will override profile defaults.",
+                self.tls_profile
+            );
+        }
+
+        // Validate version range
+        if let (Some(min_version), Some(max_version)) =
+            (&self.tls_min_version, &self.tls_max_version)
+        {
+            if matches!(
+                (min_version, max_version),
+                (TlsVersion::Tls13, TlsVersion::Tls12)
+            ) {
+                bail!(
+                    "tls_min_version ({}) cannot be greater than tls_max_version ({})",
+                    min_version.as_ref(),
+                    max_version.as_ref()
+                );
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -153,8 +232,17 @@ impl TryFrom<&Path> for KbsConfig {
             .build()
             .map_err(|e| format_config_load_error(config_path, e))?;
 
-        c.try_deserialize()
-            .map_err(|e| format_config_load_error(config_path, e))
+        let config: KbsConfig = c
+            .try_deserialize()
+            .map_err(|e| format_config_load_error(config_path, e));
+
+        // Validate TLS configuration
+        config
+            .http_server
+            .validate_tls_config()
+            .context("TLS configuration error")?;
+
+        Ok(config)
     }
 }
 
@@ -175,7 +263,8 @@ mod tests {
     use crate::{
         admin::AdminConfig,
         config::{
-            HttpServerConfig, DEFAULT_INSECURE_HTTP, DEFAULT_PAYLOAD_REQUEST_SIZE, DEFAULT_SOCKET,
+            HttpServerConfig, TlsProfile, TlsVersion, DEFAULT_INSECURE_HTTP,
+            DEFAULT_PAYLOAD_REQUEST_SIZE, DEFAULT_SOCKET,
         },
         plugins::{
             implementations::{RepositoryConfig, SampleConfig},
@@ -273,6 +362,11 @@ mod tests {
             insecure_http: false,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            tls_profile: TlsProfile::default(),
+            tls_min_version: None,
+            tls_max_version: None,
+            tls_ciphers: None,
+            tls_groups: None,
         },
         admin: AdminConfig::DenyAll {},
         storage_backend: StorageBackendConfig {
@@ -326,6 +420,11 @@ mod tests {
             insecure_http: DEFAULT_INSECURE_HTTP,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            tls_profile: TlsProfile::default(),
+            tls_min_version: None,
+            tls_max_version: None,
+            tls_ciphers: None,
+            tls_groups: None,
         },
         admin: AdminConfig::DenyAll {},
         storage_backend: StorageBackendConfig {
@@ -370,6 +469,11 @@ mod tests {
             insecure_http: false,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            tls_profile: TlsProfile::default(),
+            tls_min_version: None,
+            tls_max_version: None,
+            tls_ciphers: None,
+            tls_groups: None,
         },
         admin: AdminConfig::DenyAll {},
         storage_backend: StorageBackendConfig {
@@ -411,6 +515,11 @@ mod tests {
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            tls_profile: TlsProfile::default(),
+            tls_min_version: None,
+            tls_max_version: None,
+            tls_ciphers: None,
+            tls_groups: None,
         },
         admin: make_token_authorization_admin_config(),
         storage_backend: StorageBackendConfig {
@@ -457,6 +566,11 @@ mod tests {
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            tls_profile: TlsProfile::default(),
+            tls_min_version: None,
+            tls_max_version: None,
+            tls_ciphers: None,
+            tls_groups: None,
         },
         admin: AdminConfig::InsecureAllowAll {},
         storage_backend: StorageBackendConfig {
@@ -499,6 +613,11 @@ mod tests {
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            tls_profile: TlsProfile::default(),
+            tls_min_version: None,
+            tls_max_version: None,
+            tls_ciphers: None,
+            tls_groups: None,
         },
         admin: AdminConfig::DenyAll {},
         storage_backend: StorageBackendConfig::default(),
@@ -636,5 +755,56 @@ type = "Simple"
             message.contains("#admin-api-configuration"),
             "expected admin doc hint in: {message}"
         );
+
+    #[test]
+    fn test_tls_profile_default() {
+        let config = HttpServerConfig::default();
+        assert_eq!(config.tls_profile, TlsProfile::Intermediate);
+    }
+
+    #[test]
+    fn test_tls_version_range_validation_error() {
+        let mut config = HttpServerConfig::default();
+        config.tls_min_version = Some(TlsVersion::Tls13);
+        config.tls_max_version = Some(TlsVersion::Tls12);
+
+        assert!(config.validate_tls_config().is_err());
+    }
+
+    #[test]
+    fn test_tls_version_range_validation_ok() {
+        let mut config = HttpServerConfig::default();
+        config.tls_min_version = Some(TlsVersion::Tls12);
+        config.tls_max_version = Some(TlsVersion::Tls13);
+
+        assert!(config.validate_tls_config().is_ok());
+    }
+
+    #[rstest]
+    #[case("test_data/configs/tls-profile-old.toml", TlsProfile::Old, None)]
+    #[case(
+        "test_data/configs/tls-profile-intermediate.toml",
+        TlsProfile::Intermediate,
+        None
+    )]
+    #[case("test_data/configs/tls-profile-modern.toml", TlsProfile::Modern, None)]
+    #[case(
+        "test_data/configs/tls-profile-custom.toml",
+        TlsProfile::Custom,
+        Some(TlsVersion::Tls13)
+    )]
+    #[case(
+        "test_data/configs/tls-profile-custom-pqc.toml",
+        TlsProfile::Custom,
+        Some(TlsVersion::Tls13)
+    )]
+    fn test_tls_config_files(
+        #[case] config_path: &str,
+        #[case] expected_profile: TlsProfile,
+        #[case] expected_min_version: Option<TlsVersion>,
+    ) {
+        let config = KbsConfig::try_from(Path::new(config_path)).unwrap();
+        assert_eq!(config.http_server.tls_profile, expected_profile);
+        assert_eq!(config.http_server.tls_min_version, expected_min_version);
     }
 }

--- a/kbs/src/http.rs
+++ b/kbs/src/http.rs
@@ -7,7 +7,7 @@ use std::sync::OnceLock;
 use anyhow::{anyhow, Result};
 use tracing::{debug, info, warn};
 
-use crate::config::{HttpServerConfig, TlsProfile, TlsVersion};
+use crate::config::{HttpServerConfig, TlsConfig, TlsProfile, TlsVersion};
 use openssl::ssl::SslVersion;
 
 /// PQC algorithm candidates in priority order
@@ -90,9 +90,9 @@ fn apply_mozilla_profile(
 /// Apply custom TLS configuration from explicit fields
 fn apply_custom_tls_config(
     builder: &mut openssl::ssl::SslAcceptorBuilder,
-    config: &HttpServerConfig,
+    config: &TlsConfig,
 ) -> Result<()> {
-    if let Some(min_version) = &config.tls_min_version {
+    if let Some(min_version) = &config.min_version {
         let ssl_version = match min_version {
             TlsVersion::Tls12 => SslVersion::TLS1_2,
             TlsVersion::Tls13 => SslVersion::TLS1_3,
@@ -101,7 +101,7 @@ fn apply_custom_tls_config(
         debug!("TLS minimum version: {:?}", min_version);
     }
 
-    if let Some(max_version) = &config.tls_max_version {
+    if let Some(max_version) = &config.max_version {
         let ssl_version = match max_version {
             TlsVersion::Tls12 => SslVersion::TLS1_2,
             TlsVersion::Tls13 => SslVersion::TLS1_3,
@@ -110,14 +110,14 @@ fn apply_custom_tls_config(
         debug!("TLS maximum version: {:?}", max_version);
     }
 
-    if let Some(ciphers) = &config.tls_ciphers {
+    if let Some(ciphers) = &config.ciphers {
         // set_cipher_list() configures TLS 1.2 ciphers
         // set_ciphersuites() configures TLS 1.3 ciphers
         // TLS 1.2 is disabled if: min_version is 1.3 OR profile is Modern
         // TLS 1.3 is disabled if: max_version is 1.2
-        let tls12_disabled = config.tls_min_version == Some(TlsVersion::Tls13)
-            || config.tls_profile == TlsProfile::Modern;
-        let tls13_disabled = config.tls_max_version == Some(TlsVersion::Tls12);
+        let tls12_disabled =
+            config.min_version == Some(TlsVersion::Tls13) || config.profile == TlsProfile::Modern;
+        let tls13_disabled = config.max_version == Some(TlsVersion::Tls12);
 
         if !tls12_disabled {
             builder.set_cipher_list(ciphers)?;
@@ -132,8 +132,8 @@ fn apply_custom_tls_config(
 }
 
 /// Determine effective TLS groups configuration
-fn get_effective_groups(config: &HttpServerConfig) -> String {
-    if let Some(groups) = &config.tls_groups {
+fn get_effective_groups(config: &TlsConfig) -> String {
+    if let Some(groups) = &config.groups {
         return groups.clone();
     }
 
@@ -148,11 +148,13 @@ pub fn tls_config(config: &HttpServerConfig) -> Result<openssl::ssl::SslAcceptor
     use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
 
     let cert_file = config
+        .tls
         .certificate
         .as_ref()
         .ok_or_else(|| anyhow!("Missing certificate"))?;
 
     let key_file = config
+        .tls
         .private_key
         .as_ref()
         .ok_or_else(|| anyhow!("Missing private key"))?;
@@ -165,22 +167,22 @@ pub fn tls_config(config: &HttpServerConfig) -> Result<openssl::ssl::SslAcceptor
     builder.set_certificate_chain_file(cert_file)?;
 
     // Apply profile-specific configuration
-    apply_mozilla_profile(&mut builder, &config.tls_profile)?;
+    apply_mozilla_profile(&mut builder, &config.tls.profile)?;
 
     // Apply custom overrides (these take precedence)
-    if config.tls_profile == TlsProfile::Custom
-        || config.tls_min_version.is_some()
-        || config.tls_max_version.is_some()
-        || config.tls_ciphers.is_some()
+    if config.tls.profile == TlsProfile::Custom
+        || config.tls.min_version.is_some()
+        || config.tls.max_version.is_some()
+        || config.tls.ciphers.is_some()
     {
-        apply_custom_tls_config(&mut builder, config)?;
+        apply_custom_tls_config(&mut builder, &config.tls)?;
     }
 
     // Configure TLS groups (with PQC auto-detection)
-    let groups = get_effective_groups(config);
+    let groups = get_effective_groups(&config.tls);
     builder.set_groups_list(&groups)?;
 
-    if config.tls_groups.is_some() {
+    if config.tls.groups.is_some() {
         info!("TLS groups (explicit): {}", groups);
     } else if groups.contains("MLKEM") {
         info!("TLS groups (auto-detected PQC): {}", groups);

--- a/kbs/src/http.rs
+++ b/kbs/src/http.rs
@@ -5,9 +5,10 @@
 use std::sync::OnceLock;
 
 use anyhow::{anyhow, Result};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
-use crate::config::HttpServerConfig;
+use crate::config::{HttpServerConfig, TlsProfile, TlsVersion};
+use openssl::ssl::SslVersion;
 
 /// PQC algorithm candidates in priority order
 /// Based on OpenSSL 3.5+ supported hybrid groups
@@ -61,6 +62,88 @@ fn detect_best_pqc_group() -> Option<&'static str> {
     })
 }
 
+/// Apply TLS profile-specific configuration
+fn apply_mozilla_profile(
+    builder: &mut openssl::ssl::SslAcceptorBuilder,
+    profile: &TlsProfile,
+) -> Result<()> {
+    match profile {
+        TlsProfile::Old => {
+            builder.set_min_proto_version(Some(SslVersion::TLS1_2))?;
+            info!("TLS profile: Old (minimum TLS 1.2)");
+        }
+        TlsProfile::Intermediate => {
+            // Already configured by mozilla_intermediate_v5
+            info!("TLS profile: Intermediate (TLS 1.2+, recommended)");
+        }
+        TlsProfile::Modern => {
+            builder.set_min_proto_version(Some(SslVersion::TLS1_3))?;
+            info!("TLS profile: Modern (TLS 1.3 only)");
+        }
+        TlsProfile::Custom => {
+            info!("TLS profile: Custom");
+        }
+    }
+    Ok(())
+}
+
+/// Apply custom TLS configuration from explicit fields
+fn apply_custom_tls_config(
+    builder: &mut openssl::ssl::SslAcceptorBuilder,
+    config: &HttpServerConfig,
+) -> Result<()> {
+    if let Some(min_version) = &config.tls_min_version {
+        let ssl_version = match min_version {
+            TlsVersion::Tls12 => SslVersion::TLS1_2,
+            TlsVersion::Tls13 => SslVersion::TLS1_3,
+        };
+        builder.set_min_proto_version(Some(ssl_version))?;
+        debug!("TLS minimum version: {:?}", min_version);
+    }
+
+    if let Some(max_version) = &config.tls_max_version {
+        let ssl_version = match max_version {
+            TlsVersion::Tls12 => SslVersion::TLS1_2,
+            TlsVersion::Tls13 => SslVersion::TLS1_3,
+        };
+        builder.set_max_proto_version(Some(ssl_version))?;
+        debug!("TLS maximum version: {:?}", max_version);
+    }
+
+    if let Some(ciphers) = &config.tls_ciphers {
+        // set_cipher_list() configures TLS 1.2 ciphers
+        // set_ciphersuites() configures TLS 1.3 ciphers
+        // TLS 1.2 is disabled if: min_version is 1.3 OR profile is Modern
+        // TLS 1.3 is disabled if: max_version is 1.2
+        let tls12_disabled = config.tls_min_version == Some(TlsVersion::Tls13)
+            || config.tls_profile == TlsProfile::Modern;
+        let tls13_disabled = config.tls_max_version == Some(TlsVersion::Tls12);
+
+        if !tls12_disabled {
+            builder.set_cipher_list(ciphers)?;
+        }
+        if !tls13_disabled {
+            builder.set_ciphersuites(ciphers)?;
+        }
+        debug!("TLS ciphers: {}", ciphers);
+    }
+
+    Ok(())
+}
+
+/// Determine effective TLS groups configuration
+fn get_effective_groups(config: &HttpServerConfig) -> String {
+    if let Some(groups) = &config.tls_groups {
+        return groups.clone();
+    }
+
+    if let Some(pqc_group) = detect_best_pqc_group() {
+        format!("{}:{}", pqc_group, CLASSICAL_GROUPS)
+    } else {
+        CLASSICAL_GROUPS.to_string()
+    }
+}
+
 pub fn tls_config(config: &HttpServerConfig) -> Result<openssl::ssl::SslAcceptorBuilder> {
     use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
 
@@ -81,21 +164,29 @@ pub fn tls_config(config: &HttpServerConfig) -> Result<openssl::ssl::SslAcceptor
     builder.set_private_key_file(key_file, SslFiletype::PEM)?;
     builder.set_certificate_chain_file(cert_file)?;
 
-    // Auto-detect and configure TLS groups based on OpenSSL capabilities
-    let groups = if let Some(pqc_group) = detect_best_pqc_group() {
-        info!("PQC TLS enabled with {}", pqc_group);
-        format!("{}:{}", pqc_group, CLASSICAL_GROUPS)
-    } else {
-        info!(
-            "PQC TLS not available, using classical algorithms: {}",
-            CLASSICAL_GROUPS
-        );
-        CLASSICAL_GROUPS.to_string()
-    };
+    // Apply profile-specific configuration
+    apply_mozilla_profile(&mut builder, &config.tls_profile)?;
 
+    // Apply custom overrides (these take precedence)
+    if config.tls_profile == TlsProfile::Custom
+        || config.tls_min_version.is_some()
+        || config.tls_max_version.is_some()
+        || config.tls_ciphers.is_some()
+    {
+        apply_custom_tls_config(&mut builder, config)?;
+    }
+
+    // Configure TLS groups (with PQC auto-detection)
+    let groups = get_effective_groups(config);
     builder.set_groups_list(&groups)?;
-    info!("KBS TLS groups: {}", groups);
-    info!("Supported TLS versions: 1.2, 1.3");
+
+    if config.tls_groups.is_some() {
+        info!("TLS groups (explicit): {}", groups);
+    } else if groups.contains("MLKEM") {
+        info!("TLS groups (auto-detected PQC): {}", groups);
+    } else {
+        info!("TLS groups (classical): {}", groups);
+    }
 
     Ok(builder)
 }

--- a/kbs/test_data/configs/tls-profile-custom-pqc.toml
+++ b/kbs/test_data/configs/tls-profile-custom-pqc.toml
@@ -15,7 +15,7 @@ type = "coco_as_grpc"
 as_addr = "http://127.0.0.1:50001"
 
 [admin]
-type = "DenyAll"
+authorization_mode = "DenyAll"
 
 [storage_backend]
 storage_type = "memory"

--- a/kbs/test_data/configs/tls-profile-custom-pqc.toml
+++ b/kbs/test_data/configs/tls-profile-custom-pqc.toml
@@ -1,0 +1,21 @@
+[http_server]
+sockets = ["0.0.0.0:8080"]
+private_key = "/etc/kbs-private.key"
+certificate = "/etc/kbs-cert.pem"
+tls_profile = "custom"
+tls_min_version = "1.3"
+tls_max_version = "1.3"
+# TLS 1.3 cipher suites (only encryption+hash; key exchange configured via tls_groups)
+tls_ciphers = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
+# Post-quantum key exchange groups with classical fallbacks
+tls_groups = "X25519MLKEM768:X25519:secp256r1"
+
+[attestation_service]
+type = "coco_as_grpc"
+as_addr = "http://127.0.0.1:50001"
+
+[admin]
+type = "DenyAll"
+
+[storage_backend]
+storage_type = "memory"

--- a/kbs/test_data/configs/tls-profile-custom.toml
+++ b/kbs/test_data/configs/tls-profile-custom.toml
@@ -12,7 +12,7 @@ type = "coco_as_grpc"
 as_addr = "http://127.0.0.1:50001"
 
 [admin]
-type = "DenyAll"
+authorization_mode = "DenyAll"
 
 [storage_backend]
 storage_type = "memory"

--- a/kbs/test_data/configs/tls-profile-custom.toml
+++ b/kbs/test_data/configs/tls-profile-custom.toml
@@ -1,0 +1,18 @@
+[http_server]
+sockets = ["0.0.0.0:8080"]
+private_key = "/etc/kbs-private.key"
+certificate = "/etc/kbs-cert.pem"
+tls_profile = "custom"
+tls_min_version = "1.3"
+tls_ciphers = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
+tls_groups = "X25519:secp384r1"
+
+[attestation_service]
+type = "coco_as_grpc"
+as_addr = "http://127.0.0.1:50001"
+
+[admin]
+type = "DenyAll"
+
+[storage_backend]
+storage_type = "memory"

--- a/kbs/test_data/configs/tls-profile-intermediate.toml
+++ b/kbs/test_data/configs/tls-profile-intermediate.toml
@@ -13,7 +13,7 @@ type = "coco_as_grpc"
 as_addr = "http://127.0.0.1:50001"
 
 [admin]
-type = "DenyAll"
+authorization_mode = "DenyAll"
 
 [storage_backend]
 storage_type = "memory"

--- a/kbs/test_data/configs/tls-profile-intermediate.toml
+++ b/kbs/test_data/configs/tls-profile-intermediate.toml
@@ -1,0 +1,19 @@
+# TLS Intermediate profile (default)
+# - Supports TLS 1.2 and TLS 1.3
+# - Recommended for most deployments
+# - Balances security and compatibility
+[http_server]
+sockets = ["0.0.0.0:8080"]
+private_key = "/etc/kbs-private.key"
+certificate = "/etc/kbs-cert.pem"
+tls_profile = "intermediate"
+
+[attestation_service]
+type = "coco_as_grpc"
+as_addr = "http://127.0.0.1:50001"
+
+[admin]
+type = "DenyAll"
+
+[storage_backend]
+storage_type = "memory"

--- a/kbs/test_data/configs/tls-profile-modern.toml
+++ b/kbs/test_data/configs/tls-profile-modern.toml
@@ -9,7 +9,7 @@ type = "coco_as_grpc"
 as_addr = "http://127.0.0.1:50001"
 
 [admin]
-type = "DenyAll"
+authorization_mode = "DenyAll"
 
 [storage_backend]
 storage_type = "memory"

--- a/kbs/test_data/configs/tls-profile-modern.toml
+++ b/kbs/test_data/configs/tls-profile-modern.toml
@@ -1,0 +1,15 @@
+[http_server]
+sockets = ["0.0.0.0:8080"]
+private_key = "/etc/kbs-private.key"
+certificate = "/etc/kbs-cert.pem"
+tls_profile = "modern"
+
+[attestation_service]
+type = "coco_as_grpc"
+as_addr = "http://127.0.0.1:50001"
+
+[admin]
+type = "DenyAll"
+
+[storage_backend]
+storage_type = "memory"

--- a/kbs/test_data/configs/tls-profile-old.toml
+++ b/kbs/test_data/configs/tls-profile-old.toml
@@ -1,0 +1,19 @@
+# TLS Old profile
+# - Supports TLS 1.2 and TLS 1.3
+# - For legacy client compatibility
+# - Less restrictive cipher suite requirements
+[http_server]
+sockets = ["0.0.0.0:8080"]
+private_key = "/etc/kbs-private.key"
+certificate = "/etc/kbs-cert.pem"
+tls_profile = "old"
+
+[attestation_service]
+type = "coco_as_grpc"
+as_addr = "http://127.0.0.1:50001"
+
+[admin]
+type = "DenyAll"
+
+[storage_backend]
+storage_type = "memory"

--- a/kbs/test_data/configs/tls-profile-old.toml
+++ b/kbs/test_data/configs/tls-profile-old.toml
@@ -13,7 +13,7 @@ type = "coco_as_grpc"
 as_addr = "http://127.0.0.1:50001"
 
 [admin]
-type = "DenyAll"
+authorization_mode = "DenyAll"
 
 [storage_backend]
 storage_type = "memory"

--- a/tools/trustee-cli/src/run.rs
+++ b/tools/trustee-cli/src/run.rs
@@ -71,17 +71,18 @@ fn get_config(config_file: Option<PathBuf>, trustee_home_dir: &Path) -> Result<K
     // Generate and use a self-signed certificate if there is none configured.
     // Intended to discourage using the service in the clear.
     if !config.http_server.insecure_http {
-        if config.http_server.private_key.is_none() {
+        if config.http_server.tls.private_key.is_none() {
             let (private_path, _) = ensure_https_key_pair(trustee_home_dir)?;
 
-            config.http_server.private_key = Some(private_path);
+            config.http_server.tls.private_key = Some(private_path);
         }
 
-        if config.http_server.certificate.is_none() {
+        if config.http_server.tls.certificate.is_none() {
             let private_key = {
                 let private_key_data = std::fs::read(
                     config
                         .http_server
+                        .tls
                         .private_key
                         .as_ref()
                         .expect("private_key should be already set in config"),
@@ -93,7 +94,7 @@ fn get_config(config_file: Option<PathBuf>, trustee_home_dir: &Path) -> Result<K
             let cert_path = trustee_home_dir.join("https_cert_cache.pem");
             write(&cert_path, &cert.to_pem()?)?;
 
-            config.http_server.certificate = Some(cert_path);
+            config.http_server.tls.certificate = Some(cert_path);
         }
     }
 


### PR DESCRIPTION
Add support for Mozilla TLS security profiles (old, intermediate, modern, custom) and custom TLS configuration options.

Fix issue #1347