### PR TITLE
verifieri/hygon-dcu: emit one claim per attestation report

### DIFF
--- a/attestation-service/docs/attestation_token.md
+++ b/attestation-service/docs/attestation_token.md
@@ -11,6 +11,7 @@ Each submod is given a generic key constructed from the CPU class and the device
 For instance, the CPU submod will be called `cpu0`.
 If a GPU has been attested as part of the guest, there will be a `gpu0` submod.
 If there is more than one GPU, there will be additional `gpuN` submods.
+Hygon DCU attestation uses `dcu0` and additional `dcuN` submods in the same way.
 
 `cpu0` is considered to be the primary attester and has some special
 information associated with it.

--- a/attestation-service/docs/tcb_claims.md
+++ b/attestation-service/docs/tcb_claims.md
@@ -12,7 +12,7 @@ Policy input is a JSON object composed from verifier output. In most cases, it f
 
 | Field | Type | Meaning |
 | --- | --- | --- |
-| `<tee-name>` | object | TEE-specific claims (for example: `tdx`, `sgx`, `snp`, `se`, `tpm`, `nvidia`, `az-tdx-vtpm`, `az-snp-vtpm`, `sample`, `csv`, `cca`) |
+| `<tee-name>` | object | TEE-specific claims (for example: `tdx`, `sgx`, `snp`, `se`, `tpm`, `nvidia`, `hygondcu`, `az-tdx-vtpm`, `az-snp-vtpm`, `sample`, `csv`, `cca`) |
 | `report_data` | string | Hex/base64-encoded report data extracted from evidence (format depends on verifier) |
 | `init_data` | string | Hex/base64-encoded init-data hash extracted from evidence (when supported) |
 | `init_data_claims` | object | Parsed init-data claims (present when init-data is provided and verified) |
@@ -256,16 +256,16 @@ Generally, policies should be evaluated against the reported TCB.
 
 ## Hygon DCU
 
-Claims are reported per attestation report entry using numeric keys under the top-level `hygondcu` object:
+Each attestation report produces one set of claims under `hygondcu`. Multiple DCUs are evaluated separately (EAR token submods `dcu0`, `dcu1`, ... in evidence list order):
 
-- `hygondcu.<index>.body.version`: Firmware version.
-- `hygondcu.<index>.body.chip_id`: DCU chip ID.
-- `hygondcu.<index>.body.user_data`: The challenge data for the attestation.
-- `hygondcu.<index>.body.measure`: measurement of the firmware.
-- `hygondcu.<index>.body.reserved`: Reserved field.
-- `hygondcu.<index>.body.sig_usage`: The usage of the signature.
-- `hygondcu.<index>.body.sig_algo`: The algorithm of the signature.
-- `hygondcu.<index>.report_data` (same value as `body.user_data`)
+- `hygondcu.body.version`: Firmware version.
+- `hygondcu.body.chip_id`: DCU chip ID.
+- `hygondcu.body.user_data`: The challenge data for the attestation.
+- `hygondcu.body.measure`: measurement of the firmware.
+- `hygondcu.body.reserved`: Reserved field.
+- `hygondcu.body.sig_usage`: The usage of the signature.
+- `hygondcu.body.sig_algo`: The algorithm of the signature.
+- `hygondcu.report_data` (same value as `body.user_data`)
 
 ## Hygon CSV
 

--- a/deps/verifier/src/hygon_dcu/mod.rs
+++ b/deps/verifier/src/hygon_dcu/mod.rs
@@ -7,7 +7,7 @@ use anyhow::{bail, Result};
 use async_trait::async_trait;
 use csv_rs::api::dcu::{verify_reports, AttestationReport};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Map};
+use serde_json::json;
 use tracing::{instrument, warn};
 
 use crate::{
@@ -53,30 +53,25 @@ impl Verifier for HygonDcuVerifier {
             warn!("DCU does not support init data hash mechanism. skip.");
         }
 
-        let claims = parse_tee_evidence(tee_evidence.attestation_reports)?;
-        Ok(vec![(claims, "dcu".to_string())])
+        let claims = tee_evidence
+            .attestation_reports
+            .into_iter()
+            .map(|report| {
+                let value = json!({
+                    "body": {
+                        "version": report.body.version,
+                        "chip_id": hex::encode(report.body.chip_id),
+                        "user_data": hex::encode(report.body.user_data),
+                        "measure": hex::encode(report.body.measure),
+                        "reserved": hex::encode(report.body.reserved),
+                        "sig_usage": format!("{:x}", report.body.sig_usage),
+                        "sig_algo": format!("{:x}", report.body.sig_algo),
+                    },
+                    "report_data": hex::encode(report.body.user_data),
+                });
+                (value, HYGON_DCU_TEE_CLASS.to_string())
+            })
+            .collect();
+        Ok(claims)
     }
-}
-
-// Dump the DCU information from the report.
-fn parse_tee_evidence(reports: Vec<AttestationReport>) -> Result<TeeEvidenceParsedClaim> {
-    let mut claims = Map::new();
-    for (index, report) in reports.into_iter().enumerate() {
-        let key = index.to_string();
-        let value = json!({
-            "body": {
-                "version": report.body.version,
-                "chip_id": hex::encode(report.body.chip_id),
-                "user_data": hex::encode(report.body.user_data),
-                "measure": hex::encode(report.body.measure),
-                "reserved": hex::encode(report.body.reserved),
-                "sig_usage": format!("{:x}", report.body.sig_usage),
-                "sig_algo": format!("{:x}", report.body.sig_algo),
-            },
-            "report_data": hex::encode(report.body.user_data),
-        });
-        claims.insert(key, value);
-    }
-
-    Ok(TeeEvidenceParsedClaim::Object(claims))
 }


### PR DESCRIPTION
Return a separate (claims, dcu) pair for each DCU report instead of bundling all reports under numeric keys in a single hygondcu object. This aligns with other multi-device verifiers and yields per-device policy evaluation and EAR submods (dcu0, dcu1, ...). Breaking change: policy and token consumers must use flat paths such as input.hygondcu.body.chip_id instead of input.hygondcu["0"].body.chip_id. Update tcb_claims and attestation_token docs accordingly.

Close #1372