### PR TITLE
KBS Protocol | Add PQC algorithm support - Prototype/iss 1271

### DIFF
--- a/.github/workflows/test-rust-ci.yml
+++ b/.github/workflows/test-rust-ci.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         include:
           - instance: ubuntu-24.04
-            test_features: "pkcs11"
+            test_features: "pkcs11,pqc-experimental"
           - instance: ubuntu-24.04-arm
             test_features: "coco-as-builtin,coco-as-grpc,intel-trust-authority-as,cca-attester,pkcs11"
           - instance: s390x-large

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common 0.1.7",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -601,7 +601,7 @@ dependencies = [
  "const_format",
  "crypto",
  "hex",
- "kbs-types",
+ "kbs-types 0.15.0",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -630,7 +630,7 @@ dependencies = [
  "ear",
  "hex",
  "jsonwebtoken",
- "kbs-types",
+ "kbs-types 0.18.0",
  "key-value-storage",
  "mobc",
  "openssl",
@@ -684,7 +684,7 @@ dependencies = [
  "hyper 0.14.32",
  "hyper-tls 0.5.0",
  "iocuddle 0.2.0",
- "kbs-types",
+ "kbs-types 0.15.0",
  "num-traits",
  "nv-attestation-sdk",
  "occlum_dcap",
@@ -1468,7 +1468,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2126,7 +2126,7 @@ dependencies = [
  "base64 0.22.1",
  "concat-kdf",
  "ctr 0.10.1",
- "kbs-types",
+ "kbs-types 0.15.0",
  "openssl",
  "p256",
  "p521",
@@ -2146,7 +2146,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -2158,7 +2158,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -2648,7 +2648,7 @@ dependencies = [
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
- "generic-array",
+ "generic-array 0.14.7",
  "group",
  "hkdf",
  "pem-rfc7468 0.7.0",
@@ -3040,6 +3040,16 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "generic-array"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab9e9188e97a93276e1fe7b56401b851e2b45a46d045ca658100c1303ada649"
+dependencies = [
+ "rustversion",
+ "typenum",
 ]
 
 [[package]]
@@ -3958,7 +3968,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -4326,9 +4336,10 @@ dependencies = [
  "hex",
  "josekit",
  "jsonwebtoken",
- "kbs-types",
+ "kbs-types 0.18.0",
  "key-value-storage",
  "kms",
+ "ml-kem",
  "mobc",
  "openssl",
  "p256",
@@ -4350,6 +4361,7 @@ dependencies = [
  "serde_with",
  "serial_test",
  "sha2 0.11.0",
+ "sha3-kmac",
  "shadow-rs",
  "strum 0.28.0",
  "tempfile",
@@ -4401,6 +4413,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "kbs-types"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4453d70e4a9a7db181a83661803dc296471957d16cb4ddd2af7a52d17eb234cc"
+dependencies = [
+ "base64 0.22.1",
+ "ear",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sm3 0.4.2",
+ "strum 0.27.2",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "kbs_protocol"
 version = "0.1.0"
 source = "git+https://github.com/confidential-containers/guest-components.git?rev=da8d93f2797088a5f0636c8c1eeb31da73784fe8#da8d93f2797088a5f0636c8c1eeb31da73784fe8"
@@ -4411,7 +4439,7 @@ dependencies = [
  "base64 0.22.1",
  "crypto",
  "jwt-simple",
- "kbs-types",
+ "kbs-types 0.15.0",
  "reqwest 0.13.4",
  "resource_uri",
  "serde",
@@ -4428,12 +4456,31 @@ dependencies = [
 
 [[package]]
 name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4766,8 +4813,22 @@ dependencies = [
  "hybrid-array",
  "module-lattice",
  "pkcs8 0.11.0",
- "sha3",
+ "sha3 0.11.0",
  "signature 3.0.0",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -6728,7 +6789,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der 0.7.10",
- "generic-array",
+ "generic-array 0.14.7",
  "pkcs8 0.10.2",
  "subtle",
  "zeroize",
@@ -7059,12 +7120,42 @@ dependencies = [
 
 [[package]]
 name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.3",
- "keccak",
+ "keccak 0.2.0",
+]
+
+[[package]]
+name = "sha3-kmac"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b6b86fb906e40929519c1a38dc349a7f5595778cc00cc20b55eec34fddeb9ec"
+dependencies = [
+ "generic-array 1.4.1",
+ "sha3 0.10.9",
+ "sha3-utils",
+]
+
+[[package]]
+name = "sha3-utils"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08e0bf98cc082cbe077f06a707c94ca15796d046cc4cd2593167b5730a6727be"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -7372,7 +7463,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-util",
- "generic-array",
+ "generic-array 0.14.7",
  "hex",
  "hkdf",
  "hmac 0.12.1",
@@ -8478,7 +8569,7 @@ dependencies = [
  "intel-tee-quote-verification-rs",
  "jsonwebkey 0.4.0",
  "jsonwebtoken",
- "kbs-types",
+ "kbs-types 0.18.0",
  "key-value-storage",
  "openssl",
  "reqwest 0.13.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ educe = "0.7"
 ear = "0.5.0"
 hex = "0.4.3"
 kbs_protocol = { git = "https://github.com/confidential-containers/guest-components.git", rev = "da8d93f2797088a5f0636c8c1eeb31da73784fe8", default-features = false }
-kbs-types = "0.15.0"
+kbs-types = "0.18.0"
 kms = { git = "https://github.com/confidential-containers/guest-components.git", rev = "da8d93f2797088a5f0636c8c1eeb31da73784fe8", default-features = false }
 jsonwebtoken = { version = "10", default-features = false, features = [
     "aws_lc_rs",

--- a/kbs/Cargo.toml
+++ b/kbs/Cargo.toml
@@ -43,8 +43,14 @@ nebula-ca-plugin = []
 # Use HashiCorp Vault KV v1 as KBS backend
 vault = ["vaultrs"]
 
+
 # Use AWS Secrets Manager as KBS resource backend
 aws = ["aws-config", "aws-sdk-secretsmanager"]
+# Experimental Post-Quantum Cryptography support for the resource-response
+# JWE path. Implements draft-ietf-jose-pqc-kem-05 (ML-KEM-768+A192KW). The
+# IETF draft is not finalized and the wire format may change; do not enable
+# in production.
+pqc-experimental = ["dep:ml-kem", "dep:sha3-kmac"]
 
 # Use GCP Secret Manager as KBS resource backend
 gcp = ["google-cloud-secretmanager-v1"]
@@ -111,6 +117,8 @@ uuid = { workspace = true, features = ["serde"] }
 openssl.workspace = true
 az-cvm-vtpm = { version = "0.8.0", default-features = false, optional = true }
 vaultrs = { version = "0.8.0", optional = true }
+ml-kem = { version = "0.3.2", features = ["getrandom"], optional = true }
+sha3-kmac = { version = "0.3.0", optional = true }
 aws-config = { version = "1", features = [
     "behavior-version-latest",
 ], optional = true }

--- a/kbs/Makefile
+++ b/kbs/Makefile
@@ -1,5 +1,6 @@
 AS_TYPE ?= coco-as
 ALIYUN ?= false
+PQC_EXPERIMENTAL ?= false
 NEBULA_CA_PLUGIN ?= false
 VAULT ?= true
 GCP ?= false
@@ -73,6 +74,10 @@ endif
 
 ifeq ($(EXTERNAL_PLUGIN), true)
   override FEATURES := $(FEATURES),external-plugin
+endif
+
+ifeq ($(PQC_EXPERIMENTAL), true)
+  override FEATURES := $(FEATURES),pqc-experimental
 endif
 
 ifeq ($(CLI_FEATURES),sample_only)

--- a/kbs/README.md
+++ b/kbs/README.md
@@ -141,6 +141,16 @@ The KBS can use different backend storage. `LocalFs` will always be builtin.
 are `true` or `false` (by defult). Please refer to [the document](docs/config.md#repository-configuration)
 for more details.
 
+## Experimental Features
+
+PQC algorithm support for the KBS protocol as a replacement for classic cryptographic methods is provided here as an experimental compile-time feature. These can be enabled by building with the additional [PQC_EXPERIMENTAL=?] parameter set as required, e.g.
+
+```shell
+PQC_EXPERIMENTAL=true make
+```
+
+**Please note, enabling this feature extends support for the designated PQC algorithm, but will still support classic algorithms. However enabling this feature in guest components will require the feature to be enabled here to support resource requests with the new TeePubKey::AKP type.**
+
 ## References
 
 ### Attestation Protocol

--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -457,6 +457,7 @@ pub(crate) async fn api(
                     .map_err(|e| Error::PluginInternalError { source: e })?
                 {
                     let public_key = core.token_verifier.extract_tee_public_key(claims)?;
+
                     let jwe =
                         jwe(public_key, response).map_err(|e| Error::JweError { source: e })?;
                     let res = serde_json::to_string(&jwe)?;

--- a/kbs/src/jwe/akp.rs
+++ b/kbs/src/jwe/akp.rs
@@ -1,0 +1,219 @@
+// Copyright (c) 2026 Trustee contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Experimental Post-Quantum Cryptography extension for the KBS
+//! resource-response JWE path.
+//!
+//! Implements `ML-KEM-768+A192KW` per draft-ietf-jose-pqc-kem-05.
+//!
+//! Wire format is not finalized — the IETF draft is in WG-adopted
+//! Standards Track but not yet RFC. The KDF FixedInfo encoding (X input
+//! to KMAC256) is underspecified by the draft; we follow the RFC 7518
+//! §4.6.2 ConcatKDF precedent, omitting PartyUInfo/PartyVInfo as the PQ
+//! draft directs. Verify against reference implementations and test
+//! vectors when those emerge.
+
+use aes_gcm::{
+    aead::{AeadInOut, Generate},
+    Aes256Gcm, KeyInit, Nonce,
+};
+use aes_kw::KwAes192;
+use anyhow::{anyhow, bail, Context, Result};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use kbs_types::{ProtectedHeader, Response};
+use ml_kem::{Encapsulate, EncapsulationKey, Key, MlKem768};
+use serde_json::{Map, Value};
+use sha3_kmac::Kmac256;
+use zeroize::Zeroizing;
+
+/// `kty` value for the Algorithm Key Pair (AKP) key type per
+/// draft-ietf-jose-pqc-kem-05 §10.
+pub const AKP_KTY: &str = "AKP";
+
+/// Algorithm identifier for ML-KEM-768 with AES-192 key wrap.
+pub const ML_KEM_768_A192KW_ALGORITHM: &str = "ML-KEM-768+A192KW";
+
+/// AES-256-GCM content encryption, matches existing classical paths.
+const AES_GCM_256_ALGORITHM: &str = "A256GCM";
+
+/// ML-KEM-768 encapsulation-key length in bytes (FIPS 203).
+const ML_KEM_768_ENCAP_KEY_LEN: usize = 1184;
+
+/// KMAC256-based KDF per draft-ietf-jose-pqc-kem-05 §5.1.
+///
+/// `KMAC256(K = shared_secret, X = AlgorithmID || SuppPubInfo,
+///          L = out_len_bytes·8 bits, S = "")`
+///
+/// AlgorithmID = 4-byte BE length(alg) || alg.
+/// SuppPubInfo = 4-byte BE keydatalen-in-bits.
+/// PartyUInfo / PartyVInfo are intentionally excluded per the draft.
+fn kmac256_kdf(shared_secret: &[u8], alg: &str, out_len_bytes: usize) -> Result<Vec<u8>> {
+    let alg_bytes = alg.as_bytes();
+    let alg_len = (alg_bytes.len() as u32).to_be_bytes();
+    let keydatalen_bits = ((out_len_bytes * 8) as u32).to_be_bytes();
+
+    let mut x = Vec::with_capacity(4 + alg_bytes.len() + 4);
+    x.extend_from_slice(&alg_len);
+    x.extend_from_slice(alg_bytes);
+    x.extend_from_slice(&keydatalen_bits);
+
+    let mut kmac =
+        Kmac256::new(shared_secret, b"").map_err(|e| anyhow!("KMAC256 init failed: {e:?}"))?;
+    kmac.update(&x);
+    let mut out = vec![0u8; out_len_bytes];
+    kmac.finalize_into(&mut out);
+    Ok(out)
+}
+
+/// Encrypt `payload_data` for an AKP/ML-KEM-768 recipient per
+/// draft-ietf-jose-pqc-kem-05.
+pub fn ml_kem_768_a192kw(pub_key_b64: &str, mut payload_data: Vec<u8>) -> Result<Response> {
+    // 1. Decode and parse the recipient's encapsulation key.
+    let pub_key_bytes = URL_SAFE_NO_PAD
+        .decode(pub_key_b64)
+        .context("base64 decode AKP pub_key failed")?;
+    if pub_key_bytes.len() != ML_KEM_768_ENCAP_KEY_LEN {
+        bail!(
+            "ML-KEM-768 encapsulation key has wrong length: got {}, expected {}",
+            pub_key_bytes.len(),
+            ML_KEM_768_ENCAP_KEY_LEN,
+        );
+    }
+    let ek_typed: &Key<EncapsulationKey<MlKem768>> = pub_key_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow!("ML-KEM-768 encapsulation key array conversion failed"))?;
+    let encap_key = EncapsulationKey::<MlKem768>::new(ek_typed)
+        .map_err(|e| anyhow!("invalid ML-KEM-768 encapsulation key: {e:?}"))?;
+
+    // 2. Encapsulate → (KEM ciphertext, 32-byte shared secret). Uses OS RNG
+    // internally (ml-kem `getrandom` feature).
+    let (kem_ciphertext, shared_secret) = encap_key.encapsulate();
+
+    // 3. Derive the 24-byte AES-192 wrapping key from the shared secret.
+    let kwk = kmac256_kdf(shared_secret.as_slice(), ML_KEM_768_A192KW_ALGORITHM, 24)?;
+    let kwk: [u8; 24] = kwk
+        .try_into()
+        .map_err(|_| anyhow!("KDF output not 24 bytes"))?;
+
+    // 4. Generate a 32-byte CEK and wrap it under the KWK.
+    let cek = Zeroizing::new(<[u8; 32]>::generate());
+    let wrapper = KwAes192::new(&kwk.into());
+    let mut encrypted_key = vec![0u8; 40]; // 32-byte CEK + 8-byte AES-KW integrity check
+    wrapper
+        .wrap_key(cek.as_slice(), &mut encrypted_key)
+        .map_err(|e| anyhow!("AES-KW failed: {e:?}"))?;
+
+    // 5. Protected header carries the KEM ciphertext in the `ek` parameter
+    // per draft-ietf-jose-pqc-kem §6.2.
+    let ek_b64 = URL_SAFE_NO_PAD.encode(kem_ciphertext.as_slice());
+    let mut other_fields = Map::new();
+    other_fields.insert("ek".to_string(), Value::String(ek_b64));
+    let protected = ProtectedHeader {
+        alg: ML_KEM_768_A192KW_ALGORITHM.to_string(),
+        enc: AES_GCM_256_ALGORITHM.to_string(),
+        other_fields,
+    };
+
+    // 6. Encrypt payload with AES-256-GCM under the CEK; AAD per RFC 7516.
+    let cipher = Aes256Gcm::new_from_slice(cek.as_slice())
+        .map_err(|e| anyhow!("invalid AES key length: {e}"))?;
+    let iv = <[u8; 12]>::generate();
+    let nonce = Nonce::from(iv);
+    let aad = protected.generate_aad().context("Generate JWE AAD")?;
+    let tag = cipher
+        .encrypt_inout_detached(&nonce, &aad, payload_data.as_mut_slice().into())
+        .map_err(|e| anyhow!("AES-GCM encrypt failed: {e}"))?;
+
+    Ok(Response {
+        protected,
+        encrypted_key,
+        iv: iv.into(),
+        ciphertext: payload_data,
+        aad: None,
+        tag: tag.to_vec(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kbs_types::TeePubKey;
+    use ml_kem::{kem::KeyExport, Decapsulate, Kem};
+
+    #[test]
+    fn ml_kem_768_a192kw_roundtrip() {
+        // Fresh ML-KEM-768 keypair.
+        let (decap_key, encap_key) = MlKem768::generate_keypair();
+        let pub_key_b64 = URL_SAFE_NO_PAD.encode(encap_key.to_bytes());
+
+        let payload = b"hello post-quantum world".to_vec();
+        let response = ml_kem_768_a192kw(&pub_key_b64, payload.clone()).expect("encrypt");
+
+        // Recipient: pull KEM ciphertext out of `ek`, decapsulate, derive KWK,
+        // unwrap CEK, decrypt payload.
+        let ek_b64 = response
+            .protected
+            .other_fields
+            .get("ek")
+            .and_then(|v| v.as_str())
+            .expect("ek header present");
+        let kem_ct_bytes = URL_SAFE_NO_PAD.decode(ek_b64).expect("decode ek");
+        let shared_secret = decap_key
+            .decapsulate_slice(&kem_ct_bytes)
+            .expect("decapsulate");
+
+        let kwk =
+            kmac256_kdf(shared_secret.as_slice(), ML_KEM_768_A192KW_ALGORITHM, 24).expect("kdf");
+        let kwk: [u8; 24] = kwk.try_into().unwrap();
+        let unwrapper = KwAes192::new(&kwk.into());
+        let mut cek = vec![0u8; 32];
+        unwrapper
+            .unwrap_key(&response.encrypted_key, &mut cek)
+            .expect("unwrap CEK");
+
+        let cipher = Aes256Gcm::new_from_slice(&cek).expect("build cipher");
+        let nonce = Nonce::try_from(response.iv.as_slice()).expect("nonce length");
+        let aad = response.protected.generate_aad().expect("aad");
+        let mut buf = response.ciphertext.clone();
+        let tag = response.tag.as_slice().try_into().expect("tag length");
+        cipher
+            .decrypt_inout_detached(&nonce, &aad, buf.as_mut_slice().into(), tag)
+            .expect("decrypt payload");
+
+        assert_eq!(buf, payload);
+    }
+
+    #[test]
+    fn protected_header_carries_ek_and_correct_alg() {
+        let (_decap_key, encap_key) = MlKem768::generate_keypair();
+        let pub_key_b64 = URL_SAFE_NO_PAD.encode(encap_key.to_bytes());
+        let response = ml_kem_768_a192kw(&pub_key_b64, b"x".to_vec()).expect("encrypt");
+        assert_eq!(response.protected.alg, ML_KEM_768_A192KW_ALGORITHM);
+        assert_eq!(response.protected.enc, AES_GCM_256_ALGORITHM);
+        assert!(response.protected.other_fields.contains_key("ek"));
+    }
+
+    #[test]
+    fn rejects_wrong_length_pub_key() {
+        let bad = URL_SAFE_NO_PAD.encode([0u8; 100]);
+        let err = ml_kem_768_a192kw(&bad, b"x".to_vec()).expect_err("should reject");
+        assert!(err.to_string().contains("wrong length"));
+    }
+
+    #[test]
+    fn akp_pub_key_deserializes_from_jwk() {
+        let json = serde_json::json!({
+            "kty": "AKP",
+            "alg": "ML-KEM-768+A192KW",
+            "pub": "AAAAAAAAAAAAAAAAAA",
+        });
+        let key: TeePubKey = serde_json::from_value(json).expect("deserialize");
+        let TeePubKey::AKP { alg, public_key } = key else {
+            panic!("expected AKP variant");
+        };
+        assert_eq!(alg, ML_KEM_768_A192KW_ALGORITHM);
+        assert_eq!(public_key, "AAAAAAAAAAAAAAAAAA");
+    }
+}

--- a/kbs/src/jwe/mod.rs
+++ b/kbs/src/jwe/mod.rs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "pqc-experimental")]
+pub mod akp;
+
 use core::{clone::Clone, convert::TryInto};
 
 use aes_gcm::{
@@ -341,6 +344,17 @@ pub fn jwe(tee_pub_key: TeePubKey, payload_data: Vec<u8>) -> Result<Response> {
             (P256_CURVE, ECDH_ES_A256KW) => ecdh_es_a256kw_p256(x, y, payload_data),
             (P521_CURVE, ECDH_ES_A256KW) => ecdh_es_a256kw_p521(x, y, payload_data),
             (crv, alg) => bail!("curve {crv} and algorithm {alg} is not supported"),
+        },
+
+        TeePubKey::AKP {
+            alg,
+            public_key: _public_key,
+        } => match &alg[..] {
+            #[cfg(feature = "pqc-experimental")]
+            akp::ML_KEM_768_A192KW_ALGORITHM => akp::ml_kem_768_a192kw(&_public_key, payload_data),
+            others => {
+                bail!("pqc-experimental feature not enabled or algorithm {others} is not supported")
+            }
         },
     }
 }


### PR DESCRIPTION
This is the initial draft implementation to enable PQC algorithm support across CoCo. These changes reflect those required on the Trustee side, and is enabled via a compile time feature flag.