### PR TITLE
Add PQC-aware TLS for KBS HTTP and gRPC TLS across KBS, attestation-service, and RVPS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,7 @@ dependencies = [
  "regorus",
  "rsa",
  "rstest",
+ "rustls",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
@@ -616,6 +617,7 @@ dependencies = [
  "testing_logger",
  "thiserror 2.0.18",
  "time",
+ "tls-config",
  "tokio",
  "toml",
  "tonic",
@@ -3649,6 +3651,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "time",
+ "tls-config",
  "tokio",
  "toml",
  "tonic",
@@ -5302,6 +5305,7 @@ dependencies = [
  "prost",
  "roxmltree",
  "rstest",
+ "rustls",
  "serde",
  "serde_json",
  "serial_test",
@@ -5310,6 +5314,7 @@ dependencies = [
  "sled",
  "strum 0.28.0",
  "tempfile",
+ "tls-config",
  "tokio",
  "tonic",
  "tonic-prost",
@@ -7064,6 +7069,20 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls-config"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "openssl",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tracing",
+]
 
 [[package]]
 name = "tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "tools/trustee-cli",
     "deps/key-value-storage",
     "deps/policy-engine",
+    "deps/tls-config",
 ]
 resolver = "2"
 

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -18,10 +18,10 @@ se-verifier = ["verifier/se-verifier"]
 nvidia-verifier = ["verifier/nvidia-verifier"]
 tpm-verifier = ["verifier/tpm-verifier"]
 
-rvps-grpc = ["prost", "tonic", "mobc"]
+rvps-grpc = ["prost", "tonic", "mobc", "tls-config/grpc", "rustls"]
 
 # For building gRPC CoCo-AS binary
-grpc-bin = ["clap", "prost", "tonic", "tonic-prost"]
+grpc-bin = ["clap", "prost", "tonic", "tonic-prost", "rustls", "tls-config/grpc"]
 
 # For restful CoCo-AS binary
 restful-bin = ["actix-cors", "actix-web/openssl", "clap"]
@@ -49,6 +49,7 @@ kbs-types.workspace = true
 key-value-storage.path = "../deps/key-value-storage"
 mobc = { workspace = true, optional = true }
 openssl.workspace = true
+tls-config.path = "../deps/tls-config"
 policy-engine.path = "../deps/policy-engine"
 prost = { workspace = true, optional = true }
 reference-value-provider-service.path = "../rvps"
@@ -67,6 +68,10 @@ tokio.workspace = true
 toml.workspace = true
 tonic = { workspace = true, optional = true }
 tonic-prost = { workspace = true, optional = true }
+rustls = { version = "0.23", default-features = false, features = [
+    "aws-lc-rs",
+    "prefer-post-quantum",
+], optional = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true

--- a/attestation-service/docs/config.md
+++ b/attestation-service/docs/config.md
@@ -84,9 +84,11 @@ For detailed information about extractors configuration, including available ext
 
 If `type` is set to `GrpcRemote`, the following extra properties can be set
 
-| Property       | Type                    | Description                             | Required | Default          |
-|----------------|-------------------------|-----------------------------------------|----------|------------------|
-| `address`      | String                  | Remote address of the RVPS server       | No       | `127.0.0.1:50003`|
+| Property       | Type   | Description                                                                                  | Required | Default           |
+|----------------|--------|----------------------------------------------------------------------------------------------|----------|-------------------|
+| `address`      | String | Remote address of the RVPS server                                                            | No       | `127.0.0.1:50003` |
+| `tls_mode`     | String | gRPC channel security: `"insecure"` (plaintext) or `"tls"`                                  | No       | `"insecure"`      |
+| `ca_cert_path` | String | Path to PEM CA certificate used to verify the RVPS server. Required when `tls_mode = "tls"` | No       | —                 |
 
 #### Verifier Configuration
 

--- a/attestation-service/docs/grpc-as.md
+++ b/attestation-service/docs/grpc-as.md
@@ -90,6 +90,13 @@ Start Attestation Service and specify the listen port of its gRPC service:
 grpc-as --socket 127.0.0.1:50004
 ```
 
+To enable TLS on the gRPC listener, provide a certificate and private key (both PEM format):
+```shell
+grpc-as --socket 0.0.0.0:50004 --tls-cert /etc/as/server.crt --tls-key /etc/as/server.key
+```
+
+Both `--tls-cert` and `--tls-key` must be provided together. If neither is given the server starts without TLS (default behavior). When TLS is enabled the server negotiates PQC hybrid key exchange (e.g., X25519MLKEM768) automatically with compatible clients via the aws-lc-rs rustls provider.
+
 If you want to see the runtime log, run:
 ```shell
 RUST_LOG=debug grpc-as --socket 127.0.0.1:50004

--- a/attestation-service/src/bin/grpc-as.rs
+++ b/attestation-service/src/bin/grpc-as.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
@@ -29,6 +30,16 @@ pub struct Cli {
     /// Socket that the server will listen on to accept requests.
     #[arg(short, long, default_value = "127.0.0.1:3000")]
     pub socket: SocketAddr,
+
+    /// Path to the TLS certificate file (PEM) for the gRPC listener.
+    /// When provided, --tls-key must also be given.
+    /// If omitted, the server starts without TLS (default behavior).
+    #[arg(long)]
+    pub tls_cert: Option<PathBuf>,
+
+    /// Path to the TLS private key file (PEM) for the gRPC listener.
+    #[arg(long)]
+    pub tls_key: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -65,7 +76,14 @@ loglevel: {env_filter}
 
     let cli = Cli::parse();
 
-    let server = grpc::start(cli.socket, cli.config_file);
+    // Install aws-lc-rs as the rustls crypto provider so PQC hybrid groups
+    // (X25519MLKEM768 etc.) are available for any TLS connection in this process.
+    // install_default() is idempotent via .ok().
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+
+    let server = grpc::start(cli.socket, cli.config_file, cli.tls_cert, cli.tls_key);
     tokio::try_join!(server)?;
 
     Ok(())

--- a/attestation-service/src/bin/grpc/mod.rs
+++ b/attestation-service/src/bin/grpc/mod.rs
@@ -7,13 +7,13 @@ use attestation_service::{
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use std::net::SocketAddr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
-use tracing::{debug, info, instrument, Span};
+use tracing::{debug, info, instrument, warn, Span};
 use uuid::Uuid;
 
 use crate::as_api::attestation_service_server::{AttestationService, AttestationServiceServer};
@@ -57,6 +57,8 @@ pub enum GrpcError {
     Service(#[from] ServiceError),
     #[error("tonic transport error: {0}")]
     TonicTransport(#[from] tonic::transport::Error),
+    #[error("TLS configuration error: {0}")]
+    TlsConfig(#[source] anyhow::Error),
 }
 
 pub struct AttestationServer {
@@ -309,7 +311,12 @@ impl ReferenceValueProviderService for Arc<RwLock<AttestationServer>> {
     }
 }
 
-pub async fn start(socket: SocketAddr, config_path: Option<String>) -> Result<(), GrpcError> {
+pub async fn start(
+    socket: SocketAddr,
+    config_path: Option<String>,
+    tls_cert: Option<PathBuf>,
+    tls_key: Option<PathBuf>,
+) -> Result<(), GrpcError> {
     info!(
         "Starting gRPC Attestation Service. Listening on socket: {}",
         &socket
@@ -317,10 +324,26 @@ pub async fn start(socket: SocketAddr, config_path: Option<String>) -> Result<()
 
     let attestation_server = Arc::new(RwLock::new(AttestationServer::new(config_path).await?));
 
-    Server::builder()
+    let tls =
+        tls_config::grpc::build_grpc_server_tls_config(tls_cert.as_deref(), tls_key.as_deref())
+            .await
+            .map_err(GrpcError::TlsConfig)?;
+
+    let mut builder = Server::builder();
+    if let Some(tls_config) = tls {
+        builder = builder
+            .tls_config(tls_config)
+            .map_err(GrpcError::TonicTransport)?;
+        info!("gRPC AS: TLS enabled");
+    } else {
+        warn!("gRPC AS: TLS not configured — running in plaintext mode");
+    }
+
+    builder
         .add_service(AttestationServiceServer::new(attestation_server.clone()))
         .add_service(ReferenceValueProviderServiceServer::new(attestation_server))
         .serve(socket)
         .await?;
+
     Ok(())
 }

--- a/attestation-service/src/bin/restful-as.rs
+++ b/attestation-service/src/bin/restful-as.rs
@@ -1,4 +1,8 @@
-use std::{net::SocketAddr, path::{Path, PathBuf}, sync::Arc};
+use std::{
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use actix_cors::Cors;
 use actix_web::{http::header, web, App, HttpServer};
@@ -207,9 +211,8 @@ loglevel: {env_filter}
                 .set_certificate_chain_file(&tls_cert)
                 .map_err(RestfulError::SetHttpsCert)?;
 
-            let pqc_result =
-                tls_config::configure_pqc_groups(&mut builder, cli.require_pqc)
-                    .map_err(|e| RestfulError::Anyhow(e.into()))?;
+            let pqc_result = tls_config::configure_pqc_groups(&mut builder, cli.require_pqc)
+                .map_err(|e| RestfulError::Anyhow(e.into()))?;
             info!("AS REST TLS groups: {}", pqc_result.groups_list);
 
             info!("starting HTTPS server at https://{}", cli.socket);

--- a/attestation-service/src/bin/restful-as.rs
+++ b/attestation-service/src/bin/restful-as.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, path::Path, sync::Arc};
+use std::{net::SocketAddr, path::{Path, PathBuf}, sync::Arc};
 
 use actix_cors::Cors;
 use actix_web::{http::header, web, App, HttpServer};
@@ -34,20 +34,27 @@ pub struct Cli {
     #[arg(short, long)]
     pub socket: SocketAddr,
 
-    /// Path to the public key cert for HTTPS. Both public key cert and
-    /// private key are provided then HTTPS will be enabled.
-    #[arg(short = 't', long)]
-    pub https_pubkey_cert: Option<String>,
+    /// Path to the TLS certificate file (PEM). Both certificate and private
+    /// key must be provided to enable HTTPS.
+    #[arg(short = 't', long = "tls-cert", alias = "https-pubkey-cert")]
+    pub tls_cert: Option<PathBuf>,
 
-    /// Path to the private key for HTTPS. Both public key cert and
-    /// private key are provided then HTTPS will be enabled.
-    #[arg(short = 'k', long)]
-    pub https_prikey: Option<String>,
+    /// Path to the TLS private key file (PEM). Both certificate and private
+    /// key must be provided to enable HTTPS.
+    #[arg(short = 'k', long = "tls-key", alias = "https-prikey")]
+    pub tls_key: Option<PathBuf>,
 
     /// Allowed origin for CORS access (e.g., "http://localhost:3000")
     /// Can be specified multiple times or comma-separated
     #[arg(short = 'r', long = "allowed_origin", value_delimiter = ',', num_args = 1..)]
     pub allowed_origin: Vec<String>,
+
+    /// Require post-quantum cryptography for TLS.
+    /// When true, the server refuses to start if no PQC hybrid groups
+    /// are supported by the OpenSSL build, and only PQC hybrid groups
+    /// are offered — clients without PQC support cannot connect.
+    #[arg(long)]
+    pub require_pqc: bool,
 }
 
 #[derive(EnumString, AsRefStr)]
@@ -146,6 +153,14 @@ loglevel: {env_filter}
     info!("Welcome to Confidential Containers Attestation Service (RESTful version)!\n\n{version}");
     let cli = Cli::parse();
 
+    // Install aws-lc-rs as the rustls crypto provider so PQC hybrid groups
+    // are available for any TLS connection in this process.
+    // install_default() is idempotent via .ok().
+    #[cfg(feature = "rvps-grpc")]
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+
     let config = match cli.config_file {
         Some(path) => {
             info!("Using config file {path}");
@@ -175,11 +190,11 @@ loglevel: {env_filter}
             .app_data(web::Data::clone(&attestation_service))
     });
 
-    let server = match (cli.https_prikey, cli.https_pubkey_cert) {
-        (Some(prikey), Some(pubkey_cert)) => {
+    let server = match (cli.tls_key, cli.tls_cert) {
+        (Some(tls_key), Some(tls_cert)) => {
             let mut builder = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls())?;
 
-            let prikey = tokio::fs::read(prikey)
+            let prikey = tokio::fs::read(&tls_key)
                 .await
                 .map_err(RestfulError::ReadHttpsKey)?;
             let prikey =
@@ -189,16 +204,32 @@ loglevel: {env_filter}
                 .set_private_key(&prikey)
                 .map_err(RestfulError::SetPrivateKey)?;
             builder
-                .set_certificate_chain_file(pubkey_cert)
+                .set_certificate_chain_file(&tls_cert)
                 .map_err(RestfulError::SetHttpsCert)?;
+
+            let pqc_result =
+                tls_config::configure_pqc_groups(&mut builder, cli.require_pqc)
+                    .map_err(|e| RestfulError::Anyhow(e.into()))?;
+            info!("AS REST TLS groups: {}", pqc_result.groups_list);
+
             info!("starting HTTPS server at https://{}", cli.socket);
             server.bind_openssl(cli.socket, builder)?.run()
         }
-        _ => {
+        (None, None) => {
+            if cli.require_pqc {
+                return Err(RestfulError::Anyhow(anyhow::anyhow!(
+                    "--require-pqc requires TLS: provide both --tls-cert and --tls-key"
+                )));
+            }
             info!("starting HTTP server at http://{}", cli.socket);
             server
                 .bind((cli.socket.ip().to_string(), cli.socket.port()))?
                 .run()
+        }
+        _ => {
+            return Err(RestfulError::Anyhow(anyhow::anyhow!(
+                "--tls-cert and --tls-key must be provided together"
+            )));
         }
     };
 

--- a/attestation-service/src/rvps/grpc.rs
+++ b/attestation-service/src/rvps/grpc.rs
@@ -1,8 +1,11 @@
+use anyhow::Context;
 use mobc::{Manager, Pool};
 use serde::Deserialize;
 use serde_json::Value;
-use tonic::transport::Channel;
+use std::path::PathBuf;
+use tonic::transport::{Channel, ClientTlsConfig};
 use tracing::{debug, info};
+use tls_config::grpc::GrpcTlsMode;
 
 use self::rvps_api::{
     reference_value_provider_service_client::ReferenceValueProviderServiceClient,
@@ -21,10 +24,27 @@ pub struct RvpsRemoteConfig {
     /// If this field is not given, a built-in RVPS will be used.
     #[serde(default = "default_address")]
     pub address: String,
+    /// TLS mode for the gRPC channel. Default: `insecure` (plaintext).
+    #[serde(default)]
+    pub tls_mode: GrpcTlsMode,
+    /// Path to a PEM CA certificate used to verify the RVPS server certificate.
+    /// Required when `tls_mode = "tls"`.
+    #[serde(default)]
+    pub ca_cert_path: Option<PathBuf>,
 }
 
 fn default_address() -> String {
     "127.0.0.1:50003".into()
+}
+
+impl Default for RvpsRemoteConfig {
+    fn default() -> Self {
+        Self {
+            address: default_address(),
+            tls_mode: GrpcTlsMode::Insecure,
+            ca_cert_path: None,
+        }
+    }
 }
 
 /// The default pool size for the RVPS client.
@@ -35,19 +55,52 @@ pub struct Agent {
 }
 
 impl Agent {
-    pub async fn new(addr: &str) -> Result<Self> {
+    pub async fn new(config: &RvpsRemoteConfig) -> Result<Self> {
         info!(
             "connect to remote RVPS [{}] with pool size {}",
-            addr, DEFAULT_RVPS_POOL_SIZE
+            config.address, DEFAULT_RVPS_POOL_SIZE
         );
 
-        let mut address = addr.to_string();
-        if !address.starts_with("http://") && !address.starts_with("https://") {
-            debug!("add http:// prefix to the rvps grpc address [{}]", address);
-            address = format!("http://{}", address);
+        // Tonic uses the URI scheme (not the TLS config object) to decide whether
+        // to activate TLS, so an explicit http:// with tls_mode="tls" would
+        // silently connect in plaintext. Reject contradictions up front.
+        if config.address.starts_with("https://") && config.tls_mode != GrpcTlsMode::Tls {
+            return Err(anyhow::anyhow!(
+                "RVPS gRPC: tls_mode=\"insecure\" requires an http:// address, got \"{}\"",
+                config.address
+            )
+            .into());
+        }
+        if config.address.starts_with("http://") && config.tls_mode == GrpcTlsMode::Tls {
+            return Err(anyhow::anyhow!(
+                "RVPS gRPC: tls_mode=\"tls\" requires an https:// address, got \"{}\"",
+                config.address
+            )
+            .into());
         }
 
-        let manager = GrpcManager { address };
+        // Auto-prepend the correct scheme if none was given.
+        let address = if !config.address.starts_with("http://")
+            && !config.address.starts_with("https://")
+        {
+            let scheme = if config.tls_mode == GrpcTlsMode::Tls { "https" } else { "http" };
+            debug!("add {scheme}:// prefix to the rvps grpc address [{}]", config.address);
+            format!("{scheme}://{}", config.address)
+        } else {
+            config.address.clone()
+        };
+
+        let tls_config = tls_config::grpc::build_grpc_client_tls_config(
+            &config.tls_mode,
+            config.ca_cert_path.as_deref(),
+        )
+        .await
+        .context("RVPS gRPC client TLS")?;
+
+        let manager = GrpcManager {
+            address,
+            tls_config,
+        };
         let pool = Pool::builder()
             .max_open(DEFAULT_RVPS_POOL_SIZE)
             .build(manager);
@@ -92,6 +145,7 @@ impl RvpsApi for Agent {
 
 pub struct GrpcManager {
     address: String,
+    tls_config: Option<ClientTlsConfig>,
 }
 
 #[async_trait::async_trait]
@@ -100,9 +154,11 @@ impl Manager for GrpcManager {
     type Error = anyhow::Error;
 
     async fn connect(&self) -> std::result::Result<Self::Connection, Self::Error> {
-        let channel = Channel::from_shared(self.address.clone())?
-            .connect()
-            .await?;
+        let mut endpoint = Channel::from_shared(self.address.clone())?;
+        if let Some(tls) = &self.tls_config {
+            endpoint = endpoint.tls_config(tls.clone())?;
+        }
+        let channel = endpoint.connect().await?;
         Ok(ReferenceValueProviderServiceClient::new(channel))
     }
 

--- a/attestation-service/src/rvps/grpc.rs
+++ b/attestation-service/src/rvps/grpc.rs
@@ -3,9 +3,9 @@ use mobc::{Manager, Pool};
 use serde::Deserialize;
 use serde_json::Value;
 use std::path::PathBuf;
+use tls_config::grpc::GrpcTlsMode;
 use tonic::transport::{Channel, ClientTlsConfig};
 use tracing::{debug, info};
-use tls_config::grpc::GrpcTlsMode;
 
 use self::rvps_api::{
     reference_value_provider_service_client::ReferenceValueProviderServiceClient,
@@ -80,15 +80,21 @@ impl Agent {
         }
 
         // Auto-prepend the correct scheme if none was given.
-        let address = if !config.address.starts_with("http://")
-            && !config.address.starts_with("https://")
-        {
-            let scheme = if config.tls_mode == GrpcTlsMode::Tls { "https" } else { "http" };
-            debug!("add {scheme}:// prefix to the rvps grpc address [{}]", config.address);
-            format!("{scheme}://{}", config.address)
-        } else {
-            config.address.clone()
-        };
+        let address =
+            if !config.address.starts_with("http://") && !config.address.starts_with("https://") {
+                let scheme = if config.tls_mode == GrpcTlsMode::Tls {
+                    "https"
+                } else {
+                    "http"
+                };
+                debug!(
+                    "add {scheme}:// prefix to the rvps grpc address [{}]",
+                    config.address
+                );
+                format!("{scheme}://{}", config.address)
+            } else {
+                config.address.clone()
+            };
 
         let tls_config = tls_config::grpc::build_grpc_client_tls_config(
             &config.tls_mode,

--- a/attestation-service/src/rvps/mod.rs
+++ b/attestation-service/src/rvps/mod.rs
@@ -106,7 +106,7 @@ pub async fn initialize_rvps_client(
         #[cfg(feature = "rvps-grpc")]
         RvpsConfig::GrpcRemote(config) => {
             info!("connect to remote RVPS: {}", config.address);
-            Ok(Arc::new(Mutex::new(grpc::Agent::new(&config.address).await?)) as RvpsClient)
+            Ok(Arc::new(Mutex::new(grpc::Agent::new(config).await?)) as RvpsClient)
         }
     }
 }

--- a/deps/tls-config/Cargo.toml
+++ b/deps/tls-config/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "tls-config"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+# Shared helpers for gRPC TLS (client and server).
+grpc = ["dep:tonic", "dep:tokio", "dep:serde", "dep:anyhow"]
+
+[dependencies]
+openssl.workspace = true
+tracing.workspace = true
+thiserror.workspace = true
+# Optional — activated by the `grpc` feature.
+tonic  = { workspace = true, optional = true }
+tokio  = { workspace = true, optional = true }
+serde  = { workspace = true, optional = true }
+anyhow = { workspace = true, optional = true }
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/deps/tls-config/src/lib.rs
+++ b/deps/tls-config/src/lib.rs
@@ -1,0 +1,393 @@
+// Copyright (c) 2025 by Red Hat.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared TLS configuration helpers for KBS and its companion services.
+//!
+//! The top-level items configure OpenSSL-based listeners with PQC hybrid key
+//! exchange groups.  The optional [`grpc`] module (enabled by the `grpc`
+//! feature) provides helpers for tonic gRPC client and server TLS.
+
+use std::sync::OnceLock;
+
+use openssl::ssl::{SslAcceptor, SslAcceptorBuilder, SslMethod, SslVersion};
+use thiserror::Error;
+use tracing::{debug, info, warn};
+
+// X448MLKEM1024 is intentionally omitted: it is not officially standardized and
+// remains experimental — not yet accepted by IETF or NIST as a hybrid group.
+const PQC_CANDIDATES: &[&str] = &[
+    "X25519MLKEM768",
+    "SecP256r1MLKEM768",
+    "SecP384r1MLKEM1024",
+];
+
+const CLASSICAL_GROUPS: &str = "X25519:secp256r1:secp384r1";
+
+static SUPPORTED_PQC_GROUPS: OnceLock<Vec<&'static str>> = OnceLock::new();
+
+#[derive(Error, Debug)]
+pub enum PqcTlsError {
+    #[error(
+        "PQC TLS is required but no PQC groups are supported by OpenSSL (tried: {candidates:?})"
+    )]
+    PqcRequired { candidates: &'static [&'static str] },
+
+    #[error("Failed to set TLS groups list '{groups}': {source}")]
+    SetGroupsFailed {
+        groups: String,
+        source: openssl::error::ErrorStack,
+    },
+
+    #[error("Failed to set minimum TLS protocol version: {0}")]
+    SetMinVersionFailed(openssl::error::ErrorStack),
+}
+
+#[derive(Debug, Clone)]
+pub struct PqcGroupsResult {
+    pub pqc_groups: Vec<&'static str>,
+    pub groups_list: String,
+}
+
+impl PqcGroupsResult {
+    pub fn has_pqc(&self) -> bool {
+        !self.pqc_groups.is_empty()
+    }
+}
+
+pub(crate) fn detect_supported_pqc_groups() -> &'static [&'static str] {
+    SUPPORTED_PQC_GROUPS.get_or_init(|| {
+        let mut supported = Vec::new();
+        for &candidate in PQC_CANDIDATES {
+            // A fresh builder per candidate avoids state from a failed
+            // set_groups_list call leaking into the next probe.
+            let mut builder = match SslAcceptor::mozilla_intermediate_v5(SslMethod::tls()) {
+                Ok(b) => b,
+                Err(e) => {
+                    warn!("Failed to create SSL acceptor for PQC detection: {e}");
+                    return Vec::new();
+                }
+            };
+            if builder.set_groups_list(candidate).is_ok() {
+                debug!("PQC group supported: {candidate}");
+                supported.push(candidate);
+            }
+        }
+        if supported.is_empty() {
+            info!("No PQC groups supported by OpenSSL (probed: {PQC_CANDIDATES:?})");
+        }
+        supported
+    })
+}
+
+pub fn configure_pqc_groups(
+    builder: &mut SslAcceptorBuilder,
+    require_pqc: bool,
+) -> Result<PqcGroupsResult, PqcTlsError> {
+    let pqc_groups = detect_supported_pqc_groups();
+
+    if pqc_groups.is_empty() && require_pqc {
+        return Err(PqcTlsError::PqcRequired {
+            candidates: PQC_CANDIDATES,
+        });
+    }
+
+    let groups_list = if pqc_groups.is_empty() {
+        warn!("PQC TLS not available, using classical groups: {CLASSICAL_GROUPS}");
+        CLASSICAL_GROUPS.to_string()
+    } else if require_pqc {
+        let pqc_only = pqc_groups.join(":");
+        info!("PQC TLS enforced (PQC-only, no classical fallback): {pqc_only}");
+        pqc_only
+    } else {
+        let pqc_part = pqc_groups.join(":");
+        let full = format!("{pqc_part}:{CLASSICAL_GROUPS}");
+        info!("PQC TLS enabled with classical fallback: {full}");
+        full
+    };
+
+    builder
+        .set_groups_list(&groups_list)
+        .map_err(|e| PqcTlsError::SetGroupsFailed {
+            groups: groups_list.clone(),
+            source: e,
+        })?;
+
+    if require_pqc {
+        builder
+            .set_min_proto_version(Some(SslVersion::TLS1_3))
+            .map_err(PqcTlsError::SetMinVersionFailed)?;
+    }
+
+    Ok(PqcGroupsResult {
+        pqc_groups: pqc_groups.to_vec(),
+        groups_list,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openssl::ssl::{SslAcceptor, SslMethod};
+
+    fn fresh_builder() -> SslAcceptorBuilder {
+        SslAcceptor::mozilla_intermediate_v5(SslMethod::tls()).unwrap()
+    }
+
+    #[test]
+    fn pqc_groups_require_false_never_errors() {
+        // require_pqc=false must succeed regardless of PQC availability.
+        let mut builder = fresh_builder();
+        assert!(configure_pqc_groups(&mut builder, false).is_ok());
+    }
+
+    #[test]
+    fn groups_list_always_includes_classical_fallback() {
+        // Classical groups must always appear in the output when require_pqc=false,
+        // whether PQC is available or not.
+        let mut builder = fresh_builder();
+        let result = configure_pqc_groups(&mut builder, false).unwrap();
+        assert!(
+            result.groups_list.contains(CLASSICAL_GROUPS),
+            "groups_list {:?} does not contain classical groups {:?}",
+            result.groups_list,
+            CLASSICAL_GROUPS
+        );
+    }
+
+    #[test]
+    fn require_pqc_true_behaves_correctly_for_environment() {
+        // Inspect what this OpenSSL build actually supports, then assert the
+        // correct branch — both paths are reachable depending on the environment.
+        let supported = detect_supported_pqc_groups();
+        let mut builder = fresh_builder();
+
+        if supported.is_empty() {
+            // No PQC support: must return PqcRequired error.
+            let err = configure_pqc_groups(&mut builder, true)
+                .expect_err("expected PqcRequired when PQC is unavailable");
+            assert!(
+                matches!(err, PqcTlsError::PqcRequired { .. }),
+                "unexpected error variant: {err}"
+            );
+        } else {
+            // PQC available: must succeed with PQC-only groups (no classical fallback).
+            let result = configure_pqc_groups(&mut builder, true)
+                .expect("expected Ok when PQC is available and require_pqc=true");
+            assert!(result.has_pqc(), "has_pqc() must be true when PQC groups are supported");
+            assert!(
+                !result.groups_list.contains("X25519:"),
+                "groups_list must not contain classical groups when require_pqc=true, got: {:?}",
+                result.groups_list
+            );
+            // At least one PQC candidate must appear in the groups list.
+            assert!(
+                PQC_CANDIDATES.iter().any(|g| result.groups_list.contains(g)),
+                "groups_list {:?} contains no PQC candidate",
+                result.groups_list
+            );
+        }
+    }
+
+    #[cfg(feature = "grpc")]
+    mod grpc_tests {
+        use super::super::grpc::{
+            build_grpc_client_tls_config, build_grpc_server_tls_config, GrpcTlsMode,
+        };
+        use std::io::Write as _;
+
+        // Generate a self-signed EC P-256 certificate and private key in PEM format.
+        fn test_cert_and_key_pem() -> (Vec<u8>, Vec<u8>) {
+            use openssl::asn1::Asn1Time;
+            use openssl::bn::{BigNum, MsbOption};
+            use openssl::ec::{EcGroup, EcKey};
+            use openssl::hash::MessageDigest;
+            use openssl::nid::Nid;
+            use openssl::pkey::PKey;
+            use openssl::x509::{X509Builder, X509NameBuilder};
+
+            let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+            let ec_key = EcKey::generate(&group).unwrap();
+            let pkey = PKey::from_ec_key(ec_key).unwrap();
+
+            let mut name = X509NameBuilder::new().unwrap();
+            name.append_entry_by_text("CN", "tls-config-test").unwrap();
+            let name = name.build();
+
+            let mut serial = BigNum::new().unwrap();
+            serial.rand(128, MsbOption::MAYBE_ZERO, false).unwrap();
+
+            let mut x509 = X509Builder::new().unwrap();
+            x509.set_version(2).unwrap();
+            x509.set_subject_name(&name).unwrap();
+            x509.set_issuer_name(&name).unwrap();
+            x509.set_pubkey(&pkey).unwrap();
+            x509.set_serial_number(&serial.to_asn1_integer().unwrap()).unwrap();
+            x509.set_not_before(&Asn1Time::days_from_now(0).unwrap()).unwrap();
+            x509.set_not_after(&Asn1Time::days_from_now(1).unwrap()).unwrap();
+            x509.sign(&pkey, MessageDigest::sha256()).unwrap();
+
+            (x509.build().to_pem().unwrap(), pkey.private_key_to_pem_pkcs8().unwrap())
+        }
+
+        #[test]
+        fn grpc_tls_mode_default_is_insecure() {
+            assert_eq!(GrpcTlsMode::default(), GrpcTlsMode::Insecure);
+        }
+
+        #[tokio::test]
+        async fn client_tls_insecure_returns_none() {
+            let result = build_grpc_client_tls_config(&GrpcTlsMode::Insecure, None).await;
+            assert!(matches!(result, Ok(None)));
+        }
+
+        #[tokio::test]
+        async fn client_tls_tls_no_ca_cert_errors() {
+            let result = build_grpc_client_tls_config(&GrpcTlsMode::Tls, None).await;
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn client_tls_tls_missing_file_errors() {
+            let result = build_grpc_client_tls_config(
+                &GrpcTlsMode::Tls,
+                Some(std::path::Path::new("/nonexistent/ca.crt")),
+            )
+            .await;
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn client_tls_tls_with_valid_cert_returns_some() {
+            let (cert_pem, _) = test_cert_and_key_pem();
+            let mut tmp = tempfile::NamedTempFile::new().unwrap();
+            tmp.write_all(&cert_pem).unwrap();
+            let result = build_grpc_client_tls_config(&GrpcTlsMode::Tls, Some(tmp.path())).await;
+            assert!(matches!(result, Ok(Some(_))));
+        }
+
+        #[tokio::test]
+        async fn server_tls_both_none_returns_none() {
+            let result = build_grpc_server_tls_config(None, None).await;
+            assert!(matches!(result, Ok(None)));
+        }
+
+        #[tokio::test]
+        async fn server_tls_cert_only_errors() {
+            let result = build_grpc_server_tls_config(
+                Some(std::path::Path::new("/any/cert.pem")),
+                None,
+            )
+            .await;
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn server_tls_key_only_errors() {
+            let result = build_grpc_server_tls_config(
+                None,
+                Some(std::path::Path::new("/any/key.pem")),
+            )
+            .await;
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn server_tls_with_valid_cert_and_key_returns_some() {
+            let (cert_pem, key_pem) = test_cert_and_key_pem();
+            let mut cert_tmp = tempfile::NamedTempFile::new().unwrap();
+            let mut key_tmp = tempfile::NamedTempFile::new().unwrap();
+            cert_tmp.write_all(&cert_pem).unwrap();
+            key_tmp.write_all(&key_pem).unwrap();
+            let result =
+                build_grpc_server_tls_config(Some(cert_tmp.path()), Some(key_tmp.path())).await;
+            assert!(matches!(result, Ok(Some(_))));
+        }
+    }
+}
+
+#[cfg(feature = "grpc")]
+pub mod grpc {
+    use std::path::Path;
+
+    use anyhow::{Context, Result};
+    use tonic::transport::{Certificate, ClientTlsConfig, Identity, ServerTlsConfig};
+
+    /// TLS mode for a gRPC channel.
+    ///
+    /// Defaults to [`Insecure`](GrpcTlsMode::Insecure) so existing deployments
+    /// that omit the field keep their current plaintext behaviour unchanged.
+    #[non_exhaustive]
+    #[derive(Clone, Debug, Default, serde::Deserialize, PartialEq, Eq, Hash)]
+    #[serde(rename_all = "lowercase")]
+    pub enum GrpcTlsMode {
+        /// Plaintext gRPC — default, backward-compatible.
+        #[default]
+        Insecure,
+        /// TLS — `ca_cert_path` must also be set.
+        Tls,
+    }
+
+    /// Build a tonic [`ClientTlsConfig`] from a PEM CA certificate file.
+    ///
+    /// Returns `None` when `mode` is `Insecure` (no TLS, no I/O performed).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `mode` is `Tls` and:
+    /// - `ca_cert_path` is `None`, or
+    /// - the certificate file cannot be read.
+    pub async fn build_grpc_client_tls_config(
+        mode: &GrpcTlsMode,
+        ca_cert_path: Option<&Path>,
+    ) -> Result<Option<ClientTlsConfig>> {
+        match mode {
+            GrpcTlsMode::Insecure => Ok(None),
+            GrpcTlsMode::Tls => {
+                let path = ca_cert_path.ok_or_else(|| {
+                    anyhow::anyhow!("ca_cert_path is required when tls_mode = \"tls\"")
+                })?;
+                let pem = tokio::fs::read(path)
+                    .await
+                    .with_context(|| format!("read gRPC CA cert {}", path.display()))?;
+                Ok(Some(
+                    ClientTlsConfig::new().ca_certificate(Certificate::from_pem(&pem)),
+                ))
+            }
+        }
+    }
+
+    /// Build a tonic [`ServerTlsConfig`] from PEM certificate and key files.
+    ///
+    /// Returns `None` when both paths are absent — server starts without TLS,
+    /// identical to the pre-TLS default behaviour.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when:
+    /// - exactly one of `cert_path` / `key_path` is provided (both required together), or
+    /// - either file cannot be read.
+    pub async fn build_grpc_server_tls_config(
+        cert_path: Option<&Path>,
+        key_path: Option<&Path>,
+    ) -> Result<Option<ServerTlsConfig>> {
+        match (cert_path, key_path) {
+            (None, None) => Ok(None),
+            (Some(cert), Some(key)) => {
+                let cert_pem = tokio::fs::read(cert)
+                    .await
+                    .with_context(|| format!("read gRPC TLS cert {}", cert.display()))?;
+                let key_pem = tokio::fs::read(key)
+                    .await
+                    .with_context(|| format!("read gRPC TLS key {}", key.display()))?;
+                let identity = Identity::from_pem(cert_pem, key_pem);
+                Ok(Some(ServerTlsConfig::new().identity(identity)))
+            }
+            _ => anyhow::bail!("cert_path and key_path must both be provided, or both omitted"),
+        }
+    }
+}

--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -183,6 +183,7 @@ impl TestHarness {
 
                 RvpsConfig::GrpcRemote(RvpsRemoteConfig {
                     address: RVPS_URL.to_string(),
+                    ..Default::default()
                 })
             }
         };
@@ -241,6 +242,7 @@ impl TestHarness {
                 insecure_http: true,
                 payload_request_size: 2,
                 worker_count: Some(4),
+                require_pqc: false,
             },
             admin: admin_config,
             storage_backend: StorageBackendConfig {

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -22,7 +22,7 @@ coco-as-builtin = ["coco-as", "attestation-service/default"]
 coco-as-builtin-no-verifier = ["coco-as"]
 
 # Use remote gRPC CoCo-AS as backend attestation service
-coco-as-grpc = ["coco-as", "mobc", "tonic", "tonic-prost", "prost"]
+coco-as-grpc = ["coco-as", "mobc", "tonic", "tonic-prost", "prost", "rustls", "tls-config/grpc"]
 
 # Use Intel TA as backend attestation service
 intel-trust-authority-as = ["as", "az-cvm-vtpm"]
@@ -62,6 +62,7 @@ hex.workspace = true
 jsonwebtoken = { workspace = true, default-features = false }
 kbs-types.workspace = true
 key-value-storage.path = "../deps/key-value-storage"
+tls-config.path = "../deps/tls-config"
 kms = { workspace = true, default-features = false }
 mobc = { workspace = true, optional = true }
 p256 = { workspace = true, features = ["ecdh"] }
@@ -74,7 +75,8 @@ regorus.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 rsa.workspace = true
 rustls = { version = "0.23", default-features = false, features = [
-    "ring",
+    "aws-lc-rs",
+    "prefer-post-quantum",
 ], optional = true }
 semver = "1.0.28"
 serde = { workspace = true, features = ["derive"] }

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -27,6 +27,23 @@ The following properties can be set under the `[http_server]` section.
 | `certificate`          | String       | Path to a certificate file to be used for HTTPS. | No       | None                     |
 | `payload_request_size` | Integer      | Request payload size in mega bytes.              | No       | 2                        |
 | `worker_count`         | Integer      | Number of HTTP actix worker threads              | No       | Num of logical CPU cores |
+| `require_pqc`          | Boolean      | Require post-quantum cryptography for TLS key exchange. See [PQC TLS](#pqc-tls-configuration) below. | No | `false` |
+
+#### PQC TLS Configuration
+
+The `require_pqc` option controls post-quantum cryptography (PQC) enforcement
+for TLS key exchange, providing protection against
+[Harvest Now, Decrypt Later (HNDL)](https://en.wikipedia.org/wiki/Harvest_now,_decrypt_later) attacks.
+This option only takes effect when TLS is enabled (`insecure_http = false` with
+`private_key` and `certificate` configured).
+
+At startup, KBS probes the linked OpenSSL library for supported PQC hybrid key
+exchange groups. The following candidates are tested (OpenSSL 3.5+):
+
+- `X25519MLKEM768` — X25519 + ML-KEM-768
+- `SecP256r1MLKEM768` — NIST P-256 + ML-KEM-768 (FIPS-compatible)
+- `SecP384r1MLKEM1024` — NIST P-384 + ML-KEM-1024 (FIPS-compatible)
+
 
 ### Attestation Token Configuration
 
@@ -139,9 +156,11 @@ For detailed information about extractors configuration, including available ext
 
 If `type` is set to `GrpcRemote`, the following extra properties can be set
 
-| Property  | Type   | Description                       | Required | Default           |
-|-----------|--------|-----------------------------------|----------|-------------------|
-| `address` | String | Remote address of the RVPS server | No       | `127.0.0.1:50003` |
+| Property       | Type   | Description                                                                 | Required | Default           |
+|----------------|--------|-----------------------------------------------------------------------------|----------|-------------------|
+| `address`      | String | Remote address of the RVPS server                                           | No       | `127.0.0.1:50003` |
+| `tls_mode`     | String | gRPC channel security: `"insecure"` (plaintext) or `"tls"`                 | No       | `"insecure"`      |
+| `ca_cert_path` | String | Path to PEM CA certificate used to verify the RVPS server. Required when `tls_mode = "tls"` | No | — |
 
 #### gRPC CoCo AS
 
@@ -152,9 +171,11 @@ The following properties can be set.
 
 | Property    | Type    | Description                                                                                                                   | Default                  |
 |-------------|---------|-------------------------------------------------------------------------------------------------------------------------------|--------------------------|
-| `timeout`   | Integer | The maximum time (in minutes) between RCAR handshake's `auth` and `attest` requests                                           | 5                        |
-| `as_addr`   | String  | The URL of the remote CoCoAS                                                                                                  | `http://127.0.0.1:50004` |
-| `pool_size` | Integer | The connections between KBS and CoCoAS are maintained in a conenction pool. This property determines the max size of the pool | `100`                    |
+| `timeout`      | Integer | The maximum time (in minutes) between RCAR handshake's `auth` and `attest` requests                                           | 5                        |
+| `as_addr`      | String  | The URL of the remote CoCoAS                                                                                                  | `http://127.0.0.1:50004` |
+| `pool_size`    | Integer | The connections between KBS and CoCoAS are maintained in a connection pool. This property determines the max size of the pool | `100`                    |
+| `tls_mode`     | String  | gRPC channel security: `"insecure"` (plaintext) or `"tls"`                                                                   | `"insecure"`             |
+| `ca_cert_path` | String  | Path to PEM CA certificate used to verify the AS server. Required when `tls_mode = "tls"`                                    | —                        |
 
 #### Intel&reg; TA
 

--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -187,6 +187,14 @@ impl ApiServer {
             http_server = http_server.workers(worker_count);
         }
 
+        if http_config.require_pqc && http_config.insecure_http {
+            return Err(Error::HTTPSFailed {
+                source: anyhow::anyhow!(
+                    "require_pqc = true is incompatible with insecure_http = true"
+                ),
+            });
+        }
+
         if !http_config.insecure_http {
             let tls_server = http_server
                 .bind_openssl(

--- a/kbs/src/attestation/coco/grpc.rs
+++ b/kbs/src/attestation/coco/grpc.rs
@@ -13,8 +13,10 @@ use kbs_types::{Challenge, Tee};
 use mobc::{Manager, Pool};
 use serde::Deserialize;
 use std::collections::HashMap;
-use tonic::transport::Channel;
+use std::path::PathBuf;
+use tonic::transport::{Channel, ClientTlsConfig};
 use tracing::info;
+use tls_config::grpc::GrpcTlsMode;
 
 use crate::attestation::backend::{make_nonce, Attest, IndependentEvidence};
 
@@ -40,6 +42,13 @@ pub struct GrpcConfig {
     pub as_addr: String,
     #[serde(default = "default_pool_size")]
     pub pool_size: u64,
+    /// TLS mode for the gRPC channel. Default: `insecure` (plaintext).
+    #[serde(default)]
+    pub tls_mode: GrpcTlsMode,
+    /// Path to a PEM CA certificate used to verify the AS server certificate.
+    /// Required when `tls_mode = "tls"`.
+    #[serde(default)]
+    pub ca_cert_path: Option<PathBuf>,
 }
 
 fn default_as_addr() -> String {
@@ -55,6 +64,8 @@ impl Default for GrpcConfig {
         Self {
             as_addr: DEFAULT_AS_ADDR.to_string(),
             pool_size: DEFAULT_POOL_SIZE,
+            tls_mode: GrpcTlsMode::Insecure,
+            ca_cert_path: None,
         }
     }
 }
@@ -69,8 +80,36 @@ impl GrpcClientPool {
             "connect to remote AS [{}] with pool size {}",
             config.as_addr, config.pool_size
         );
+
+        if !config.as_addr.starts_with("http://") && !config.as_addr.starts_with("https://") {
+            bail!(
+                "AS gRPC: as_addr must start with http:// or https://, got \"{}\"",
+                config.as_addr
+            );
+        }
+        if config.as_addr.starts_with("http://") && config.tls_mode == GrpcTlsMode::Tls {
+            bail!(
+                "AS gRPC: tls_mode=\"tls\" requires https:// in as_addr, got \"{}\"",
+                config.as_addr
+            );
+        }
+        if config.as_addr.starts_with("https://") && config.tls_mode != GrpcTlsMode::Tls {
+            bail!(
+                "AS gRPC: tls_mode=\"insecure\" requires http:// in as_addr, got \"{}\"",
+                config.as_addr
+            );
+        }
+
+        let tls_config = tls_config::grpc::build_grpc_client_tls_config(
+            &config.tls_mode,
+            config.ca_cert_path.as_deref(),
+        )
+        .await
+        .context("AS gRPC client TLS")?;
+
         let manager = GrpcManager {
             as_addr: config.as_addr,
+            tls_config,
         };
         let pool = Pool::builder().max_open(config.pool_size).build(manager);
 
@@ -220,6 +259,7 @@ impl Attest for GrpcClientPool {
 
 pub struct GrpcManager {
     as_addr: String,
+    tls_config: Option<ClientTlsConfig>,
 }
 
 pub struct AsConnection {
@@ -233,9 +273,11 @@ impl Manager for GrpcManager {
     type Error = Error;
 
     async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        let connection = Channel::from_shared(self.as_addr.clone())?
-            .connect()
-            .await?;
+        let mut endpoint = Channel::from_shared(self.as_addr.clone())?;
+        if let Some(tls) = &self.tls_config {
+            endpoint = endpoint.tls_config(tls.clone())?;
+        }
+        let connection = endpoint.connect().await?;
         let as_rpc = AttestationServiceClient::new(connection.clone());
         let rvps_rpc = ReferenceValueProviderServiceClient::new(connection);
         Ok(AsConnection { as_rpc, rvps_rpc })

--- a/kbs/src/attestation/coco/grpc.rs
+++ b/kbs/src/attestation/coco/grpc.rs
@@ -14,9 +14,9 @@ use mobc::{Manager, Pool};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use tls_config::grpc::GrpcTlsMode;
 use tonic::transport::{Channel, ClientTlsConfig};
 use tracing::info;
-use tls_config::grpc::GrpcTlsMode;
 
 use crate::attestation::backend::{make_nonce, Attest, IndependentEvidence};
 

--- a/kbs/src/bin/kbs.rs
+++ b/kbs/src/bin/kbs.rs
@@ -20,12 +20,12 @@ shadow!(build);
 
 #[actix_web::main]
 async fn main() -> Result<()> {
-    // tonic (pulled in by the external-plugin feature) brings aws-lc-rs into
-    // the dependency tree alongside ring. When rustls finds multiple crypto
-    // backends compiled in it requires an explicit default; install ring.
-    // install_default() returns Err if already set — .ok() makes this idempotent.
-    #[cfg(feature = "external-plugin")]
-    rustls::crypto::ring::default_provider()
+    // Install aws-lc-rs as the rustls crypto provider so PQC hybrid groups
+    // (X25519MLKEM768 etc.) are available for any TLS connection in this
+    // process.  install_default() is idempotent via .ok().
+    // Only needed when rustls is in the dependency tree.
+    #[cfg(any(feature = "coco-as-grpc", feature = "external-plugin"))]
+    rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .ok();
 

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -39,6 +39,12 @@ pub struct HttpServerConfig {
     /// Number of worker threads for the actix-web server.
     /// If not specified, defaults to the number of logical CPU cores.
     pub worker_count: Option<usize>,
+
+    /// Require post-quantum cryptography for TLS.
+    /// When true, the server refuses to start if no PQC hybrid groups
+    /// are supported by the OpenSSL build, and only PQC hybrid groups
+    /// are offered — clients without PQC support cannot connect.
+    pub require_pqc: bool,
 }
 
 impl Default for HttpServerConfig {
@@ -50,6 +56,7 @@ impl Default for HttpServerConfig {
             insecure_http: DEFAULT_INSECURE_HTTP,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            require_pqc: false,
         }
     }
 }
@@ -165,6 +172,7 @@ mod tests {
                     crate::attestation::coco::grpc::GrpcConfig {
                         as_addr: "http://127.0.0.1:50001".into(),
                         pool_size: 100,
+                        ..Default::default()
                     },
                 ),
             timeout: 600,
@@ -176,6 +184,7 @@ mod tests {
             insecure_http: false,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            require_pqc: false,
         },
         admin: AdminConfig {
             admin_backend: AdminBackendType::DenyAll,
@@ -212,6 +221,7 @@ mod tests {
                         storage_type: None,
                         rvps_config: RvpsConfig::GrpcRemote(RvpsRemoteConfig {
                             address: "http://127.0.0.1:50003".into(),
+                            ..Default::default()
                         }),
                         attestation_token_broker: EarTokenConfiguration {
                             duration_min: DEFAULT_TOKEN_DURATION,
@@ -231,6 +241,7 @@ mod tests {
             insecure_http: DEFAULT_INSECURE_HTTP,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            require_pqc: false,
         },
         admin: AdminConfig {
             admin_backend: AdminBackendType::DenyAll,
@@ -277,6 +288,7 @@ mod tests {
             insecure_http: false,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            require_pqc: false,
         },
         admin: AdminConfig {
             admin_backend: AdminBackendType::DenyAll,
@@ -309,6 +321,7 @@ mod tests {
                     crate::attestation::coco::grpc::GrpcConfig {
                         as_addr: "http://as:50004".into(),
                         pool_size: crate::attestation::coco::grpc::DEFAULT_POOL_SIZE,
+                        ..Default::default()
                     },
                 ),
             timeout: crate::attestation::config::DEFAULT_TIMEOUT,
@@ -320,6 +333,7 @@ mod tests {
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            require_pqc: false,
         },
         admin: AdminConfig {
             admin_backend: AdminBackendType::Simple(SimpleAdminConfig {
@@ -373,6 +387,7 @@ mod tests {
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            require_pqc: false,
         },
         admin: AdminConfig {
             admin_backend: AdminBackendType::InsecureAllowAll,
@@ -417,6 +432,7 @@ mod tests {
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            require_pqc: false,
         },
         admin: AdminConfig {
             admin_backend: AdminBackendType::DenyAll,
@@ -437,6 +453,7 @@ mod tests {
                     crate::attestation::coco::grpc::GrpcConfig {
                         as_addr: "http://127.0.0.1:50004".into(),
                         pool_size: 100,
+                        ..Default::default()
                     },
                 ),
             timeout: crate::attestation::config::DEFAULT_TIMEOUT,

--- a/kbs/src/http.rs
+++ b/kbs/src/http.rs
@@ -2,64 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::OnceLock;
-
 use anyhow::{anyhow, Result};
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::config::HttpServerConfig;
-
-/// PQC algorithm candidates in priority order
-/// Based on OpenSSL 3.5+ supported hybrid groups
-const PQC_CANDIDATES: &[&str] = &[
-    "X25519MLKEM768",     // X25519 + ML-KEM-768 (preferred)
-    "SecP256r1MLKEM768",  // NIST P-256 + ML-KEM-768 (FIPS)
-    "X448MLKEM1024",      // X448 + ML-KEM-1024 (high security)
-    "SecP384r1MLKEM1024", // NIST P-384 + ML-KEM-1024 (FIPS + high security)
-];
-
-/// Classical algorithm groups for fallback
-const CLASSICAL_GROUPS: &str = "X25519:secp256r1:secp384r1";
-
-/// Global cache for the best supported PQC group
-static BEST_PQC_GROUP: OnceLock<Option<&'static str>> = OnceLock::new();
-
-/// Detect the best PQC group supported by OpenSSL
-///
-/// Tries each candidate in priority order and returns the first one supported.
-/// The result is cached globally for performance.
-///
-/// Returns:
-/// - Some(algorithm) if PQC is supported
-/// - None if no PQC algorithms are available
-fn detect_best_pqc_group() -> Option<&'static str> {
-    *BEST_PQC_GROUP.get_or_init(|| {
-        use openssl::ssl::{SslAcceptor, SslMethod};
-
-        // Create a temporary acceptor for testing
-        let mut builder = match SslAcceptor::mozilla_intermediate_v5(SslMethod::tls()) {
-            Ok(b) => b,
-            Err(e) => {
-                warn!("Failed to create SSL acceptor for PQC detection: {}", e);
-                return None;
-            }
-        };
-
-        // Try each PQC candidate in priority order
-        for &candidate in PQC_CANDIDATES {
-            if builder.set_groups_list(candidate).is_ok() {
-                info!("PQC algorithm detected: {}", candidate);
-                return Some(candidate);
-            }
-        }
-
-        info!(
-            "No PQC algorithms supported by OpenSSL (tried: {:?})",
-            PQC_CANDIDATES
-        );
-        None
-    })
-}
 
 pub fn tls_config(config: &HttpServerConfig) -> Result<openssl::ssl::SslAcceptorBuilder> {
     use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
@@ -74,28 +20,17 @@ pub fn tls_config(config: &HttpServerConfig) -> Result<openssl::ssl::SslAcceptor
         .as_ref()
         .ok_or_else(|| anyhow!("Missing private key"))?;
 
-    // Use mozilla_intermediate_v5 which supports both TLS 1.2 and TLS 1.3
-    // Note: mozilla_intermediate (v4) explicitly disables TLS 1.3 via NO_TLSV1_3 flag
-    // Version 5 is required for TLS 1.3 and PQC support
     let mut builder = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls())?;
     builder.set_private_key_file(key_file, SslFiletype::PEM)?;
     builder.set_certificate_chain_file(cert_file)?;
 
-    // Auto-detect and configure TLS groups based on OpenSSL capabilities
-    let groups = if let Some(pqc_group) = detect_best_pqc_group() {
-        info!("PQC TLS enabled with {}", pqc_group);
-        format!("{}:{}", pqc_group, CLASSICAL_GROUPS)
+    let result = tls_config::configure_pqc_groups(&mut builder, config.require_pqc)?;
+    info!("KBS TLS groups: {}", result.groups_list);
+    if config.require_pqc {
+        info!("Supported TLS versions: 1.3");
     } else {
-        info!(
-            "PQC TLS not available, using classical algorithms: {}",
-            CLASSICAL_GROUPS
-        );
-        CLASSICAL_GROUPS.to_string()
-    };
-
-    builder.set_groups_list(&groups)?;
-    info!("KBS TLS groups: {}", groups);
-    info!("Supported TLS versions: 1.2, 1.3");
+        info!("Supported TLS versions: 1.2, 1.3");
+    }
 
     Ok(builder)
 }

--- a/rvps/Cargo.toml
+++ b/rvps/Cargo.toml
@@ -45,6 +45,11 @@ tempfile.workspace = true
 tokio.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
+rustls = { version = "0.23", default-features = false, features = [
+    "aws-lc-rs",
+    "prefer-post-quantum",
+] }
+tls-config = { path = "../deps/tls-config", features = ["grpc"] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, optional = true }
 uuid.workspace = true

--- a/rvps/README.md
+++ b/rvps/README.md
@@ -66,6 +66,13 @@ rvps
 
 By default RVPS listens on `localhost:50003` waiting for requests.
 
+To enable TLS on the gRPC listener, provide a certificate and private key (both PEM format):
+```shell
+rvps --address 0.0.0.0:50003 --tls-cert /etc/rvps/server.crt --tls-key /etc/rvps/server.key
+```
+
+Both `--tls-cert` and `--tls-key` must be provided together. If neither is given the server starts without TLS (default behavior).
+
 ### Container Image
 
 We can build an RVPS docker image

--- a/rvps/src/bin/rvps.rs
+++ b/rvps/src/bin/rvps.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use std::path::PathBuf;
 use shadow_rs::shadow;
+use std::path::PathBuf;
 use tracing::{info, warn};
 use tracing_subscriber::{fmt::Subscriber, EnvFilter};
 

--- a/rvps/src/bin/rvps.rs
+++ b/rvps/src/bin/rvps.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
+use std::path::PathBuf;
 use shadow_rs::shadow;
 use tracing::{info, warn};
 use tracing_subscriber::{fmt::Subscriber, EnvFilter};
@@ -28,6 +29,16 @@ pub struct Cli {
     /// `--address 127.0.0.1:55554`
     #[arg(short = 'a', long, default_value = DEFAULT_ADDRESS)]
     pub address: String,
+
+    /// Path to the TLS certificate file (PEM) for the gRPC listener.
+    /// When provided, --tls-key must also be given.
+    /// If omitted, the server starts without TLS (default behavior).
+    #[arg(long)]
+    pub tls_cert: Option<PathBuf>,
+
+    /// Path to the TLS private key file (PEM) for the gRPC listener.
+    #[arg(long)]
+    pub tls_key: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -58,7 +69,14 @@ async fn main() -> Result<()> {
 
     info!("Listen socket: {}", &cli.address);
 
+    // Install aws-lc-rs as the rustls crypto provider so PQC hybrid groups
+    // (X25519MLKEM768 etc.) are available for any TLS connection in this process.
+    // install_default() is idempotent via .ok().
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+
     let socket = cli.address.parse().context("parse socket addr failed")?;
 
-    server::start(socket, config).await
+    server::start(socket, config, cli.tls_cert, cli.tls_key).await
 }

--- a/rvps/src/server/mod.rs
+++ b/rvps/src/server/mod.rs
@@ -92,9 +92,7 @@ pub async fn start(
 
     let mut builder = Server::builder();
     if let Some(tls_config) = tls {
-        builder = builder
-            .tls_config(tls_config)
-            .context("RVPS TLS config")?;
+        builder = builder.tls_config(tls_config).context("RVPS TLS config")?;
         info!("RVPS: TLS enabled");
     } else {
         warn!("RVPS: TLS not configured — running in plaintext mode");

--- a/rvps/src/server/mod.rs
+++ b/rvps/src/server/mod.rs
@@ -1,10 +1,11 @@
 use anyhow::{Context, Result};
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::{Config, Rvps};
 
@@ -75,12 +76,31 @@ impl ReferenceValueProviderService for RvpsServer {
     }
 }
 
-pub async fn start(socket: SocketAddr, config: Config) -> Result<()> {
+pub async fn start(
+    socket: SocketAddr,
+    config: Config,
+    tls_cert: Option<PathBuf>,
+    tls_key: Option<PathBuf>,
+) -> Result<()> {
     let service = Rvps::new(config).await?;
     let inner = Arc::new(RwLock::new(service));
     let rvps_server = RvpsServer::new(inner.clone());
 
-    Server::builder()
+    let tls =
+        tls_config::grpc::build_grpc_server_tls_config(tls_cert.as_deref(), tls_key.as_deref())
+            .await?;
+
+    let mut builder = Server::builder();
+    if let Some(tls_config) = tls {
+        builder = builder
+            .tls_config(tls_config)
+            .context("RVPS TLS config")?;
+        info!("RVPS: TLS enabled");
+    } else {
+        warn!("RVPS: TLS not configured — running in plaintext mode");
+    }
+
+    builder
         .add_service(ReferenceValueProviderServiceServer::new(rvps_server))
         .serve(socket)
         .await


### PR DESCRIPTION
## Summary

This PR addresses two related gaps: KBS's HTTP TLS has no way to enforce
post-quantum cryptography, and none of the service-to-service gRPC channels
support TLS at all.

Related to #1347. See the overlap note at the end.

## What this adds

### Shared `deps/tls-config` crate

A small new crate centralising TLS logic shared by all three services:

- **PQC group detection** — probes OpenSSL at startup for supported hybrid
  groups (`X25519MLKEM768`, `SecP256r1MLKEM768`, `SecP384r1MLKEM1024`).
- **`configure_pqc_groups(builder, require_pqc)`** — applies PQC groups with
  classical fallback, or enforces PQC-only + TLS 1.3 minimum when
  `require_pqc = true`.
- **gRPC TLS helpers** — tonic `ClientTlsConfig` / `ServerTlsConfig`
  wrappers behind the `grpc` feature flag, eliminating duplicated
  certificate-loading boilerplate across services.
- 12 unit tests covering all public entry points.

`X448MLKEM1024` is omitted as it appears to still be experimental.

### KBS HTTP TLS

- New `require_pqc` config field (default `false`). When `true`, startup fails
  if PQC is unavailable, TLS 1.3 minimum is enforced, and classical groups are
  dropped.
- Switches the rustls provider from `ring` to `aws-lc-rs`.

### gRPC TLS

- **KBS → AS**: new `tls_mode` / `ca_cert_path` fields on `GrpcConfig`.
- **grpc-as**: `--tls-cert` / `--tls-key` for server-side TLS.
- **restful-as**: adds `--require-pqc`; renames `--https-pubkey-cert` /
  `--https-prikey` to `--tls-cert` / `--tls-key` (old names kept as aliases).
- **RVPS client and server**: same `tls_mode` / `ca_cert_path` pattern.

All gRPC clients validate the URI scheme against `tls_mode` to prevent silent
plaintext fallback.

## Backward compatibility

All new fields default to their pre-existing behaviour. Existing config files
and CLI invocations work without modification.

## Relation to #1347 and #1348

PR #1348 covers overlapping ground from the operator-profile angle —
complementary rather than conflicting. Happy to coordinate with @lmilleri and
maintainers on sequencing.