### PR TITLE
KBS | Promote the configuration error printing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3654,6 +3654,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
+ "const_format",
  "cryptoki",
  "educe",
  "hex",

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -60,6 +60,7 @@ base64.workspace = true
 cfg-if.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 config.workspace = true
+const_format = "0.2.36"
 cryptoki = { version = "0.12.0", optional = true }
 educe.workspace = true
 hex.workspace = true

--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -258,7 +258,12 @@ pub(crate) async fn api(
             .map_err(From::from),
         #[cfg(feature = "as")]
         "attestation-policy" if request.method() == Method::POST => {
-            core.admin.check_admin_access(&request)?;
+            core.admin
+                .check_admin_access(&request)
+                .map_err(|e| Error::AdminAuthAccess {
+                    source: e,
+                    endpoint: "attestation-policy".to_string(),
+                })?;
             core.attestation_service.set_policy(&body).await?;
 
             Ok(HttpResponse::Ok().finish())
@@ -267,7 +272,12 @@ pub(crate) async fn api(
         // Reference value querying API is exposed as
         // GET /reference-value/<reference_value_id>
         "reference-value" if request.method() == Method::GET => {
-            core.admin.check_admin_access(&request)?;
+            core.admin
+                .check_admin_access(&request)
+                .map_err(|e| Error::AdminAuthAccess {
+                    source: e,
+                    endpoint: "reference-value".to_string(),
+                })?;
             let reference_value_id = resource_path.join("/");
             let reference_values = core
                 .attestation_service
@@ -283,7 +293,12 @@ pub(crate) async fn api(
         }
         #[cfg(feature = "as")]
         "reference-value" if request.method() == Method::POST => {
-            core.admin.check_admin_access(&request)?;
+            core.admin
+                .check_admin_access(&request)
+                .map_err(|e| Error::AdminAuthAccess {
+                    source: e,
+                    endpoint: "reference-value".to_string(),
+                })?;
             let message = std::str::from_utf8(&body).map_err(|_| Error::RvpsError {
                 message: "Failed to parse reference value message".to_string(),
             })?;
@@ -303,7 +318,12 @@ pub(crate) async fn api(
         // TODO: consider to rename the api name for it is not only for
         // resource retrievement but for all plugins.
         "resource-policy" if request.method() == Method::POST => {
-            core.admin.check_admin_access(&request)?;
+            core.admin
+                .check_admin_access(&request)
+                .map_err(|e| Error::AdminAuthAccess {
+                    source: e,
+                    endpoint: "resource-policy".to_string(),
+                })?;
             let request: serde_json::Value =
                 serde_json::from_slice(&body).map_err(|_| Error::ParsePolicyError {
                     source: anyhow::anyhow!("Illegal SetPolicy Request Json"),
@@ -340,7 +360,12 @@ pub(crate) async fn api(
         // TODO: consider to rename the api name for it is not only for
         // resource retrievement but for all plugins.
         "resource-policy" if request.method() == Method::GET => {
-            core.admin.check_admin_access(&request)?;
+            core.admin
+                .check_admin_access(&request)
+                .map_err(|e| Error::AdminAuthAccess {
+                    source: e,
+                    endpoint: "resource-policy".to_string(),
+                })?;
             let policy = core.policy_engine.list_policies().await?;
 
             Ok(HttpResponse::Ok()

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -8,6 +8,7 @@ use crate::token::AttestationTokenVerifierConfig;
 use anyhow::anyhow;
 use clap::Parser;
 use config::{Config, File};
+use const_format::concatcp;
 use key_value_storage::{KeyValueStorageType, StorageBackendConfig};
 use serde::Deserialize;
 use std::net::SocketAddr;
@@ -92,18 +93,68 @@ pub struct KbsConfig {
     pub plugins: Vec<PluginsConfig>,
 }
 
+/// The commit ref of the config documentation in the Trustee repository
+const DOC_COMMIT_REF: &str = "dc6ea0dd";
+
+const CONFIG_DOC: &str = concatcp!(
+    "https://github.com/confidential-containers/trustee/blob/",
+    DOC_COMMIT_REF,
+    "/kbs/docs/config.md"
+);
+
+fn config_section_hint(err: &str) -> Option<&'static str> {
+    if err.contains("admin") || err.contains("admin.") {
+        return Some(concatcp!(CONFIG_DOC, "#admin-api-configuration"));
+    }
+    if err.contains("attestation_service") {
+        return Some(concatcp!(CONFIG_DOC, "#attestation-configuration"));
+    }
+    if err.contains("attestation_token") {
+        return Some(concatcp!(CONFIG_DOC, "#attestation-token-configuration"));
+    }
+    if err.contains("http_server") {
+        return Some(concatcp!(CONFIG_DOC, "#http-server-configuration"));
+    }
+    if err.contains("storage_backend") {
+        return Some(concatcp!(CONFIG_DOC, "#storage-backend-configuration"));
+    }
+    if err.contains("plugins") {
+        return Some(concatcp!(CONFIG_DOC, "#plugins-configuration"));
+    }
+    None
+}
+
+fn format_config_load_error(config_path: &Path, err: impl std::fmt::Display) -> anyhow::Error {
+    let err_str = err.to_string();
+    let mut message = format!(
+        "failed to load configuration file {}: {err_str}",
+        config_path.display()
+    );
+    if let Some(doc) = config_section_hint(&err_str) {
+        message.push_str("\nSee ");
+        message.push_str(doc);
+        message.push('.');
+    }
+    anyhow!(message)
+}
+
 impl TryFrom<&Path> for KbsConfig {
     type Error = anyhow::Error;
 
     /// Load `Config` from a configuration file. Supported formats are all formats supported by the
     /// `config` crate. See `KbsConfig` for schema information.
     fn try_from(config_path: &Path) -> Result<Self, Self::Error> {
+        let config_name = config_path
+            .to_str()
+            .ok_or_else(|| anyhow!("configuration path is not valid UTF-8"))?;
+
         let c = Config::builder()
-            .add_source(File::with_name(config_path.to_str().unwrap()))
-            .build()?;
+            .add_source(File::with_name(config_name))
+            .build()
+            .map_err(|e| format_config_load_error(config_path, e))?;
 
         c.try_deserialize()
-            .map_err(|e| anyhow!("invalid config: {}", e))
+            .map_err(|e| format_config_load_error(config_path, e))
     }
 }
 
@@ -549,5 +600,35 @@ mod tests {
     fn read_config(#[case] config_path: &str, #[case] expected: KbsConfig) {
         let config = KbsConfig::try_from(Path::new(config_path)).unwrap();
         assert_eq!(config, expected, "case {config_path}");
+    }
+
+    #[test]
+    fn config_load_error_includes_path_and_section_hint() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("kbs.toml");
+        std::fs::write(
+            &path,
+            r#"
+[http_server]
+sockets = ["127.0.0.1:8080"]
+
+[admin]
+authorization_mode = "InsecureAllowAll"
+type = "Simple"
+"#,
+        )
+        .expect("write config");
+
+        let err = KbsConfig::try_from(path.as_path()).unwrap_err();
+        let message = format!("{err}");
+        assert!(message.contains("kbs.toml"), "expected path in: {message}");
+        assert!(
+            message.contains("key `admin`") || message.contains("admin"),
+            "expected admin key in: {message}"
+        );
+        assert!(
+            message.contains("#admin-api-configuration"),
+            "expected admin doc hint in: {message}"
+        );
     }
 }

--- a/kbs/src/error.rs
+++ b/kbs/src/error.rs
@@ -18,8 +18,15 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Error, AsRefStr, Debug)]
 pub enum Error {
-    #[error("Admin auth error: {0}")]
-    AdminAuth(#[from] crate::admin::Error),
+    #[error("failed to initialize [admin] configuration: {0}")]
+    AdminAuthInitialization(#[from] crate::admin::Error),
+
+    #[error("admin access denied for endpoint {endpoint}: {source}")]
+    AdminAuthAccess {
+        #[source]
+        source: crate::admin::Error,
+        endpoint: String,
+    },
 
     #[cfg(feature = "as")]
     #[error("Attestation error: {0}")]


### PR DESCRIPTION
This is based on #1239 

The core idea is from https://github.com/confidential-containers/trustee/pull/1239#discussion_r3264201873
'''
The goal is to inform the user that the current configuration will not take effect. Could I do this by mandating that the input configuration format must conform to certain fields, otherwise throwing an error and referencing a configuration file format documentation?

Because if we set a precedent here—meaning that every time the configuration file is modified, we need to record historical configuration items in the code—we'll need to do the same elsewhere in the future. This will result in a lot of redundant code. My suggestion is to avoid saying "which are no longer supported" and instead directly say "the current format is as follows, there are configuration errors, startup failed, and modifications are needed."
'''

