### PR TITLE
ci: fix link check for ascii-code.com

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,3 +2,4 @@ https://developer.hashicorp.com
 https://uefi.org/specs/UEFI/2.11/38_Confidential_Computing.html
 https://www.openpolicyagent.org
 https://confidentialcontainers.org/docs/attestation/installation/docker/
+https://www.ascii-code.com


### PR DESCRIPTION
Error like https://github.com/confidential-containers/trustee/actions/runs/26378352326/job/77642724758

The link is unstable to access so we skip.