### PR TITLE
kbs: fix insecure_key for AttestationTokenVerifierConfig

### DIFF
--- a/deps/verifier/src/se/README.md
+++ b/deps/verifier/src/se/README.md
@@ -106,7 +106,7 @@ sockets = ["0.0.0.0:8080"]
 insecure_http = true
 
 [attestation_token]
-insecure_key = true
+insecure_header_jwk = true
 
 [attestation_service]
 type = "coco_as_builtin"
@@ -193,7 +193,7 @@ sockets = ["0.0.0.0:8080"]
 insecure_http = true
 
 [attestation_token]
-insecure_key = true
+insecure_header_jwk = true
 
 [attestation_service]
 type = "coco_as_builtin"

--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -255,7 +255,7 @@ impl TestHarness {
         let kbs_config = KbsConfig {
             attestation_token: AttestationTokenVerifierConfig {
                 trusted_certs_paths: vec![],
-                insecure_key: true,
+                insecure_header_jwk: true,
                 trusted_jwk_sets: vec![],
                 extra_teekey_paths: vec![],
             },

--- a/kbs/config/kbs-config-grpc.toml
+++ b/kbs/config/kbs-config-grpc.toml
@@ -2,7 +2,7 @@
 insecure_http = true
 
 [attestation_token]
-insecure_key = true
+insecure_header_jwk = true
 
 [attestation_service]
 type = "coco_as_grpc"

--- a/kbs/config/kbs-config.toml
+++ b/kbs/config/kbs-config.toml
@@ -2,7 +2,7 @@
 insecure_http = true
 
 [attestation_token]
-insecure_key = true
+insecure_header_jwk = true
 
 [attestation_service]
 type = "coco_as_builtin"

--- a/kbs/config/kubernetes/base/kbs-config.toml
+++ b/kbs/config/kubernetes/base/kbs-config.toml
@@ -5,7 +5,7 @@ sockets = ["0.0.0.0:8080"]
 insecure_http = true
 
 [attestation_token]
-insecure_key = true
+insecure_header_jwk = true
 
 [attestation_service]
 type = "coco_as_builtin"

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -41,7 +41,7 @@ The following properties can be set under the `[attestation_token]` section.
 | `trusted_jwk_sets`    | String Array | Trusted JWKS/OpenID sources (`file://` or `https://`) used to verify attestation tokens                                         | Empty   |
 | `trusted_certs_paths` | String Array | Trusted Certificates file (PEM format) for Attestation Tokens trustworthy verification                                            | Empty   |
 | `extra_teekey_paths`  | String Array | User defined paths to the tee public key in the JWT body                                                                          | Empty   |
-| `insecure_key`        | Boolean      | Whether to skip provenance checks of header-embedded JWK keys. Signature is still verified.                                      | `false` |
+| `insecure_header_jwk`        | Boolean      | Skip `x5c`/`trusted_certs_paths` endorsement for a JWK in the JWT header; signature is still verified | `false` |
 
 Each JWT contains a TEE Public Key. Users can use the `extra_teekey_paths` field to additionally specify the path of
 this Key in the JWT.
@@ -49,16 +49,20 @@ Example of `extra_teekey_paths` is `/attester_runtime_data/tee-pubkey` which ref
 `attester_runtime_data.tee-pubkey` inside the JWT body claims. By default CoCo AS Token and Intel TA
 Token TEE Public Key paths are supported.
 
-For Attestation Services like CoCo-AS, the public key to verify the JWT will be given
-in the token's `jwk` field (with or without the public key cert chain `x5c`).
+For attestation services like CoCo-AS, the JWT header often carries a `jwk` (sometimes with an
+`x5c` certificate chain). KBS uses that key to verify the token signature. Whether the key's
+provenance is checked depends on `insecure_header_jwk`:
 
-- If `insecure_key` is set to `true`, KBS will ignore to verify the trustworthy of the `jwk`.
-- If `insecure_key` is set to `false`, KBS will look up its `trusted_certs_paths` and the `x5c`
-  field to verify the trustworthy of the `jwk`.
+- If `insecure_header_jwk` is `true`, the header `jwk` is used as-is; KBS does not validate its `x5c`
+  chain against `trusted_certs_paths`. The JWT signature is still verified. Intended for
+  testing only.
+- If `insecure_header_jwk` is `false`, the header `jwk` must include a non-empty `x5c` chain that
+  matches the key and chains to a certificate in `trusted_certs_paths`.
+  If `trusted_certs_paths` is empty, tokens with a header `jwk` cannot be verified.
 
-For Attestation Services like Intel TA, there will only be a `kid` field inside the JWT.
-The `kid` field is used to look up the trusted jwk configured by KBS via `trusted_jwk_sets` to
-verify the integrity and trustworthy of the JWT.
+For attestation services like Intel TA, the JWT header carries a `kid` instead of an embedded
+`jwk`. The `kid` is used to look up the signing key from `trusted_jwk_sets`.
+This lookup path is not affected by `insecure_header_jwk`.
 
 ### Attestation Configuration
 
@@ -574,7 +578,7 @@ authorization_mode = "InsecureAllowAll"
 
 [attestation_token]
 trusted_certs_paths = ["./work/ca-cert.pem"]
-insecure_key = false
+insecure_header_jwk = false
 
 [storage_backend]
 storage_type = "LocalFs"

--- a/kbs/docs/self-signed-https.md
+++ b/kbs/docs/self-signed-https.md
@@ -80,7 +80,7 @@ insecure_http = false
 authorization_mode = "InsecureAllowAll"
 
 [attestation_token]
-insecure_key = true
+insecure_header_jwk = true
 
 [policy_engine]
 policy_path = "/opa/confidential-containers/kbs/policy.rego"

--- a/kbs/quickstart.md
+++ b/kbs/quickstart.md
@@ -252,23 +252,22 @@ Adding the following content to the config file of Resource KBS to specify trust
 or JWK set which are used to verify the trustworthy of the Attestation Token:
 
 ```toml
-[attestation_token_broker]
-# Path of root certificate used to verify the trustworthy of `x5c` extension in the JWT
+[attestation_token]
+# Trust anchors (PEM) used to validate the `x5c` chain on a header-embedded `jwk`
+# when `insecure_header_jwk` is false.
 trusted_certs_paths = ["/path/to/trusted_cacert.pem"]
 
-# URL (`path://` or `https://`) of the trusted JWK that can be indexed by `kid` in
-# JWT Header.
+# Trusted JWK set (`file://` or `https://`) used when the JWT header carries `kid`
+# instead of an embedded `jwk`.
 trusted_jwk_sets = ["/url/to/trusted_jwk_set"]
 
-# For Attestation Services like CoCo-AS, the public key to verify the JWT will be given
-# in the token's `jwk` field (with or without the public key cert chain `x5c`).
-#
-# - If this flag is set to `true`, KBS will ignore to verify the trustworthy of the `jwk`.
-# - If this flag is set to `false`, KBS will look up its `trusted_certs_paths` and the `x5c`
-# field to verify the trustworthy of the `jwk`.
-insecure_key = false
+# When false, header `jwk` keys must be endorsed via `x5c` and `trusted_certs_paths`.
+# When true, the header `jwk` is trusted without endorsement checks (testing only).
+insecure_header_jwk = false
 ```
 
-If `trusted_certs_paths` field is not set, KBS will skip the verification of the certificate in Attestation Token.
+When `insecure_header_jwk` is `false` and the token header contains a `jwk`, you must configure
+`trusted_certs_paths`; otherwise verification fails. Tokens that use `kid` rely on
+`trusted_jwk_sets` instead and are not affected by `insecure_header_jwk`.
 
 Refer to [config.md](./docs/config.md) for more details.

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -251,7 +251,7 @@ mod tests {
     #[case("test_data/configs/coco-as-grpc-1.toml",         KbsConfig {
         attestation_token: AttestationTokenVerifierConfig {
             trusted_certs_paths: vec!["/etc/ca".into(), "/etc/ca2".into()],
-            insecure_key: false,
+            insecure_header_jwk: false,
             trusted_jwk_sets: vec![],
             extra_teekey_paths: vec![],
         },
@@ -294,7 +294,7 @@ mod tests {
     #[case("test_data/configs/coco-as-builtin-1.toml",         KbsConfig {
         attestation_token: AttestationTokenVerifierConfig {
             trusted_certs_paths: vec![],
-            insecure_key: false,
+            insecure_header_jwk: false,
             trusted_jwk_sets: vec![],
             extra_teekey_paths: vec![],
         },
@@ -343,7 +343,7 @@ mod tests {
     #[case("test_data/configs/intel-ta-1.toml",         KbsConfig {
         attestation_token: AttestationTokenVerifierConfig {
             trusted_jwk_sets: vec!["/etc/ca".into(), "/etc/ca2".into()],
-            insecure_key: false,
+            insecure_header_jwk: false,
             trusted_certs_paths: vec![],
             extra_teekey_paths: vec![],
         },
@@ -426,7 +426,7 @@ mod tests {
     #[case("test_data/configs/coco-as-builtin-2.toml",         KbsConfig {
         attestation_token: AttestationTokenVerifierConfig {
             trusted_certs_paths: vec![],
-            insecure_key: false,
+            insecure_header_jwk: false,
             trusted_jwk_sets: vec![],
             extra_teekey_paths: vec![],
         },
@@ -469,7 +469,7 @@ mod tests {
     #[case("test_data/configs/intel-ta-2.toml",         KbsConfig {
         attestation_token: AttestationTokenVerifierConfig {
             trusted_jwk_sets: vec!["https://portal.trustauthority.intel.com".into()],
-            insecure_key: false,
+            insecure_header_jwk: false,
             trusted_certs_paths: vec![],
             extra_teekey_paths: vec![],
         },
@@ -527,7 +527,7 @@ mod tests {
     #[case("test_data/configs/intel-ta-3.toml",         KbsConfig {
         attestation_token: AttestationTokenVerifierConfig {
             trusted_jwk_sets: vec!["https://portal.trustauthority.intel.com".into()],
-            insecure_key: false,
+            insecure_header_jwk: false,
             trusted_certs_paths: vec![],
             extra_teekey_paths: vec![],
         },
@@ -557,7 +557,7 @@ mod tests {
     #[case("test_data/configs/coco-as-builtin-3.toml",         KbsConfig {
         attestation_token: AttestationTokenVerifierConfig {
             trusted_certs_paths: vec![],
-            insecure_key: false,
+            insecure_header_jwk: false,
             trusted_jwk_sets: vec![],
             extra_teekey_paths: vec![],
         },

--- a/kbs/src/token/mod.rs
+++ b/kbs/src/token/mod.rs
@@ -44,18 +44,22 @@ pub struct AttestationTokenVerifierConfig {
     #[serde(default)]
     pub trusted_jwk_sets: Vec<String>,
 
-    /// Whether the token signing key is (not) validated.
-    /// If true, the attestation token can be modified in flight.
-    /// This should only be set to true for testing.
-    /// While the token signature is still validated, the provenance of the
-    /// signing key is not checked and the key could be replaced.
+    /// Whether to skip endorsement checks for a JWK embedded in the JWT header.
     ///
-    /// When false, the key must be endorsed by the certificates or JWK sets
-    /// specified above.
+    /// When false (default) and the token header carries a `jwk`, the key must be
+    /// backed by an `x5c` certificate chain that chains to [`trusted_certs_paths`].
+    /// When true, that `jwk` is used directly to verify the signature without
+    /// checking its provenance; the signature itself is still validated.
+    ///
+    /// This only affects header-embedded `jwk` keys. Tokens that identify the
+    /// signing key via `kid` are still resolved from [`trusted_jwk_sets`].
+    ///
+    /// Should only be set to true for testing: an attacker who can replace the
+    /// header `jwk` can make KBS accept tokens signed with an arbitrary key.
     ///
     /// Default: false
     #[serde(default = "bool::default")]
-    pub insecure_key: bool,
+    pub insecure_header_jwk: bool,
 }
 
 #[derive(Clone)]
@@ -76,7 +80,7 @@ impl TokenVerifier {
             &config.trusted_jwk_sets,
             &config.trusted_certs_paths,
             &Vec::new(),
-            config.insecure_key,
+            config.insecure_header_jwk,
         )
         .await
         .map_err(|e| Error::TokenVerifierInitialization { source: e })?;

--- a/kbs/test/config/external-plugin-tls.toml
+++ b/kbs/test/config/external-plugin-tls.toml
@@ -3,7 +3,7 @@ sockets = ["127.0.0.1:8086"]
 insecure_http = true
 
 [attestation_token]
-insecure_key = true
+insecure_header_jwk = true
 
 [admin]
 authorization_mode = "InsecureAllowAll"

--- a/kbs/test/config/external-plugin.toml
+++ b/kbs/test/config/external-plugin.toml
@@ -3,7 +3,7 @@ sockets = ["127.0.0.1:8085"]
 insecure_http = true
 
 [attestation_token]
-insecure_key = true
+insecure_header_jwk = true
 
 [admin]
 authorization_mode = "InsecureAllowAll"

--- a/kbs/test_data/configs/coco-as-builtin-2.toml
+++ b/kbs/test_data/configs/coco-as-builtin-2.toml
@@ -8,7 +8,7 @@ insecure_http = true
 payload_request_size = 2
 
 [attestation_token]
-insecure_key = false
+insecure_header_jwk = false
 
 [attestation_service]
 type = "coco_as_builtin"

--- a/kbs/test_data/configs/coco-as-builtin-3.toml
+++ b/kbs/test_data/configs/coco-as-builtin-3.toml
@@ -2,7 +2,7 @@
 insecure_http = true
 
 [attestation_token]
-insecure_key = false
+insecure_header_jwk = false
 
 [attestation_service]
 type = "coco_as_builtin"


### PR DESCRIPTION
Old name `insecure_key` is confusing. Actually, the option controls
whether the endorsement of the jwk field of the token will be checked.

The old comment and document for insecure_key item in
AttestationTokenVerifierConfig is not clear enough. This commit fixes
the documents and changes the config name.