### PR TITLE
AS: add issuer to ear claims

### DIFF
--- a/attestation-service/src/ear_token/broker.rs
+++ b/attestation-service/src/ear_token/broker.rs
@@ -328,6 +328,9 @@ impl EarAttestationTokenBroker {
         extensions.register("exp", 4, RawValueKind::Integer)?;
         extensions.set_by_name("exp", RawValue::Integer(exp.unix_timestamp()))?;
 
+        extensions.register("iss", 1, RawValueKind::String)?;
+        extensions.set_by_name("iss", RawValue::String(self.config.issuer_name.clone()))?;
+
         let ear = Ear {
             profile: self.config.profile_name.clone(),
             iat: now.unix_timestamp(),


### PR DESCRIPTION
The issuer_name in the attestation token configuration has not been used for EAR up to now. This patch adds an `iss` field in the claims of the ear. This follows RFC7519 about " JSON Web Token (JWT) " where `iss` is a registered claim.