### PR TITLE
Promote SNP parsed claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- Added detailed AMD SEV-SNP parsed claims under `snp.evidence` and a `snp.generation` claim for the processor generation.
+
+### Changed
+
+- Preserved the existing flat AMD SEV-SNP parsed claim fields while adding detailed claims, keeping existing Attestation Service policies compatible.
+- Updated the default AMD SEV-SNP policy to use the detailed `snp.evidence` claim paths.

--- a/attestation-service/docs/tcb_claims.md
+++ b/attestation-service/docs/tcb_claims.md
@@ -225,27 +225,97 @@ along with the full set of detached claims.
 
 ## AMD SEV-SNP
 
-- `snp.measurement` Launch Digest covering initial guest memory
-- `snp.platform_smt_enabled`:  Whether Simultaneous Multithreading is enabled on the system
-- `snp.platform_tsme_enabled`: Whether Transparent SME is enabled on the system
-- `snp.policy_abi_major`: Minimum ABI major version allowed for guest
-- `snp.policy_abi_minor`: Minimum ABI minor version allowed for guest
-- `snp.policy_debug_allowed`: Whether SNP debug features are allowed for guest
-- `snp.policy_migrate_ma`: Whether migration agent can be connected to guest
-- `snp.policy_single_socket`: Whether guest can be activated only on one socket
-- `snp.policy_smt_allowed`: Whether guest can run on a system with SMT enabled
-- `snp.reported_tcb_bootloader`: Reported SVN of ASP bootloader
-- `snp.reported_tcb_microcode`: Reported microcode version
-- `snp.reported_tcb_snp`: Reported SVN of SNP Firmware
-- `snp.reported_tcb_tee`: Reported SVN of ASP OS
+Existing flat SNP claims are preserved for policy compatibility. New detailed claims are additive under `snp.evidence`. When a flat claim and a detailed claim describe the same value, both paths are listed on the same line below.
 
-The claims map only includes the reported TCB version.
-An SEV-SNP Attestation Report contains four sets of TCB version information.
-Often all four values are the same, but sometimes the reported TCB might lag
-behind the true firmware version. This is done to minimize churn of policies
-and certificates while the provider updates to provisional firmware.
-The actual firmware must always be newer than or equal to the reported TCB.
-Generally, policies should be evaluated against the reported TCB.
+- `snp.generation`: string. Processor generation derived from the attestation report. One of `milan` (3rd Gen EPYC), `genoa` (4th Gen EPYC), or `turin` (5th Gen EPYC).
+
+### Guest policy
+
+The guest policy is set by the guest owner at launch and cannot be changed for the lifetime of the guest.
+
+- `snp.policy_abi_major` / `snp.evidence.policy.abi_major`: u64. Minimum SNP firmware ABI major version required for this guest.
+- `snp.policy_abi_minor` / `snp.evidence.policy.abi_minor`: u64. Minimum SNP firmware ABI minor version required for this guest.
+- `snp.policy_smt_allowed` / `snp.evidence.policy.smt_allowed`: Boolean. Whether the guest may run on a host with SMT enabled.
+- `snp.policy_migrate_ma` / `snp.evidence.policy.migrate_ma_allowed`: Boolean. Whether the guest may be associated with a migration agent.
+- `snp.policy_debug_allowed` / `snp.evidence.policy.debug_allowed`: Boolean. Whether SNP debug features are allowed for the guest.
+- `snp.policy_single_socket` / `snp.evidence.policy.single_socket_required`: Boolean. Whether the guest may be activated on multiple sockets.
+- `snp.evidence.policy.cxl_allowed`: Boolean. Whether CXL may be populated with devices or memory.
+- `snp.evidence.policy.mem_aes_256_xts`: Boolean. Memory encryption mode requirement. `false`: AES-128-XEX or AES-256-XTS is allowed; `true`: AES-256-XTS is required.
+- `snp.evidence.policy.rapl_dis`: Boolean. Running Average Power Limit (RAPL) requirement.
+- `snp.evidence.policy.ciphertext_hiding`: Boolean. Ciphertext hiding requirement.
+- `snp.evidence.policy.page_swap_disabled`: Boolean. Guest access to page-move/swap commands. `false`: SNP page-move/swap commands are allowed; `true`: guest access to `SNP_PAGE_MOVE`, `SNP_SWAP_OUT`, and `SNP_SWAP_IN` is disabled.
+
+### Platform info
+
+- `snp.platform_smt_enabled` / `snp.evidence.plat_info.smt_enabled`: Boolean. Whether Simultaneous Multithreading is enabled on the host.
+- `snp.platform_tsme_enabled` / `snp.evidence.plat_info.tsme_enabled`: Boolean. Whether Transparent SME is enabled on the host.
+- `snp.evidence.plat_info.ecc_enabled`: Boolean. Whether the platform is currently using ECC memory.
+- `snp.evidence.plat_info.rapl_disabled`: Boolean. Whether the RAPL feature is disabled on the platform.
+- `snp.evidence.plat_info.ciphertext_hiding_enabled`: Boolean. Whether ciphertext hiding is enabled on the platform.
+- `snp.evidence.plat_info.alias_check_complete`: Boolean. Whether alias detection has completed since the last system reset with no aliasing addresses found.
+- `snp.evidence.plat_info.tio_enabled`: Boolean. Whether SEV-TIO is enabled on the platform.
+
+### Key info (`snp.evidence.key_info`)
+
+- `snp.evidence.key_info.author_key_en`: Boolean. Whether the author key digest is present in `author_key_digest`. `true`: digest is present; `false`: digest is zero.
+- `snp.evidence.key_info.mask_chip_key`: Boolean. Whether the report signature is masked. `false`: firmware signs with VCEK or VLEK; `true`: the signature field is zeroed instead of signing.
+- `snp.evidence.key_info.signing_key`: u32. Key used to sign this report. `0`: VCEK; `1`: VLEK; `7`: none (unsigned report).
+
+### TCB versions
+
+Four TCB sets are exposed. Each is an object with the subfields below. The same subfields and types exist on `current_tcb`, `reported_tcb`, `committed_tcb`, and `launch_tcb`.
+
+- `snp.evidence.current_tcb`: object. Current platform TCB at report generation time.
+- `snp.evidence.reported_tcb`: object. TCB version used to derive the VCEK/VLEK that signed this report. **Policies should generally evaluate against this set.**
+- `snp.reported_tcb_bootloader` / `snp.evidence.reported_tcb.bootloader`: u8. Reported PSP bootloader SVN.
+- `snp.reported_tcb_tee` / `snp.evidence.reported_tcb.tee`: u8. Reported PSP operating-system SVN.
+- `snp.reported_tcb_snp` / `snp.evidence.reported_tcb.snp`: u8. Reported SNP firmware SVN.
+- `snp.reported_tcb_microcode` / `snp.evidence.reported_tcb.microcode`: u8. Reported microcode patch level.
+- `snp.evidence.committed_tcb`: object. Committed TCB version.
+- `snp.evidence.launch_tcb`: object. Platform TCB at guest launch or import time.
+
+Each TCB object contains the following fields (SVN / patch level):
+
+- `fmc`: u8 | null. FMC firmware SVN. Present on Turin (`generation` = `turin`); `null` on Milan and Genoa.
+- `bootloader`: u8. PSP bootloader SVN.
+- `tee`: u8. PSP operating-system SVN.
+- `snp`: u8. SNP firmware SVN.
+- `microcode`: u8. Lowest current microcode patch level across all cores.
+
+Often all four TCB values are the same, but the reported TCB may lag behind the true firmware version to minimize churn of policies and certificates while the provider updates to provisional firmware. The actual firmware must always be newer than or equal to the reported TCB.
+
+Firmware version objects:
+
+- `snp.evidence.current`: object. Current SNP firmware version.
+- `snp.evidence.current.major`: u8. Major version component.
+- `snp.evidence.current.minor`: u8. Minor version component.
+- `snp.evidence.current.build`: u8. Build version component.
+- `snp.evidence.committed`: object. Committed SNP firmware version.
+- `snp.evidence.committed.major`: u8. Major version component.
+- `snp.evidence.committed.minor`: u8. Minor version component.
+- `snp.evidence.committed.build`: u8. Build version component.
+
+### Measurements and identifiers
+
+- `snp.evidence.version`: u32. Attestation report format version. Supported values are 3 through 5.
+- `snp.evidence.guest_svn`: u32. Guest security version number provided at launch.
+- `snp.evidence.family_id`: string (hex). Family ID provided at launch.
+- `snp.evidence.image_id`: string (hex). Image ID provided at launch.
+- `snp.evidence.vmpl`: u32. Requested VMPL for the attestation report. Guest attestation expects `0`.
+- `snp.evidence.sig_algo`: u32. Signature algorithm identifier. `1`: ECDSA P-384 with SHA-384.
+- `snp.measurement` / `snp.evidence.measurement`: string (hex). Launch digest covering initial guest memory (48 bytes).
+- `snp.evidence.report_data`: string (hex). Guest-provided report data from the attestation report (64 bytes). Also available at the policy root as `report_data`.
+- `snp.evidence.host_data`: string (hex). Hypervisor-provided host data from launch (32 bytes). Also available at the policy root as `init_data`.
+- `snp.evidence.id_key_digest`: string (hex). SHA-384 digest of the ID public key that signed the ID block.
+- `snp.evidence.author_key_digest`: string (hex). SHA-384 digest of the author public key that certified the ID key. Zero when `key_info.author_key_en` is `false`.
+- `snp.evidence.report_id`: string (hex). Report ID of this guest.
+- `snp.evidence.report_id_ma`: string (hex). Report ID of this guest's migration agent, if applicable.
+- `snp.evidence.chip_id`: string (hex). Unique chip identifier (64 bytes). Zero when `key_info.mask_chip_key` is `true`.
+- `snp.evidence.cpu_id_fam_id`: u8 | null. CPUID family ID (combined extended family and family). Present in report version 3+; `null` on older reports.
+- `snp.evidence.cpu_id_mod_id`: u8 | null. CPUID model ID (combined extended model and model). Present in report version 3+; `null` on older reports.
+- `snp.evidence.cpu_id_step`: u8 | null. CPUID stepping. Present in report version 3+; `null` on older reports.
+- `snp.evidence.launch_mit_vector`: u64 | null. Verified mitigation vector at guest launch. Present in report version 5+; `null` on older reports.
+- `snp.evidence.current_mit_vector`: u64 | null. Current verified mitigation vector. Present in report version 5+; `null` on older reports.
 
 ## TPM
 

--- a/attestation-service/src/ear_token/ear_default_policy_cpu.rego
+++ b/attestation-service/src/ear_token/ear_default_policy_cpu.rego
@@ -103,17 +103,17 @@ executables := 3 if {
 	input.snp
 
 	# In the future, we might calculate this measurement here various components
-	input.snp.measurement in query_reference_value("snp_launch_measurement")
+	input.snp.evidence.measurement in query_reference_value("snp_launch_measurement")
 }
 
 hardware := 2 if {
 	input.snp
 
 	# Check the reported TCB to validate the ASP FW
-	input.snp.reported_tcb_bootloader in query_reference_value("snp_bootloader")
-	input.snp.reported_tcb_microcode in query_reference_value("snp_microcode")
-	input.snp.reported_tcb_snp in query_reference_value("snp_snp_svn")
-	input.snp.reported_tcb_tee in query_reference_value("snp_tee_svn")
+	input.snp.evidence.reported_tcb.bootloader in query_reference_value("snp_bootloader")
+	input.snp.evidence.reported_tcb.microcode in query_reference_value("snp_microcode")
+	input.snp.evidence.reported_tcb.snp in query_reference_value("snp_snp_svn")
+	input.snp.evidence.reported_tcb.tee in query_reference_value("snp_tee_svn")
 }
 
 # For the 'configuration' trust claim 2 stands for
@@ -123,14 +123,14 @@ hardware := 2 if {
 configuration := 2 if {
 	input.snp
 
-	input.snp.policy_debug_allowed == false
-	input.snp.policy_migrate_ma == false
-	input.snp.platform_smt_enabled == query_reference_value("snp_smt_enabled")
-	input.snp.platform_tsme_enabled == query_reference_value("snp_tsme_enabled")
-	input.snp.policy_abi_major == query_reference_value("snp_guest_abi_major")
-	input.snp.policy_abi_minor == query_reference_value("snp_guest_abi_minor")
-	input.snp.policy_single_socket == query_reference_value("snp_single_socket")
-	input.snp.policy_smt_allowed == query_reference_value("snp_smt_allowed")
+	input.snp.evidence.policy.debug_allowed == false
+	input.snp.evidence.policy.migrate_ma_allowed == false
+	input.snp.evidence.plat_info.smt_enabled == query_reference_value("snp_smt_enabled")
+	input.snp.evidence.plat_info.tsme_enabled == query_reference_value("snp_tsme_enabled")
+	input.snp.evidence.policy.abi_major == query_reference_value("snp_guest_abi_major")
+	input.snp.evidence.policy.abi_minor == query_reference_value("snp_guest_abi_minor")
+	input.snp.evidence.policy.single_socket_required == query_reference_value("snp_single_socket")
+	input.snp.evidence.policy.smt_allowed == query_reference_value("snp_smt_allowed")
 }
 
 # For the `configuration` trust claim 3 stands for
@@ -143,8 +143,8 @@ configuration := 2 if {
 else := 3 if {
 	input.snp
 
-	input.snp.policy_debug_allowed == false
-	input.snp.policy_migrate_ma == false
+	input.snp.evidence.policy.debug_allowed == false
+	input.snp.evidence.policy.migrate_ma_allowed == false
 }
 
 ##### TDX

--- a/deps/verifier/src/snp/mod.rs
+++ b/deps/verifier/src/snp/mod.rs
@@ -145,10 +145,10 @@ impl Snp {
         for source in &self.verifier_config.vcek_sources {
             let result = match source {
                 VCEKSource::OfflineStore { path } => {
-                    self.fetch_vcek_from_offline_store(att_report, &proc_gen, path.clone())
+                    self.fetch_vcek_from_offline_store(att_report, proc_gen, path.clone())
                 }
                 VCEKSource::KDS { base_url } => {
-                    self.fetch_vcek_from_kds(att_report, &proc_gen, base_url.clone())
+                    self.fetch_vcek_from_kds(att_report, proc_gen, base_url.clone())
                         .await
                 }
             };
@@ -169,12 +169,12 @@ impl Snp {
     fn fetch_vcek_from_offline_store(
         &self,
         att_report: AttestationReport,
-        proc_gen: &ProcessorGeneration,
+        proc_gen: ProcessorGeneration,
         path: Option<String>,
     ) -> Result<Vec<u8>> {
         // default dir should contain the /vcek segment
         let path = path.unwrap_or(KDS_OFFLINE_STORE_PATH.to_string());
-        let hw_id = self.parse_hw_id_from_vcek(att_report, proc_gen.clone());
+        let hw_id = self.parse_hw_id_from_vcek(att_report, proc_gen);
         let vcek_path = format!("{}/vcek/{}/vcek.der", path, hw_id);
         let vcek_bytes = std::fs::read(&vcek_path)
             .with_context(|| format!("Failed to read VCEK from offline store at {}", vcek_path))?;
@@ -200,7 +200,7 @@ impl Snp {
     async fn fetch_vcek_from_kds(
         &self,
         att_report: AttestationReport,
-        proc_gen: &ProcessorGeneration,
+        proc_gen: ProcessorGeneration,
         kds_url: Option<String>,
     ) -> Result<Vec<u8>> {
         // Use attestation report to get data for URL
@@ -208,7 +208,7 @@ impl Snp {
             bail!("Hardware ID is 0s on attestation report. Confirm that MASK_CHIP_ID is set to 0 to request VCEK from KDS.");
         }
 
-        let hw_id = self.parse_hw_id_from_vcek(att_report, proc_gen.clone());
+        let hw_id = self.parse_hw_id_from_vcek(att_report, proc_gen);
 
         // Request VCEK from KDS
         let vcek_url: String = match proc_gen {
@@ -320,7 +320,8 @@ pub(crate) struct VendorCertificates {
     pub(crate) asvk: Certificate,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, EnumString, Display, EnumIter, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, EnumString, Display, EnumIter, Hash, Serialize, Copy)]
+#[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "PascalCase", ascii_case_insensitive)]
 pub(crate) enum ProcessorGeneration {
     /// 3rd Gen AMD EPYC Processor (Standard)
@@ -438,7 +439,7 @@ impl Verifier for Snp {
             _ => {
                 // Get VCEK from configured sources (tries each in order)
                 let vcek_buf = self
-                    .fetch_vcek(report, proc_gen.clone())
+                    .fetch_vcek(report, proc_gen)
                     .await
                     .context("Failed to fetch VCEK from any configured source")?;
                 let vcek = Certificate::from_bytes(&vcek_buf)
@@ -499,7 +500,7 @@ impl Verifier for Snp {
             }
         }
 
-        let claims_map = parse_tee_evidence(&report);
+        let claims_map = parse_tee_evidence(&report, proc_gen);
         let json = json!(claims_map);
         Ok(vec![(json, "cpu".to_string())])
     }
@@ -597,33 +598,125 @@ pub(crate) fn verify_report_tcb(
 /// Parses the attestation report and extracts the TEE evidence claims.
 /// Returns a JSON-formatted map of parsed claims.
 /// Note: Uses hex encoding for consistency with other verifiers (TDX, SGX, vTPM).
-pub(crate) fn parse_tee_evidence(report: &AttestationReport) -> TeeEvidenceParsedClaim {
-    let claims_map = json!({
-        // policy fields
+pub(crate) fn parse_tee_evidence(
+    report: &AttestationReport,
+    proc_gen: ProcessorGeneration,
+) -> TeeEvidenceParsedClaim {
+    let policy = json!({
+        "abi_major": report.policy.abi_major(),
+        "abi_minor": report.policy.abi_minor(),
+        "smt_allowed": report.policy.smt_allowed(),
+        "migrate_ma_allowed": report.policy.migrate_ma_allowed(),
+        "debug_allowed": report.policy.debug_allowed(),
+        "single_socket_required": report.policy.single_socket_required(),
+        "cxl_allowed": report.policy.cxl_allowed(),
+        "mem_aes_256_xts": report.policy.mem_aes_256_xts(),
+        "rapl_dis": report.policy.rapl_dis(),
+        "ciphertext_hiding": report.policy.ciphertext_hiding(),
+        "page_swap_disabled": report.policy.page_swap_disabled(),
+    });
+    let current_tcb = json!({
+        "fmc": report.current_tcb.fmc,
+        "bootloader": report.current_tcb.bootloader,
+        "tee": report.current_tcb.tee,
+        "snp": report.current_tcb.snp,
+        "microcode": report.current_tcb.microcode,
+    });
+    let plat_info = json!({
+        "smt_enabled": report.plat_info.smt_enabled(),
+        "tsme_enabled": report.plat_info.tsme_enabled(),
+        "ecc_enabled": report.plat_info.ecc_enabled(),
+        "rapl_disabled": report.plat_info.rapl_disabled(),
+        "ciphertext_hiding_enabled": report.plat_info.ciphertext_hiding_enabled(),
+        "alias_check_complete": report.plat_info.alias_check_complete(),
+        "tio_enabled": report.plat_info.tio_enabled(),
+    });
+    let key_info = json!({
+        "author_key_en": report.key_info.author_key_en(),
+        "mask_chip_key": report.key_info.mask_chip_key(),
+        "signing_key": report.key_info.signing_key(),
+    });
+    let reported_tcb = json!({
+        "fmc": report.reported_tcb.fmc,
+        "bootloader": report.reported_tcb.bootloader,
+        "tee": report.reported_tcb.tee,
+        "snp": report.reported_tcb.snp,
+        "microcode": report.reported_tcb.microcode,
+    });
+    let committed_tcb = json!({
+        "fmc": report.committed_tcb.fmc,
+        "bootloader": report.committed_tcb.bootloader,
+        "tee": report.committed_tcb.tee,
+        "snp": report.committed_tcb.snp,
+        "microcode": report.committed_tcb.microcode,
+    });
+    let current = json!({
+        "major": report.current.major,
+        "minor": report.current.minor,
+        "build": report.current.build,
+    });
+    let committed = json!({
+        "major": report.committed.major,
+        "minor": report.committed.minor,
+        "build": report.committed.build,
+    });
+    let launch_tcb = json!({
+        "fmc": report.launch_tcb.fmc,
+        "bootloader": report.launch_tcb.bootloader,
+        "tee": report.launch_tcb.tee,
+        "snp": report.launch_tcb.snp,
+        "microcode": report.launch_tcb.microcode,
+    });
+    let evidence = json!({
+        "version": report.version,
+        "guest_svn": report.guest_svn,
+        "policy": policy,
+        "family_id": hex::encode(report.family_id),
+        "image_id": hex::encode(report.image_id),
+        "vmpl": report.vmpl,
+        "sig_algo": report.sig_algo,
+        "current_tcb": current_tcb,
+        "plat_info": plat_info,
+        "key_info": key_info,
+        "measurement": hex::encode(report.measurement),
+        "report_data": hex::encode(report.report_data),
+        "host_data": hex::encode(report.host_data),
+        "id_key_digest": hex::encode(report.id_key_digest),
+        "author_key_digest": hex::encode(report.author_key_digest),
+        "report_id": hex::encode(report.report_id),
+        "report_id_ma": hex::encode(report.report_id_ma),
+        "reported_tcb": reported_tcb,
+        "cpu_id_fam_id": report.cpuid_fam_id,
+        "cpu_id_mod_id": report.cpuid_mod_id,
+        "cpu_id_step": report.cpuid_step,
+        "chip_id": hex::encode(report.chip_id),
+        "committed_tcb": committed_tcb,
+        "current": current,
+        "committed": committed,
+        "launch_tcb": launch_tcb,
+        "launch_mit_vector": report.launch_mit_vector,
+        "current_mit_vector": report.current_mit_vector,
+    });
+
+    json!({
+        "init_data": hex::encode(report.host_data),
+        "report_data": hex::encode(report.report_data),
+        "measurement": hex::encode(report.measurement),
         "policy_abi_major": report.policy.abi_major(),
         "policy_abi_minor": report.policy.abi_minor(),
         "policy_smt_allowed": report.policy.smt_allowed(),
         "policy_migrate_ma": report.policy.migrate_ma_allowed(),
         "policy_debug_allowed": report.policy.debug_allowed(),
         "policy_single_socket": report.policy.single_socket_required(),
-
-        // versioning info
         "reported_tcb_bootloader": report.reported_tcb.bootloader,
         "reported_tcb_tee": report.reported_tcb.tee,
         "reported_tcb_snp": report.reported_tcb.snp,
         "reported_tcb_microcode": report.reported_tcb.microcode,
-
-        // platform info
         "platform_tsme_enabled": report.plat_info.tsme_enabled(),
         "platform_smt_enabled": report.plat_info.smt_enabled(),
-
-        // measurements
-        "measurement": hex::encode(report.measurement),
-        "report_data": hex::encode(report.report_data),
-        "init_data": hex::encode(report.host_data),
-    });
-
-    claims_map as TeeEvidenceParsedClaim
+        "generation": proc_gen,
+        "evidence": evidence,
+    }) as TeeEvidenceParsedClaim
 }
 
 /// Extracts the common name (CN) from the subject name of a certificate.
@@ -991,12 +1084,22 @@ mod tests {
         let attestation_report = AttestationReport::from_bytes(VCEK_REPORT).unwrap();
 
         // Generate parsed claims
-        let claims = parse_tee_evidence(&attestation_report);
+        let claims = parse_tee_evidence(&attestation_report, ProcessorGeneration::Milan);
 
         // Extract the three key fields that should be hex-encoded
         let measurement = claims.get("measurement").and_then(|v| v.as_str()).unwrap();
-        let report_data = claims.get("report_data").and_then(|v| v.as_str()).unwrap();
-        let init_data = claims.get("init_data").and_then(|v| v.as_str()).unwrap();
+        let evidence_measurement = claims
+            .pointer("/evidence/measurement")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        let report_data = claims
+            .pointer("/report_data")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        let init_data = claims
+            .pointer("/init_data")
+            .and_then(|v| v.as_str())
+            .unwrap();
 
         // Verify they are valid hex strings by checking:
         // 1. All characters are valid hex digits (0-9, a-f)
@@ -1012,6 +1115,33 @@ mod tests {
             measurement.chars().all(|c| c.is_ascii_hexdigit()),
             "measurement should only contain hex digits"
         );
+        assert_eq!(
+            measurement, evidence_measurement,
+            "legacy and detailed measurement claims should match"
+        );
+        for (legacy_claim, detailed_claim) in [
+            ("policy_debug_allowed", "/evidence/policy/debug_allowed"),
+            ("policy_migrate_ma", "/evidence/policy/migrate_ma_allowed"),
+            (
+                "policy_single_socket",
+                "/evidence/policy/single_socket_required",
+            ),
+            ("platform_smt_enabled", "/evidence/plat_info/smt_enabled"),
+            ("platform_tsme_enabled", "/evidence/plat_info/tsme_enabled"),
+            (
+                "reported_tcb_bootloader",
+                "/evidence/reported_tcb/bootloader",
+            ),
+            ("reported_tcb_tee", "/evidence/reported_tcb/tee"),
+            ("reported_tcb_snp", "/evidence/reported_tcb/snp"),
+            ("reported_tcb_microcode", "/evidence/reported_tcb/microcode"),
+        ] {
+            assert_eq!(
+                claims.get(legacy_claim),
+                claims.pointer(detailed_claim),
+                "{legacy_claim} should match {detailed_claim}"
+            );
+        }
 
         // report_data is 64 bytes -> 128 hex chars
         assert_eq!(


### PR DESCRIPTION
~~This is a simple PR to add a hardware-type extension to EAR submod.~~

~~Also, draft a Trustee EAR profile that we can work on the following.~~

~~Close https://github.com/confidential-containers/trustee/issues/1364~~

This PR adds all fields of SNP report to the claims with nested structure, to provide a more flexible way to customize their policies. Also updates the documents and polcies.