### PR TITLE
AS: remove simple token warning

### DIFF
--- a/attestation-service/src/ear_token/broker.rs
+++ b/attestation-service/src/ear_token/broker.rs
@@ -49,9 +49,6 @@ impl EarAttestationTokenBroker {
         config: EarTokenConfiguration,
         storage: KeyValueStorageInstance,
     ) -> Result<Self> {
-        // TODO: delete this warning
-        warn!("Simple Token has been deprecated in v0.16.0. Note that the `attestation_token_broker` config field `type` is now ignored and the token will always be an EAR token.");
-
         let policy_engine = PolicyEngine::<Regorus>::new(storage);
 
         let default_cpu_policy = include_str!("ear_default_policy_cpu.rego");


### PR DESCRIPTION
Simple token has been removed since 0.16.0, and it's good to remove the warning for now.