### PR TITLE
toolchain: bump rust toolchain to 1.93.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ alternative options that have been considered.
 
 ### Prerequisites
 
-- **Rust toolchain**: version pinned in `rust-toolchain.toml` (currently `1.90.0`)
+- **Rust toolchain**: version pinned in `rust-toolchain.toml` (currently `1.93.0`)
 - **Protobuf compiler** (`protoc`) for gRPC code generation
 - **OpenSSL** development libraries
 - **tpm2-tss** (for TPM verifier features)

--- a/attestation-service/docker/as-grpc/Dockerfile
+++ b/attestation-service/docker/as-grpc/Dockerfile
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# rust:1.90.0
+# rust:1.93.0
 FROM --platform=${BUILDPLATFORM:-linux/amd64} \
-    docker.io/library/rust@sha256:e227f20ec42af3ea9a3c9c1dd1b2012aa15f12279b5e9d5fb890ca1c2bb5726c \
+    docker.io/library/rust@sha256:bbde3ca426faeebab3eb58b8005d3d6da70607817a14bb92a55c94611d4d905f \
     AS builder
 ARG ARCH=x86_64
 ARG VERIFIER=all-verifier

--- a/attestation-service/docker/as-restful/Dockerfile
+++ b/attestation-service/docker/as-restful/Dockerfile
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# rust:1.90.0
+# rust:1.93.0
 FROM --platform=${BUILDPLATFORM:-linux/amd64} \
-    docker.io/library/rust@sha256:e227f20ec42af3ea9a3c9c1dd1b2012aa15f12279b5e9d5fb890ca1c2bb5726c \
+    docker.io/library/rust@sha256:bbde3ca426faeebab3eb58b8005d3d6da70607817a14bb92a55c94611d4d905f \
     AS builder
 ARG ARCH=x86_64
 ARG VERIFIER=all-verifier

--- a/attestation-service/src/bin/restful-as.rs
+++ b/attestation-service/src/bin/restful-as.rs
@@ -4,7 +4,7 @@ use actix_cors::Cors;
 use actix_web::{http::header, web, App, HttpServer};
 use anyhow::Result;
 use attestation_service::{config::Config, config::ConfigError, AttestationService, ServiceError};
-use clap::{arg, command, Parser};
+use clap::Parser;
 use openssl::{
     pkey::PKey,
     ssl::{SslAcceptor, SslMethod},

--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -1,6 +1,6 @@
-# rust:1.90.0
+# rust:1.93.0
 FROM --platform=${BUILDPLATFORM:-linux/amd64} \
-    docker.io/library/rust@sha256:e227f20ec42af3ea9a3c9c1dd1b2012aa15f12279b5e9d5fb890ca1c2bb5726c \
+    docker.io/library/rust@sha256:bbde3ca426faeebab3eb58b8005d3d6da70607817a14bb92a55c94611d4d905f \
     AS builder
 ARG ARCH=x86_64
 ARG ALIYUN=false

--- a/kbs/docker/coco-as-grpc/Dockerfile
+++ b/kbs/docker/coco-as-grpc/Dockerfile
@@ -1,6 +1,6 @@
-# rust:1.90.0
+# rust:1.93.0
 FROM --platform=${BUILDPLATFORM:-linux/amd64} \
-    docker.io/library/rust@sha256:e227f20ec42af3ea9a3c9c1dd1b2012aa15f12279b5e9d5fb890ca1c2bb5726c \
+    docker.io/library/rust@sha256:bbde3ca426faeebab3eb58b8005d3d6da70607817a14bb92a55c94611d4d905f \
     AS builder
 ARG BUILDPLATFORM=linux/amd64
 ARG ARCH=x86_64

--- a/kbs/docker/intel-trust-authority/Dockerfile
+++ b/kbs/docker/intel-trust-authority/Dockerfile
@@ -1,5 +1,5 @@
-# rust:1.90.0
-FROM docker.io/library/rust@sha256:e227f20ec42af3ea9a3c9c1dd1b2012aa15f12279b5e9d5fb890ca1c2bb5726c \
+# rust:1.93.0
+FROM docker.io/library/rust@sha256:bbde3ca426faeebab3eb58b8005d3d6da70607817a14bb92a55c94611d4d905f \
     AS builder
 ARG ALIYUN=false
 ARG VAULT=false

--- a/kbs/src/admin/error.rs
+++ b/kbs/src/admin/error.rs
@@ -4,7 +4,6 @@
 
 use strum::AsRefStr;
 use thiserror::Error;
-use tracing::error;
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/kbs/src/attestation/error.rs
+++ b/kbs/src/attestation/error.rs
@@ -4,7 +4,6 @@
 
 use strum::AsRefStr;
 use thiserror::Error;
-use tracing::error;
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/kbs/src/token/error.rs
+++ b/kbs/src/token/error.rs
@@ -4,7 +4,6 @@
 
 use strum::AsRefStr;
 use thiserror::Error;
-use tracing::error;
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.93.0"

--- a/tools/kbs-client/src/main.rs
+++ b/tools/kbs-client/src/main.rs
@@ -280,15 +280,15 @@ async fn main() -> Result<()> {
                 None => None,
             };
 
-            if token.is_some() {
-                if tee_key.is_none() {
+            if let Some(token) = token {
+                let Some(tee_key) = tee_key else {
                     bail!("if `--attestation-token` is set, `--tee_key_file` argument should also be set, and the public part of TEE Key should be consistent with tee-pubkey in the token.");
-                }
+                };
                 let resource_bytes = kbs_client::get_resource_with_token(
                     &cli.url,
                     &path,
-                    tee_key.unwrap(),
-                    token.unwrap(),
+                    tee_key,
+                    token,
                     kbs_cert.clone(),
                 )
                 .await?;

--- a/tools/trustee-cli/Dockerfile
+++ b/tools/trustee-cli/Dockerfile
@@ -1,6 +1,6 @@
-# rust:1.90.0
+# rust:1.93.0
 FROM --platform=${BUILDPLATFORM:-linux/amd64} \
-    docker.io/library/rust@sha256:e227f20ec42af3ea9a3c9c1dd1b2012aa15f12279b5e9d5fb890ca1c2bb5726c \
+    docker.io/library/rust@sha256:bbde3ca426faeebab3eb58b8005d3d6da70607817a14bb92a55c94611d4d905f \
     AS builder
 ARG ARCH=x86_64
 ARG ALIYUN=false


### PR DESCRIPTION
Now the rust toolchain is required to >= 1.91.0 to support AWS KMS backend. 1.93.0 is chosen because this follows the Kata side toolchain.