### PR TITLE
ci: optimize image building and docker e2e test

### DIFF
--- a/.github/actions/build-single-image/action.yml
+++ b/.github/actions/build-single-image/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: Whether to push the built image to GHCR
     required: false
     default: "false"
+  load:
+    description: Load the built image into the local Docker engine (for docker save / compose e2e)
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -60,6 +64,8 @@ runs:
         build_option_args=()
         if [ "${{ inputs.push }}" = "true" ]; then
           build_option_args+=(--push)
+        elif [ "${{ inputs.load }}" = "true" ]; then
+          build_option_args+=(--load)
         fi
         docker buildx build --provenance false \
           "${platform_args[@]}" \

--- a/.github/workflows/test-e2e-kbs.yml
+++ b/.github/workflows/test-e2e-kbs.yml
@@ -88,9 +88,17 @@ jobs:
       - name: Run KBS Vault integration e2e (no SSL + SSL)
         run: make test-kbs-vault-e2e
 
+  # Docker Compose cluster images (shared with docker-e2e-test via workflow artifacts)
+  build-docker-e2e-images:
+    name: Build Docker Compose e2e images
+    uses: ./.github/workflows/workflow-call-build-docker-e2e-images.yml
+    permissions:
+      contents: read
+
   # Docker Compose cluster e2e
   docker-e2e-test:
     name: Docker Compose e2e
+    needs: build-docker-e2e-images
     strategy:
       matrix:
         instance:
@@ -98,13 +106,9 @@ jobs:
           - ubuntu-24.04-arm
         include:
           - instance: ubuntu-24.04
-            build_platform: linux/amd64
-            target_arch: x86_64
-            verifier: all-verifier
+            platform_slug: linux-amd64
           - instance: ubuntu-24.04-arm
-            build_platform: linux/arm64
-            target_arch: aarch64
-            verifier: cca-verifier
+            platform_slug: linux-arm64
     runs-on: ${{ matrix.instance }}
     permissions:
       contents: read
@@ -115,6 +119,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Download pre-built images
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docker-e2e-images-${{ matrix.platform_slug }}
+          path: ${{ runner.temp }}/docker-e2e-images
+
+      - name: Load images
+        run: docker load --input "${{ runner.temp }}/docker-e2e-images/images.tar"
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
@@ -134,9 +147,7 @@ jobs:
 
       - name: Run KBS Docker Compose e2e
         env:
-          BUILD_PLATFORM: ${{ matrix.build_platform }}
-          TARGET_ARCH: ${{ matrix.target_arch }}
-          VERIFIER: ${{ matrix.verifier }}
+          SKIP_DOCKER_COMPOSE_BUILD: "1"
         run: make test-kbs-docker-e2e
 
   # External plugin e2e

--- a/.github/workflows/workflow-call-build-docker-e2e-images.yml
+++ b/.github/workflows/workflow-call-build-docker-e2e-images.yml
@@ -1,0 +1,151 @@
+name: Build Docker Compose e2e Images
+
+# Builds the docker-compose cluster images (kbs-grpc-as, coco-as-grpc, rvps) in
+# parallel (one matrix job per image/arch), then packages them per arch for
+# docker-e2e-test. See https://docs.docker.com/build/ci/github-actions/share-image-jobs/
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  build-image:
+    name: Build ${{ matrix.tag }} (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - instance: ubuntu-24.04
+            platform: linux/amd64
+            platform_slug: linux-amd64
+            arch: x86_64
+            tag: kbs-grpc-as
+            docker_file: kbs/docker/coco-as-grpc/Dockerfile
+            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64
+          - instance: ubuntu-24.04
+            platform: linux/amd64
+            platform_slug: linux-amd64
+            arch: x86_64
+            tag: coco-as-grpc
+            docker_file: attestation-service/docker/as-grpc/Dockerfile
+            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64 --build-arg VERIFIER=all-verifier
+          - instance: ubuntu-24.04
+            platform: linux/amd64
+            platform_slug: linux-amd64
+            arch: x86_64
+            tag: rvps
+            docker_file: rvps/docker/Dockerfile
+            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64
+          - instance: ubuntu-24.04-arm
+            platform: linux/arm64
+            platform_slug: linux-arm64
+            arch: aarch64
+            tag: kbs-grpc-as
+            docker_file: kbs/docker/coco-as-grpc/Dockerfile
+            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64
+          - instance: ubuntu-24.04-arm
+            platform: linux/arm64
+            platform_slug: linux-arm64
+            arch: aarch64
+            tag: coco-as-grpc
+            docker_file: attestation-service/docker/as-grpc/Dockerfile
+            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64 --build-arg VERIFIER=cca-verifier
+          - instance: ubuntu-24.04-arm
+            platform: linux/arm64
+            platform_slug: linux-arm64
+            arch: aarch64
+            tag: rvps
+            docker_file: rvps/docker/Dockerfile
+            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64
+    runs-on: ${{ matrix.instance }}
+    permissions:
+      contents: read
+    env:
+      IMAGE_PREFIX: ghcr.io/confidential-containers/staged-images
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Build ${{ matrix.tag }}
+        uses: ./.github/actions/build-single-image
+        with:
+          ghcr_token: ""
+          docker_file: ${{ matrix.docker_file }}
+          tag: ${{ matrix.tag }}
+          platform: ${{ matrix.platform }}
+          build_args: ${{ matrix.build_args }}
+          load: true
+
+      - name: Tag image for docker compose
+        run: |
+          set -euo pipefail
+          docker tag "${IMAGE_PREFIX}/${{ matrix.tag }}:latest-$(uname -m)" \
+            "${IMAGE_PREFIX}/${{ matrix.tag }}:latest"
+
+      - name: Save image
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ runner.temp }}/docker-e2e-image"
+          docker save -o "${{ runner.temp }}/docker-e2e-image/${{ matrix.tag }}.tar" \
+            "${IMAGE_PREFIX}/${{ matrix.tag }}:latest"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docker-e2e-image-${{ matrix.platform_slug }}-${{ matrix.tag }}
+          path: ${{ runner.temp }}/docker-e2e-image/${{ matrix.tag }}.tar
+          retention-days: 1
+          if-no-files-found: error
+
+  package-images:
+    name: Package docker e2e images (${{ matrix.platform }})
+    needs: build-image
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - instance: ubuntu-24.04
+            platform: linux/amd64
+            platform_slug: linux-amd64
+          - instance: ubuntu-24.04-arm
+            platform: linux/arm64
+            platform_slug: linux-arm64
+    runs-on: ${{ matrix.instance }}
+    permissions:
+      contents: read
+    env:
+      IMAGE_PREFIX: ghcr.io/confidential-containers/staged-images
+    steps:
+      - name: Download built images
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: docker-e2e-image-${{ matrix.platform_slug }}-*
+          path: ${{ runner.temp }}/docker-e2e-images
+          merge-multiple: true
+
+      - name: Load and repackage images (KBS-GRPC-AS, COCO-AS-GRPC, RVPS) in a single tarball
+        run: |
+          set -euo pipefail
+          mapfile -t image_tars < <(find "${{ runner.temp }}/docker-e2e-images" -name '*.tar' -type f)
+          if [ "${#image_tars[@]}" -ne 3 ]; then
+            echo "Expected 3 image tarballs, found ${#image_tars[@]}:" "${image_tars[@]}"
+            exit 1
+          fi
+          for tar in "${image_tars[@]}"; do
+            docker load --input "$tar"
+          done
+          docker image ls "${IMAGE_PREFIX}/"*
+          mkdir -p "${{ runner.temp }}/docker-e2e-bundle"
+          docker save -o "${{ runner.temp }}/docker-e2e-bundle/images.tar" \
+            "${IMAGE_PREFIX}/kbs-grpc-as:latest" \
+            "${IMAGE_PREFIX}/coco-as-grpc:latest" \
+            "${IMAGE_PREFIX}/rvps:latest"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docker-e2e-images-${{ matrix.platform_slug }}
+          path: ${{ runner.temp }}/docker-e2e-bundle/images.tar
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/workflow-call-build-staged-images-pr.yml
+++ b/.github/workflows/workflow-call-build-staged-images-pr.yml
@@ -1,5 +1,10 @@
 name: Build Staged Images (PR)
 
+# linux/amd64 and linux/arm64 images used by docker-compose e2e are built once in
+# workflow-call-build-docker-e2e-images.yml (called from test-e2e-kbs.yml) and
+# passed to docker-e2e-test via workflow artifacts. They are omitted here on PR to
+# avoid rebuilding the same Dockerfiles.
+
 on:
   workflow_call:
     inputs:
@@ -41,21 +46,9 @@ jobs:
           - name: gRPC AS
             tag: kbs-grpc-as
             docker_file: kbs/docker/coco-as-grpc/Dockerfile
-            platform: linux/amd64
-            instance: ubuntu-24.04
-            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64
-          - name: gRPC AS
-            tag: kbs-grpc-as
-            docker_file: kbs/docker/coco-as-grpc/Dockerfile
             platform: linux/s390x
             instance: ubuntu-24.04-s390x
             build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x
-          - name: gRPC AS
-            tag: kbs-grpc-as
-            docker_file: kbs/docker/coco-as-grpc/Dockerfile
-            platform: linux/arm64
-            instance: ubuntu-24.04-arm
-            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64
           - name: Intel Trust Authority AS
             tag: kbs-ita-as
             docker_file: kbs/docker/intel-trust-authority/Dockerfile
@@ -101,21 +94,9 @@ jobs:
           - name: gRPC CoCo-AS
             tag: coco-as-grpc
             docker_file: attestation-service/docker/as-grpc/Dockerfile
-            platform: linux/amd64
-            instance: ubuntu-24.04
-            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64 --build-arg VERIFIER=all-verifier
-          - name: gRPC CoCo-AS
-            tag: coco-as-grpc
-            docker_file: attestation-service/docker/as-grpc/Dockerfile
             platform: linux/s390x
             instance: ubuntu-24.04-s390x
             build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x --build-arg VERIFIER=snp-verifier,nvidia-verifier,se-verifier
-          - name: gRPC CoCo-AS
-            tag: coco-as-grpc
-            docker_file: attestation-service/docker/as-grpc/Dockerfile
-            platform: linux/arm64
-            instance: ubuntu-24.04-arm
-            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64 --build-arg VERIFIER=cca-verifier
           - name: RESTful CoCo-AS
             tag: coco-as-restful
             docker_file: attestation-service/docker/as-restful/Dockerfile
@@ -161,21 +142,9 @@ jobs:
           - name: RVPS
             tag: rvps
             docker_file: rvps/docker/Dockerfile
-            platform: linux/amd64
-            instance: ubuntu-24.04
-            build_args: --build-arg BUILDPLATFORM=linux/amd64 --build-arg ARCH=x86_64
-          - name: RVPS
-            tag: rvps
-            docker_file: rvps/docker/Dockerfile
             platform: linux/s390x
             instance: ubuntu-24.04-s390x
             build_args: --build-arg BUILDPLATFORM=linux/s390x --build-arg ARCH=s390x
-          - name: RVPS
-            tag: rvps
-            docker_file: rvps/docker/Dockerfile
-            platform: linux/arm64
-            instance: ubuntu-24.04-arm
-            build_args: --build-arg BUILDPLATFORM=linux/arm64 --build-arg ARCH=aarch64
     runs-on: ${{ matrix.instance }}
     steps:
       - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,12 @@ test-kbs-docker-e2e:
 		$(CURDIR)/kbs/config/docker-compose/kbs-config.toml \
 		$(CURDIR)/kbs/config/docker-compose/setup.sh \
 		$$E2E_DIR/kbs/config/docker-compose/ && \
-	docker compose -f $(CURDIR)/docker-compose.yml build --build-arg BUILDPLATFORM="$${BUILD_PLATFORM:-linux/amd64}" --build-arg ARCH="$${TARGET_ARCH:-x86_64}" --build-arg VERIFIER="$${VERIFIER:-all-verifier}" && \
+	if [ -z "$${SKIP_DOCKER_COMPOSE_BUILD:-}" ]; then \
+		docker compose -f $(CURDIR)/docker-compose.yml build \
+			--build-arg BUILDPLATFORM="$${BUILD_PLATFORM:-linux/amd64}" \
+			--build-arg ARCH="$${TARGET_ARCH:-x86_64}" \
+			--build-arg VERIFIER="$${VERIFIER:-all-verifier}"; \
+	fi && \
 	docker compose -f $(CURDIR)/docker-compose.yml --project-directory $$E2E_DIR up -d && \
 	cd $(CURDIR)/target/release && \
 	echo "shhhhh" > test-secret && \


### PR DESCRIPTION
Now we have same image building process in two places:
1. Build staged images matrix
2. Docker compose e2e test

This will waste time and computation resource. This PR will try two combine the two process into one:
1. Parallely build the images
2. Once all images required by docker-compose, the docker-compose e2e test starts.

Assisted-by: Cursor