### PR TITLE
verifier: centralize DCAP quote claim generation on Quote

### DIFF
--- a/deps/verifier/src/az_tdx_vtpm/mod.rs
+++ b/deps/verifier/src/az_tdx_vtpm/mod.rs
@@ -11,9 +11,7 @@ use super::az_snp_vtpm::{
     TpmQuote,
 };
 use super::intel_dcap::quote::{parse_quote, Quote as TdQuote};
-use super::intel_dcap::{
-    ecdsa_quote_verification, extend_using_custom_claims, pck::parse_platform_info,
-};
+use super::intel_dcap::{ecdsa_quote_verification, extend_using_custom_claims};
 use super::tdx::claims::generate_parsed_claim;
 use super::{TeeClass, TeeEvidence, TeeEvidenceParsedClaim, Verifier};
 use crate::{InitDataHash, ReportData};
@@ -68,10 +66,7 @@ impl Verifier for AzTdxVtpm {
         let pcr_refs: Vec<&[u8; 32]> = pcrs.iter().collect();
         verify_init_data(expected_init_data_hash, &pcr_refs)?;
 
-        let platform_info =
-            parse_platform_info(&td_quote.cert_data().qe_certification_data.certificates)?;
-
-        let mut claim = generate_parsed_claim(&td_quote, None, &platform_info)?;
+        let mut claim = generate_parsed_claim(&td_quote, None)?;
         extend_claim(&mut claim, &tpm_quote)?;
         extend_using_custom_claims(&mut claim, custom_claims)?;
 

--- a/deps/verifier/src/intel_dcap/claims.rs
+++ b/deps/verifier/src/intel_dcap/claims.rs
@@ -1,9 +1,14 @@
+use anyhow::Result;
+use bitflags::Flags;
 use intel_tee_quote_verification_rs::{sgx_ql_qv_result_t, sgx_ql_qv_supplemental_t};
-use serde_json::{Map, Number, Value};
+use serde_json::{json, Map, Number, Value};
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
+
+use crate::intel_dcap::pck::parse_platform_info;
+use crate::intel_dcap::quote::{Quote, QuoteV5Body, QuoteV5Type, TdAttributesFlags};
 
 struct SgxQlQvResultWrapper(pub sgx_ql_qv_result_t);
 
@@ -134,6 +139,180 @@ fn format_rfc3339(timestamp: i64) -> String {
         .expect("invalid unix timestamp.")
         .format(&Rfc3339)
         .expect("failed to format timestamp.")
+}
+
+fn parse_td_attributes(data: &[u8]) -> Result<Map<String, Value>> {
+    let arr = <[u8; 8]>::try_from(data)?;
+    let td = TdAttributesFlags::from_bits_retain(u64::from_le_bytes(arr));
+    let attribs = TdAttributesFlags::FLAGS
+        .iter()
+        .map(|f| {
+            (
+                f.name().to_string().to_lowercase(),
+                Value::Bool(td.contains(f.value().clone())),
+            )
+        })
+        .collect();
+
+    Ok(attribs)
+}
+
+impl Quote {
+    pub(crate) fn generate_parsed_claim(&self) -> Result<Map<String, Value>> {
+        let claims = match self {
+            Quote::V3 { header, body, .. } => {
+                // Claims from SGX Quote Header.
+                // tee_type encodes the same bytes as att_key_data_0 in the SGX v3 wire format.
+                // reserved[0..2] and reserved[2..4] encode qe_svn and pce_svn respectively.
+                json!({
+                    "header": {
+                        "version": hex::encode(header.version),
+                        "att_key_type": hex::encode(header.att_key_type),
+                        "att_key_data_0": hex::encode(header.tee_type),
+                        "qe_svn": hex::encode(&header.reserved[..2]),
+                        "pce_svn": hex::encode(&header.reserved[2..]),
+                        "vendor_id": hex::encode(header.vendor_id),
+                        "user_data": hex::encode(header.user_data),
+                    },
+                    "body": {
+                        "cpu_svn": hex::encode(body.cpu_svn),
+                        "misc_select": hex::encode(body.misc_select),
+                        "reserved1": hex::encode(body.reserved1),
+                        "isv_ext_prod_id": hex::encode(body.isv_ext_prod_id),
+                        "attributes.flags": hex::encode(body.attributes_flags),
+                        "attributes.xfrm": hex::encode(body.attributes_xfrm),
+                        "mr_enclave": hex::encode(body.mr_enclave),
+                        "reserved2": hex::encode(body.reserved2),
+                        "mr_signer": hex::encode(body.mr_signer),
+                        "reserved3": hex::encode(body.reserved3),
+                        "config_id": hex::encode(body.config_id),
+                        "isv_prod_id": hex::encode(body.isv_prod_id),
+                        "isv_svn": hex::encode(body.isv_svn),
+                        "config_svn": hex::encode(body.config_svn),
+                        "reserved4": hex::encode(body.reserved4),
+                        "isv_family_id": hex::encode(body.isv_family_id),
+                        "report_data": hex::encode(body.report_data),
+                    },
+                    "report_data": hex::encode(body.report_data),
+                    "init_data": hex::encode(body.config_id),
+                })
+            }
+            Quote::V4 { header, body, .. } => {
+                let td_attributes = parse_td_attributes(self.td_attributes())?;
+                json!({
+                    "quote": {
+                        "header": {
+                            "version": hex::encode(b"\x04\x00"),
+                            "att_key_type": hex::encode(header.att_key_type),
+                            "tee_type": hex::encode(header.tee_type),
+                            "reserved": hex::encode(header.reserved),
+                            "vendor_id": hex::encode(header.vendor_id),
+                            "user_data": hex::encode(header.user_data),
+                        },
+                        "body": {
+                            "tcb_svn": hex::encode(body.tcb_svn),
+                            "mr_seam": hex::encode(body.mr_seam),
+                            "mrsigner_seam": hex::encode(body.mrsigner_seam),
+                            "seam_attributes": hex::encode(body.seam_attributes),
+                            "td_attributes": hex::encode(body.td_attributes),
+                            "xfam": hex::encode(body.xfam),
+                            "mr_td": hex::encode(body.mr_td),
+                            "mr_config_id": hex::encode(body.mr_config_id),
+                            "mr_owner": hex::encode(body.mr_owner),
+                            "mr_owner_config": hex::encode(body.mr_owner_config),
+                            "rtmr_0": hex::encode(body.rtmr_0),
+                            "rtmr_1": hex::encode(body.rtmr_1),
+                            "rtmr_2": hex::encode(body.rtmr_2),
+                            "rtmr_3": hex::encode(body.rtmr_3),
+                            "report_data": hex::encode(body.report_data),
+                        },
+                    },
+                    "report_data": hex::encode(body.report_data),
+                    "init_data": hex::encode(body.mr_config_id),
+                    "td_attributes": td_attributes,
+                })
+            }
+            Quote::V5 {
+                header,
+                r#type,
+                size,
+                body,
+                ..
+            } => {
+                let td_attributes = parse_td_attributes(self.td_attributes())?;
+                json!({
+                    "quote": {
+                        "header": {
+                            "version": hex::encode(b"\x05\x00"),
+                            "att_key_type": hex::encode(header.att_key_type),
+                            "tee_type": hex::encode(header.tee_type),
+                            "reserved": hex::encode(header.reserved),
+                            "vendor_id": hex::encode(header.vendor_id),
+                            "user_data": hex::encode(header.user_data),
+                        },
+                        "body": match body {
+                            QuoteV5Body::Tdx10(body) => json!({
+                                "tcb_svn": hex::encode(body.tcb_svn),
+                                "mr_seam": hex::encode(body.mr_seam),
+                                "mrsigner_seam": hex::encode(body.mrsigner_seam),
+                                "seam_attributes": hex::encode(body.seam_attributes),
+                                "td_attributes": hex::encode(body.td_attributes),
+                                "xfam": hex::encode(body.xfam),
+                                "mr_td": hex::encode(body.mr_td),
+                                "mr_config_id": hex::encode(body.mr_config_id),
+                                "mr_owner": hex::encode(body.mr_owner),
+                                "mr_owner_config": hex::encode(body.mr_owner_config),
+                                "rtmr_0": hex::encode(body.rtmr_0),
+                                "rtmr_1": hex::encode(body.rtmr_1),
+                                "rtmr_2": hex::encode(body.rtmr_2),
+                                "rtmr_3": hex::encode(body.rtmr_3),
+                                "report_data": hex::encode(body.report_data),
+                            }),
+                            QuoteV5Body::Tdx15(body) => json!({
+                                "tcb_svn": hex::encode(body.tcb_svn),
+                                "mr_seam": hex::encode(body.mr_seam),
+                                "mrsigner_seam": hex::encode(body.mrsigner_seam),
+                                "seam_attributes": hex::encode(body.seam_attributes),
+                                "td_attributes": hex::encode(body.td_attributes),
+                                "xfam": hex::encode(body.xfam),
+                                "mr_td": hex::encode(body.mr_td),
+                                "mr_config_id": hex::encode(body.mr_config_id),
+                                "mr_owner": hex::encode(body.mr_owner),
+                                "mr_owner_config": hex::encode(body.mr_owner_config),
+                                "rtmr_0": hex::encode(body.rtmr_0),
+                                "rtmr_1": hex::encode(body.rtmr_1),
+                                "rtmr_2": hex::encode(body.rtmr_2),
+                                "rtmr_3": hex::encode(body.rtmr_3),
+                                "report_data": hex::encode(body.report_data),
+                                "tee_tcb_svn2": hex::encode(body.tee_tcb_svn2),
+                                "mr_servicetd": hex::encode(body.mr_servicetd),
+                            }),
+                        },
+                        "type": match r#type {
+                            QuoteV5Type::TDX10 => "0200",
+                            QuoteV5Type::TDX15 => "0300",
+                        },
+                        "size": hex::encode(&size[..]),
+                    },
+                    "report_data": hex::encode(self.report_data()),
+                    "init_data": hex::encode(self.mr_config_id()),
+                    "td_attributes": td_attributes,
+                })
+            }
+        };
+
+        let mut claims = claims.as_object().expect("claims is not an object").clone();
+        let platform_info =
+            parse_platform_info(&self.cert_data().qe_certification_data.certificates)?;
+        if let Some(piid) = platform_info.platform_instance_id {
+            claims.insert(
+                "platform_instance_id".to_string(),
+                Value::String(hex::encode(&piid[..])),
+            );
+        }
+
+        Ok(claims)
+    }
 }
 
 #[cfg(test)]

--- a/deps/verifier/src/intel_dcap/quote.rs
+++ b/deps/verifier/src/intel_dcap/quote.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, bail, Context, Result};
+use bitflags::bitflags;
 use core::fmt;
 use scroll::Pread;
 use std::mem::size_of;
@@ -410,6 +411,31 @@ pub(crate) enum Quote {
     },
 }
 
+macro_rules! body_field {
+    ($r: ident) => {
+        pub(crate) fn $r(&self) -> &[u8] {
+            match self {
+                Quote::V3 { .. } => unreachable!("TDX field not available on SGX v3 quote"),
+                Quote::V4 { body, .. } => &body.$r,
+                Quote::V5 { body, .. } => match body {
+                    QuoteV5Body::Tdx10(body) => &body.$r,
+                    QuoteV5Body::Tdx15(body) => &body.$r,
+                },
+            }
+        }
+    };
+}
+
+impl Quote {
+    body_field!(report_data);
+    body_field!(mr_config_id);
+    body_field!(rtmr_0);
+    body_field!(rtmr_1);
+    body_field!(rtmr_2);
+    body_field!(rtmr_3);
+    body_field!(td_attributes);
+}
+
 impl Quote {
     pub(crate) fn cert_data(&self) -> &QuoteCertificationData {
         match self {
@@ -608,6 +634,17 @@ pub(crate) fn parse_quote(quote_bin: &[u8]) -> Result<Quote> {
             })
         }
         (v, t) => bail!("unsupported quote version {v} / tee_type {t:#010x}"),
+    }
+}
+
+bitflags! {
+    #[derive(Debug, Clone)]
+    pub struct TdAttributesFlags: u64 {
+        const DEBUG            = 1 << 0;
+        const SEPTVE_DISABLE   = 1 << 28;
+        const PROTECTION_KEYS  = 1 << 30;
+        const KEY_LOCKER       = 1 << 31;
+        const PERFMON          = 1 << 63;
     }
 }
 

--- a/deps/verifier/src/sgx/claims.rs
+++ b/deps/verifier/src/sgx/claims.rs
@@ -34,77 +34,21 @@
 //!         "reserved4": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
 //!         "isv_family_id": "00000000000000000000000000000000",
 //!         "report_data": "74657374000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-//!     }
+//!     },
+//!     "report_data": "74657374000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+//!     "init_data": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+//!     "platform_instance_id": "7a3a6941065cd5060bd93d3db2cfc0c8"
 //! }
 //! ```
 
-use anyhow::{bail, Result};
-use serde_json::{Map, Value};
+use anyhow::Result;
+use serde_json::Value;
 
-use crate::intel_dcap::pck::PlatformInfo;
 use crate::intel_dcap::quote::Quote;
 use crate::TeeEvidenceParsedClaim;
 
-macro_rules! parse_claim {
-    ($map_name: ident, $key_name: literal, $field: ident) => {
-        $map_name.insert($key_name.to_string(), serde_json::Value::Object($field))
-    };
-    ($map_name: ident, $key_name: literal, $field: expr) => {
-        $map_name.insert(
-            $key_name.to_string(),
-            serde_json::Value::String(hex::encode($field)),
-        )
-    };
-}
-
-pub fn generate_parsed_claims(
-    quote: &Quote,
-    platform_info: &PlatformInfo,
-) -> Result<TeeEvidenceParsedClaim> {
-    let Quote::V3 { header, body, .. } = quote else {
-        bail!("expected SGX v3 quote");
-    };
-    let mut quote_body = Map::new();
-    let mut quote_header = Map::new();
-
-    // Claims from SGX Quote Header.
-    // tee_type encodes the same bytes as att_key_data_0 in the SGX v3 wire format.
-    // reserved[0..2] and reserved[2..4] encode qe_svn and pce_svn respectively.
-    parse_claim!(quote_header, "version", header.version);
-    parse_claim!(quote_header, "att_key_type", header.att_key_type);
-    parse_claim!(quote_header, "att_key_data_0", header.tee_type);
-    parse_claim!(quote_header, "qe_svn", &header.reserved[..2]);
-    parse_claim!(quote_header, "pce_svn", &header.reserved[2..]);
-    parse_claim!(quote_header, "vendor_id", header.vendor_id);
-    parse_claim!(quote_header, "user_data", header.user_data);
-
-    parse_claim!(quote_body, "cpu_svn", body.cpu_svn);
-    parse_claim!(quote_body, "misc_select", body.misc_select);
-    parse_claim!(quote_body, "reserved1", body.reserved1);
-    parse_claim!(quote_body, "isv_ext_prod_id", body.isv_ext_prod_id);
-    parse_claim!(quote_body, "attributes.flags", body.attributes_flags);
-    parse_claim!(quote_body, "attributes.xfrm", body.attributes_xfrm);
-    parse_claim!(quote_body, "mr_enclave", body.mr_enclave);
-    parse_claim!(quote_body, "reserved2", body.reserved2);
-    parse_claim!(quote_body, "mr_signer", body.mr_signer);
-    parse_claim!(quote_body, "reserved3", body.reserved3);
-    parse_claim!(quote_body, "config_id", body.config_id);
-    parse_claim!(quote_body, "isv_prod_id", body.isv_prod_id);
-    parse_claim!(quote_body, "isv_svn", body.isv_svn);
-    parse_claim!(quote_body, "config_svn", body.config_svn);
-    parse_claim!(quote_body, "reserved4", body.reserved4);
-    parse_claim!(quote_body, "isv_family_id", body.isv_family_id);
-    parse_claim!(quote_body, "report_data", body.report_data);
-
-    let mut claims = Map::new();
-    parse_claim!(claims, "header", quote_header);
-    parse_claim!(claims, "body", quote_body);
-    parse_claim!(claims, "report_data", body.report_data);
-    parse_claim!(claims, "init_data", body.config_id);
-
-    if let Some(piid) = platform_info.platform_instance_id {
-        parse_claim!(claims, "platform_instance_id", &piid[..]);
-    }
+pub fn generate_parsed_claims(quote: &Quote) -> Result<TeeEvidenceParsedClaim> {
+    let claims = quote.generate_parsed_claim()?;
 
     Ok(Value::Object(claims) as TeeEvidenceParsedClaim)
 }
@@ -115,17 +59,13 @@ mod tests {
     use serde_json::json;
 
     use super::generate_parsed_claims;
-    use crate::intel_dcap::pck::parse_platform_info;
 
     #[test]
     fn parse_sgx_claims() {
         let quote_bin = include_bytes!("../../test_data/occlum_quote.dat");
         let quote =
             crate::intel_dcap::quote::parse_quote(quote_bin.as_slice()).expect("parse quote");
-        let platform_info =
-            parse_platform_info(&quote.cert_data().qe_certification_data.certificates)
-                .expect("parse platform info");
-        let claims = generate_parsed_claims(&quote, &platform_info).expect("parse claim failed");
+        let claims = generate_parsed_claims(&quote).expect("parse claim failed");
         let expected = json!({
             "header":{
                 "version": "0300",

--- a/deps/verifier/src/sgx/mod.rs
+++ b/deps/verifier/src/sgx/mod.rs
@@ -11,7 +11,6 @@ use tracing::{debug, instrument};
 
 use super::intel_dcap::{
     ecdsa_quote_verification, extend_using_custom_claims,
-    pck::parse_platform_info,
     quote::{parse_quote, Quote},
 };
 use super::{regularize_data, InitDataHash, ReportData};
@@ -87,8 +86,7 @@ async fn verify_evidence(
         }
     }
 
-    let platform_info = parse_platform_info(&quote.cert_data().qe_certification_data.certificates)?;
-    let mut claim = claims::generate_parsed_claims(&quote, &platform_info)?;
+    let mut claim = claims::generate_parsed_claims(&quote)?;
     extend_using_custom_claims(&mut claim, custom_claims)?;
 
     Ok(claim)

--- a/deps/verifier/src/tdx/claims.rs
+++ b/deps/verifier/src/tdx/claims.rs
@@ -7,167 +7,19 @@
 //! serialize them into a JSON. The format will look like example available in test data:
 //! ./test_data/parse_tdx_claims_expected.json
 
-use anyhow::{bail, Result};
-use bitflags::{bitflags, Flags};
-use serde_json::{Map, Value};
+use anyhow::Result;
 
-use crate::intel_dcap::quote::Quote;
-use crate::{
-    intel_dcap::{
-        pck::PlatformInfo,
-        quote::{QuoteV5Body, QuoteV5Type},
-    },
-    TeeEvidenceParsedClaim,
-};
+use serde_json::Value;
 
-macro_rules! body_field {
-    ($r: ident) => {
-        pub(crate) fn $r(&self) -> &[u8] {
-            match self {
-                Quote::V3 { .. } => unreachable!("TDX field not available on SGX v3 quote"),
-                Quote::V4 { body, .. } => &body.$r,
-                Quote::V5 { body, .. } => match body {
-                    QuoteV5Body::Tdx10(body) => &body.$r,
-                    QuoteV5Body::Tdx15(body) => &body.$r,
-                },
-            }
-        }
-    };
-}
+use crate::{intel_dcap::quote::Quote, TeeEvidenceParsedClaim};
 
-impl Quote {
-    body_field!(report_data);
-    body_field!(mr_config_id);
-    body_field!(rtmr_0);
-    body_field!(rtmr_1);
-    body_field!(rtmr_2);
-    body_field!(rtmr_3);
-    body_field!(td_attributes);
-}
 use eventlog::CcEventLog;
-
-macro_rules! parse_claim {
-    ($map_name: ident, $key_name: literal, $field: ident) => {
-        $map_name.insert($key_name.to_string(), serde_json::Value::Object($field))
-    };
-    ($map_name: ident, $key_name: literal, $field: expr) => {
-        $map_name.insert(
-            $key_name.to_string(),
-            serde_json::Value::String(hex::encode($field)),
-        )
-    };
-}
 
 pub fn generate_parsed_claim(
     quote: &Quote,
     cc_eventlog: Option<CcEventLog>,
-    platform_info: &PlatformInfo,
 ) -> Result<TeeEvidenceParsedClaim> {
-    let mut quote_map = Map::new();
-    let mut quote_body = Map::new();
-    let mut quote_header = Map::new();
-
-    match &quote {
-        Quote::V3 { .. } => bail!("expected TDX quote (v4/v5), got SGX quote (v3)"),
-        Quote::V4 { header, body, .. } => {
-            parse_claim!(quote_header, "version", b"\x04\x00");
-            parse_claim!(quote_header, "att_key_type", header.att_key_type);
-            parse_claim!(quote_header, "tee_type", header.tee_type);
-            parse_claim!(quote_header, "reserved", header.reserved);
-            parse_claim!(quote_header, "vendor_id", header.vendor_id);
-            parse_claim!(quote_header, "user_data", header.user_data);
-            parse_claim!(quote_body, "tcb_svn", body.tcb_svn);
-            parse_claim!(quote_body, "mr_seam", body.mr_seam);
-            parse_claim!(quote_body, "mrsigner_seam", body.mrsigner_seam);
-            parse_claim!(quote_body, "seam_attributes", body.seam_attributes);
-            parse_claim!(quote_body, "td_attributes", body.td_attributes);
-            parse_claim!(quote_body, "xfam", body.xfam);
-            parse_claim!(quote_body, "mr_td", body.mr_td);
-            parse_claim!(quote_body, "mr_config_id", body.mr_config_id);
-            parse_claim!(quote_body, "mr_owner", body.mr_owner);
-            parse_claim!(quote_body, "mr_owner_config", body.mr_owner_config);
-            parse_claim!(quote_body, "rtmr_0", body.rtmr_0);
-            parse_claim!(quote_body, "rtmr_1", body.rtmr_1);
-            parse_claim!(quote_body, "rtmr_2", body.rtmr_2);
-            parse_claim!(quote_body, "rtmr_3", body.rtmr_3);
-            parse_claim!(quote_body, "report_data", body.report_data);
-
-            parse_claim!(quote_map, "header", quote_header);
-            parse_claim!(quote_map, "body", quote_body);
-        }
-        Quote::V5 {
-            header,
-            r#type,
-            size,
-            body,
-            ..
-        } => {
-            parse_claim!(quote_header, "version", b"\x05\x00");
-            parse_claim!(quote_header, "att_key_type", header.att_key_type);
-            parse_claim!(quote_header, "tee_type", header.tee_type);
-            parse_claim!(quote_header, "reserved", header.reserved);
-            parse_claim!(quote_header, "vendor_id", header.vendor_id);
-            parse_claim!(quote_header, "user_data", header.user_data);
-            parse_claim!(
-                quote_map,
-                "type",
-                match r#type {
-                    QuoteV5Type::TDX10 => 2u16.to_le_bytes(),
-                    QuoteV5Type::TDX15 => 3u16.to_le_bytes(),
-                }
-            );
-            parse_claim!(quote_map, "size", &size[..]);
-            match body {
-                QuoteV5Body::Tdx10(body) => {
-                    parse_claim!(quote_body, "tcb_svn", body.tcb_svn);
-                    parse_claim!(quote_body, "mr_seam", body.mr_seam);
-                    parse_claim!(quote_body, "mrsigner_seam", body.mrsigner_seam);
-                    parse_claim!(quote_body, "seam_attributes", body.seam_attributes);
-                    parse_claim!(quote_body, "td_attributes", body.td_attributes);
-                    parse_claim!(quote_body, "xfam", body.xfam);
-                    parse_claim!(quote_body, "mr_td", body.mr_td);
-                    parse_claim!(quote_body, "mr_config_id", body.mr_config_id);
-                    parse_claim!(quote_body, "mr_owner", body.mr_owner);
-                    parse_claim!(quote_body, "mr_owner_config", body.mr_owner_config);
-                    parse_claim!(quote_body, "rtmr_0", body.rtmr_0);
-                    parse_claim!(quote_body, "rtmr_1", body.rtmr_1);
-                    parse_claim!(quote_body, "rtmr_2", body.rtmr_2);
-                    parse_claim!(quote_body, "rtmr_3", body.rtmr_3);
-                    parse_claim!(quote_body, "report_data", body.report_data);
-
-                    parse_claim!(quote_map, "header", quote_header);
-                    parse_claim!(quote_map, "body", quote_body);
-                }
-                QuoteV5Body::Tdx15(body) => {
-                    parse_claim!(quote_body, "tcb_svn", body.tcb_svn);
-                    parse_claim!(quote_body, "mr_seam", body.mr_seam);
-                    parse_claim!(quote_body, "mrsigner_seam", body.mrsigner_seam);
-                    parse_claim!(quote_body, "seam_attributes", body.seam_attributes);
-                    parse_claim!(quote_body, "td_attributes", body.td_attributes);
-                    parse_claim!(quote_body, "xfam", body.xfam);
-                    parse_claim!(quote_body, "mr_td", body.mr_td);
-                    parse_claim!(quote_body, "mr_config_id", body.mr_config_id);
-                    parse_claim!(quote_body, "mr_owner", body.mr_owner);
-                    parse_claim!(quote_body, "mr_owner_config", body.mr_owner_config);
-                    parse_claim!(quote_body, "rtmr_0", body.rtmr_0);
-                    parse_claim!(quote_body, "rtmr_1", body.rtmr_1);
-                    parse_claim!(quote_body, "rtmr_2", body.rtmr_2);
-                    parse_claim!(quote_body, "rtmr_3", body.rtmr_3);
-                    parse_claim!(quote_body, "report_data", body.report_data);
-
-                    parse_claim!(quote_body, "tee_tcb_svn2", body.tee_tcb_svn2);
-                    parse_claim!(quote_body, "mr_servicetd", body.mr_servicetd);
-
-                    parse_claim!(quote_map, "header", quote_header);
-                    parse_claim!(quote_map, "body", quote_body);
-                }
-            }
-        }
-    }
-
-    let td_attributes = parse_td_attributes(quote.td_attributes())?;
-
-    let mut claims = Map::new();
+    let mut claims = quote.generate_parsed_claim()?;
 
     // Claims from EventLog.
     if let Some(ccel) = cc_eventlog {
@@ -175,44 +27,7 @@ pub fn generate_parsed_claim(
         claims.insert("uefi_event_logs".to_string(), result);
     }
 
-    parse_claim!(claims, "quote", quote_map);
-    parse_claim!(claims, "td_attributes", td_attributes);
-
-    parse_claim!(claims, "report_data", quote.report_data());
-    parse_claim!(claims, "init_data", quote.mr_config_id());
-
-    if let Some(piid) = platform_info.platform_instance_id {
-        parse_claim!(claims, "platform_instance_id", &piid[..]);
-    }
-
     Ok(Value::Object(claims) as TeeEvidenceParsedClaim)
-}
-
-bitflags! {
-    #[derive(Debug, Clone)]
-    struct TdAttributesFlags: u64 {
-        const DEBUG            = 1 << 0;
-        const SEPTVE_DISABLE   = 1 << 28;
-        const PROTECTION_KEYS  = 1 << 30;
-        const KEY_LOCKER       = 1 << 31;
-        const PERFMON          = 1 << 63;
-    }
-}
-
-fn parse_td_attributes(data: &[u8]) -> Result<Map<String, Value>> {
-    let arr = <[u8; 8]>::try_from(data)?;
-    let td = TdAttributesFlags::from_bits_retain(u64::from_le_bytes(arr));
-    let attribs = TdAttributesFlags::FLAGS
-        .iter()
-        .map(|f| {
-            (
-                f.name().to_string().to_lowercase(),
-                Value::Bool(td.contains(f.value().clone())),
-            )
-        })
-        .collect();
-
-    Ok(attribs)
 }
 
 #[cfg(test)]
@@ -292,7 +107,6 @@ mod tests {
     use assert_json_diff::assert_json_eq;
     use serde_json::Value;
 
-    use crate::intel_dcap::pck::parse_platform_info;
     use crate::intel_dcap::quote::parse_quote;
     use crate::tdx::claims::PlatformConfigInfoError;
 
@@ -307,11 +121,7 @@ mod tests {
         let ccel_bin = std::fs::read("./test_data/CCEL_data").expect("read ccel failed");
         let quote = parse_quote(&quote_bin).expect("parse quote");
         let ccel = CcEventLog::try_from(ccel_bin).expect("parse ccel");
-        let platform_info =
-            parse_platform_info(&quote.cert_data().qe_certification_data.certificates)
-                .expect("parse platform info");
-        let claims =
-            generate_parsed_claim(&quote, Some(ccel), &platform_info).expect("parse claim failed");
+        let claims = generate_parsed_claim(&quote, Some(ccel)).expect("parse claim failed");
         let expected_json_str =
             std::fs::read_to_string("./test_data/parse_tdx_claims_expected.json")
                 .expect("read expected json output failed");

--- a/deps/verifier/src/tdx/mod.rs
+++ b/deps/verifier/src/tdx/mod.rs
@@ -8,7 +8,6 @@ use crate::tdx::claims::generate_parsed_claim;
 use super::*;
 use crate::intel_dcap::{
     ecdsa_quote_verification, extend_using_custom_claims,
-    pck::parse_platform_info,
     quote::{parse_quote, Quote},
 };
 use async_trait::async_trait;
@@ -132,9 +131,8 @@ async fn verify_evidence(
         }
     }
     // Return Evidence parsed claim
-    let platform_info = parse_platform_info(&quote.cert_data().qe_certification_data.certificates)?;
 
-    let mut claim = generate_parsed_claim(&quote, ccel_option, &platform_info)?;
+    let mut claim = generate_parsed_claim(&quote, ccel_option)?;
     extend_using_custom_claims(&mut claim, custom_claims)?;
 
     Ok(claim)
@@ -149,21 +147,15 @@ mod tests {
 
     #[test]
     fn test_generate_parsed_claim() {
-        use crate::intel_dcap::pck::parse_platform_info;
-
         let ccel_bin = fs::read("./test_data/CCEL_data").unwrap();
         let ccel = CcEventLog::try_from(ccel_bin).unwrap();
         let quote_bin = fs::read("./test_data/tdx_quote_4.dat").unwrap();
         let quote = parse_quote(&quote_bin).unwrap();
-        let pck_certs = &quote.cert_data().qe_certification_data.certificates;
-        let platform_info = parse_platform_info(pck_certs).unwrap();
-
-        let parsed_claim = generate_parsed_claim(&quote, Some(ccel), &platform_info);
-        assert!(parsed_claim.is_ok());
+        let parsed_claim = generate_parsed_claim(&quote, Some(ccel)).unwrap();
 
         let _ = fs::write(
             "./test_data/evidence_claim_output.txt",
-            format!("{:?}", parsed_claim.unwrap()),
+            format!("{:?}", parsed_claim),
         );
     }
 }


### PR DESCRIPTION
Move SGX/TDX quote field serialization into Quote::generate_parsed_claim so platform_instance_id and td_attributes parsing live in one place. Preserve policy-stable claim layouts (flat SGX header/body, nested TDX quote). Drop duplicate parse_claim macros and per-verifier PCK parsing.

cc @mythi 