### PR TITLE
Add service health endpoints and harden gRPC/HTTP client robustness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,7 @@ dependencies = [
  "tokio",
  "toml",
  "tonic",
+ "tonic-health",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -5848,6 +5849,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tonic",
+ "tonic-health",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -7702,6 +7704,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -7809,6 +7812,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ff0636fef47afb3ec02818f5bceb4377b8abb9d6a386aeade18bd6212f8eb7"
+dependencies = [
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ tokio = { version = "1", features = ["full"], default-features = false }
 toml = "1.1.2"
 tempfile = "3.27.0"
 tonic = { version = "0.14", features = ["tls-webpki-roots"] }
+tonic-health = "0.14"
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
 rsa = { version = "0.9.10", features = ["sha2"] }

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -21,7 +21,7 @@ tpm-verifier = ["verifier/tpm-verifier"]
 rvps-grpc = ["prost", "tonic", "mobc"]
 
 # For building gRPC CoCo-AS binary
-grpc-bin = ["clap", "prost", "tonic", "tonic-prost"]
+grpc-bin = ["clap", "prost", "tonic", "tonic-health", "tonic-prost"]
 
 # For restful CoCo-AS binary
 restful-bin = ["actix-cors", "actix-web/openssl", "clap"]
@@ -66,6 +66,7 @@ thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true
 tonic = { workspace = true, optional = true }
+tonic-health = { workspace = true, optional = true }
 tonic-prost = { workspace = true, optional = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/attestation-service/src/bin/grpc/mod.rs
+++ b/attestation-service/src/bin/grpc/mod.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 use tokio::sync::RwLock;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
+use tonic_health::server::health_reporter;
 use tracing::{debug, info, instrument, Span};
 use uuid::Uuid;
 
@@ -317,7 +318,13 @@ pub async fn start(socket: SocketAddr, config_path: Option<String>) -> Result<()
 
     let attestation_server = Arc::new(RwLock::new(AttestationServer::new(config_path).await?));
 
+    let (health_reporter, health_service) = health_reporter();
+    health_reporter
+        .set_serving::<AttestationServiceServer<Arc<RwLock<AttestationServer>>>>()
+        .await;
+
     Server::builder()
+        .add_service(health_service)
         .add_service(AttestationServiceServer::new(attestation_server.clone()))
         .add_service(ReferenceValueProviderServiceServer::new(attestation_server))
         .serve(socket)

--- a/attestation-service/src/ear_token/broker.rs
+++ b/attestation-service/src/ear_token/broker.rs
@@ -194,13 +194,16 @@ impl EarAttestationTokenBroker {
 
                         let rvps_client = rvps_client.clone();
                         let reference_value_id = params[0].as_string()?.to_string();
+                        // Capture the current (main) runtime handle *before* spawning
+                        // the thread. Using the main runtime's handle ensures that
+                        // pool.get() and the tonic I/O operations run in the same
+                        // runtime context where the mobc pool and gRPC channels were
+                        // created. Creating a new isolated runtime here causes pool
+                        // futures and I/O wakeups to be delivered on the wrong reactor,
+                        // making pool.get() hang indefinitely.
+                        let rt_handle = tokio::runtime::Handle::current();
                         let handle = thread::spawn(move || {
-                            let rt = tokio::runtime::Builder::new_current_thread()
-                                .enable_all()
-                                .build()
-                                .expect("failed to build runtime");
-
-                            rt.block_on(async move {
+                            rt_handle.block_on(async move {
                                 tokio::time::timeout(
                                     Duration::from_secs(10),
                                     fut(rvps_client, reference_value_id),

--- a/attestation-service/src/rvps/grpc.rs
+++ b/attestation-service/src/rvps/grpc.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use mobc::{Manager, Pool};
 use serde::Deserialize;
 use serde_json::Value;
@@ -30,6 +32,30 @@ fn default_address() -> String {
 /// The default pool size for the RVPS client.
 const DEFAULT_RVPS_POOL_SIZE: u64 = 10;
 
+/// Drop and re-establish a pooled connection once it has been idle for this
+/// long, so a connection that died silently while idle is recycled instead of
+/// being handed out to the next query.
+const RVPS_CONN_MAX_IDLE_LIFETIME: Duration = Duration::from_secs(30);
+
+/// Send an HTTP/2 keep-alive ping after this much inactivity on a pooled
+/// connection, so a broken connection is noticed promptly rather than on the
+/// next (possibly much later) query.
+const RVPS_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// How long to wait for a keep-alive ping acknowledgement before treating the
+/// connection as dead.
+const RVPS_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Time budget for the on-checkout connection health probe. It runs on every
+/// pool.get() and only needs a local round-trip to RVPS, so it is kept short.
+const RVPS_HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Placeholder reference-value key used to probe connection liveness. RVPS
+/// returns Ok(None) for an unknown key, which confirms the connection is live
+/// without triggering an "Is a directory" error that would otherwise force an
+/// unnecessary reconnect on every pool.get() call.
+const RVPS_HEALTH_CHECK_KEY: &str = "__healthcheck__";
+
 pub struct Agent {
     pool: Pool<GrpcManager>,
 }
@@ -50,6 +76,7 @@ impl Agent {
         let manager = GrpcManager { address };
         let pool = Pool::builder()
             .max_open(DEFAULT_RVPS_POOL_SIZE)
+            .max_idle_lifetime(Some(RVPS_CONN_MAX_IDLE_LIFETIME))
             .build(manager);
 
         // the mobc Pool builder does not establish an actual connection,
@@ -100,7 +127,14 @@ impl Manager for GrpcManager {
     type Error = anyhow::Error;
 
     async fn connect(&self) -> std::result::Result<Self::Connection, Self::Error> {
+        // Called for the initial connection and whenever the pool replaces a
+        // connection that failed check() below, so this is the single place
+        // that observes every (re)connection to RVPS.
+        debug!("establishing RVPS gRPC connection to {}", self.address);
         let channel = Channel::from_shared(self.address.clone())?
+            .keep_alive_while_idle(true)
+            .http2_keep_alive_interval(RVPS_KEEP_ALIVE_INTERVAL)
+            .keep_alive_timeout(RVPS_KEEP_ALIVE_TIMEOUT)
             .connect()
             .await?;
         Ok(ReferenceValueProviderServiceClient::new(channel))
@@ -110,6 +144,16 @@ impl Manager for GrpcManager {
         &self,
         conn: Self::Connection,
     ) -> std::result::Result<Self::Connection, Self::Error> {
-        Ok(conn)
+        let mut c = conn;
+        let req = tonic::Request::new(ReferenceValueQueryRequest {
+            reference_value_id: RVPS_HEALTH_CHECK_KEY.to_string(),
+        });
+        // We only report whether the connection is still usable; the pool is
+        // responsible for discarding it and calling connect() to replace it.
+        match tokio::time::timeout(RVPS_HEALTH_CHECK_TIMEOUT, c.query_reference_value(req)).await {
+            Ok(Ok(_)) => Ok(c),
+            Ok(Err(e)) => Err(anyhow::anyhow!("stale connection: {e}")),
+            Err(_) => Err(anyhow::anyhow!("RVPS health check timed out")),
+        }
     }
 }

--- a/deps/verifier/src/nvidia/mod.rs
+++ b/deps/verifier/src/nvidia/mod.rs
@@ -39,6 +39,12 @@ pub const DMTF_MEASUREMENT_SPECIFICATION_VALUE: u8 = 1;
 /// Using Trustee with the NRAS remote verifier assumes that you have done this.
 pub const NRAS_URL: &str = "https://nras.attestation.nvidia.com/v4/attest";
 
+/// Timeout for a single NRAS attestation request. The remote service performs
+/// non-trivial verification work on the submitted evidence, so this is more
+/// generous than a plain document fetch; it only guards against an unreachable
+/// or wedged endpoint hanging the verifier indefinitely.
+const NRAS_ATTESTATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 #[derive(Default, Debug)]
 pub struct Nvidia {
     verifier_type: NvidiaVerifierType,
@@ -268,8 +274,9 @@ impl Nvidia {
             "claims_version": "3.0"
         });
 
-        // We can reuse this client for multiple requests, but for now create a new one.
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(NRAS_ATTESTATION_TIMEOUT)
+            .build()?;
         let res = client.post(request_url).json(&request_json).send().await?;
 
         if !res.status().is_success() {

--- a/deps/verifier/src/nvidia/nras_jwks.rs
+++ b/deps/verifier/src/nvidia/nras_jwks.rs
@@ -10,6 +10,11 @@ use jsonwebtoken::jwk::{Jwk, JwkSet};
 /// Using Trustee with the NRAS remote verifier assumes that you have done this.
 pub const NRAS_JWKS_URL: &str = "https://nras.attestation.nvidia.com/.well-known/jwks.json";
 
+/// Timeout for fetching the NRAS JWKS. Unlike an attestation request this is
+/// just a small, static document download with no server-side work, so a
+/// tighter budget than NRAS_ATTESTATION_TIMEOUT is sufficient.
+const NRAS_JWKS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 #[derive(Clone, Debug)]
 pub struct NrasJwks {
     // Mapping of Key Ids to JWKs
@@ -18,7 +23,10 @@ pub struct NrasJwks {
 
 impl NrasJwks {
     pub async fn new() -> Result<Self> {
-        let res = reqwest::get(NRAS_JWKS_URL).await?;
+        let client = reqwest::Client::builder()
+            .timeout(NRAS_JWKS_TIMEOUT)
+            .build()?;
+        let res = client.get(NRAS_JWKS_URL).send().await?;
 
         if !res.status().is_success() {
             bail!(

--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -180,6 +180,7 @@ impl ApiServer {
                             .route(web::get().to(prometheus_metrics_handler))
                             .route(web::post().to(|| HttpResponse::MethodNotAllowed())),
                     )
+                    .route("/healthz", web::get().to(HttpResponse::Ok))
             }
         });
 

--- a/kbs/src/attestation/coco/grpc.rs
+++ b/kbs/src/attestation/coco/grpc.rs
@@ -32,6 +32,12 @@ mod attestation {
 pub const DEFAULT_AS_ADDR: &str = "http://127.0.0.1:50004";
 pub const DEFAULT_POOL_SIZE: u64 = 100;
 
+/// Upper bound on a single KBS->AS gRPC request. TEE evidence verification
+/// (notably Intel TDX DCAP, which fetches collateral over the network) can be
+/// legitimately slow, so this is deliberately generous; it exists only to keep
+/// a silently wedged connection from blocking a request forever.
+const AS_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct GrpcConfig {
     #[serde(default = "default_as_addr")]
@@ -239,6 +245,7 @@ impl Manager for GrpcManager {
 
     async fn connect(&self) -> Result<Self::Connection, Self::Error> {
         let connection = Channel::from_shared(self.as_addr.clone())?
+            .timeout(AS_REQUEST_TIMEOUT)
             .connect()
             .await?;
         let as_rpc = AttestationServiceClient::new(connection.clone());

--- a/rvps/Cargo.toml
+++ b/rvps/Cargo.toml
@@ -39,6 +39,7 @@ strum.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tonic.workspace = true
+tonic-health.workspace = true
 tonic-prost.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, optional = true }

--- a/rvps/src/server/mod.rs
+++ b/rvps/src/server/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
+use tonic_health::server::health_reporter;
 use tracing::{debug, info};
 
 use crate::{Config, Rvps};
@@ -80,7 +81,13 @@ pub async fn start(socket: SocketAddr, config: Config) -> Result<()> {
     let inner = Arc::new(RwLock::new(service));
     let rvps_server = RvpsServer::new(inner.clone());
 
+    let (health_reporter, health_service) = health_reporter();
+    health_reporter
+        .set_serving::<ReferenceValueProviderServiceServer<RvpsServer>>()
+        .await;
+
     Server::builder()
+        .add_service(health_service)
         .add_service(ReferenceValueProviderServiceServer::new(rvps_server))
         .serve(socket)
         .await


### PR DESCRIPTION
This series makes the Trustee services more observable and more resilient
when run as long-lived deployments behind an orchestrator.

It adds standard health endpoints so liveness/readiness probes can be wired
up, and fixes a handful of robustness issues in the inter-service gRPC and
the outbound HTTP clients that can otherwise cause requests to hang
indefinitely.

These changes are independent of any particular deployment method and are
sent ahead of the Helm chart work so they can be reviewed on their own.

1. **serviceability: add health and readiness endpoints to AS, RVPS and KBS**
   The attestation-service and rvps gRPC servers now register the standard
   gRPC Health service (via `tonic-health`) and report `SERVING` once ready,
   and KBS gains a lightweight `GET /healthz` HTTP route. This lets external
   orchestrators detect a wedged or still-initialising service and restart it.

2. **attestation-service: query RVPS from the runtime that owns the pool**
   The reference-value lookup ran on a helper thread that spun up its own
   current-thread runtime, while the mobc pool and its gRPC channels live on
   the main multi-threaded runtime. Driving `pool.get()` from an unrelated
   runtime delivered wakeups to the wrong reactor and could hang the request
   forever. The query now runs on the handle of the runtime that owns the pool.

3. **attestation-service: recycle stale RVPS gRPC connections**
   Long-lived pooled connections to RVPS could be silently torn down, making
   later queries hang or fail. The channel now uses HTTP/2 keep-alive and a
   capped idle lifetime, and each pooled connection is validated on checkout
   with a short, time-bounded health query before use.

4. **kbs: bound the lifetime of requests on the AS gRPC channel**
   The KBS→AS channel had no timeout. Evidence verification can be slow
   (notably Intel TDX DCAP), but with no upper bound a wedged connection would
   block a request indefinitely. A generous 300s timeout covers the slow path
   while ensuring stuck requests fail cleanly.

5. **verifier: bound NVIDIA NRAS HTTP requests with timeouts**
   The NVIDIA verifier's attestation POST and JWKS fetch used a default
   `reqwest` client with no timeout, so an unreachable NRAS could hang the
   verifier. Explicit timeouts are now set (60s attestation, 30s JWKS).