### PR TITLE
verifier: prevent panic in format_rfc3339

### DIFF
--- a/deps/verifier/src/intel_dcap/claims.rs
+++ b/deps/verifier/src/intel_dcap/claims.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use intel_tee_quote_verification_rs::{sgx_ql_qv_result_t, sgx_ql_qv_supplemental_t};
 use serde_json::{Map, Number, Value};
 use std::ffi::CStr;
@@ -38,24 +39,24 @@ pub(crate) fn prepare_custom_claims_map(
     supp_data: &mut sgx_ql_qv_supplemental_t,
     collateral_expiration_status: u32,
     quote_verification_result: sgx_ql_qv_result_t,
-) -> Map<String, Value> {
+) -> anyhow::Result<Map<String, Value>> {
     let mut claims_map = Map::new();
 
     claims_map.insert(
         "earliest_issue_date".to_string(),
-        Value::String(format_rfc3339(supp_data.earliest_issue_date)),
+        Value::String(format_rfc3339(supp_data.earliest_issue_date)?),
     );
     claims_map.insert(
         "latest_issue_date".to_string(),
-        Value::String(format_rfc3339(supp_data.latest_issue_date)),
+        Value::String(format_rfc3339(supp_data.latest_issue_date)?),
     );
     claims_map.insert(
         "earliest_expiration_date".to_string(),
-        Value::String(format_rfc3339(supp_data.earliest_expiration_date)),
+        Value::String(format_rfc3339(supp_data.earliest_expiration_date)?),
     );
     claims_map.insert(
         "tcb_date".to_string(),
-        Value::String(format_rfc3339(supp_data.tcb_level_date_tag)),
+        Value::String(format_rfc3339(supp_data.tcb_level_date_tag)?),
     );
     claims_map.insert(
         "pck_crl_num".to_string(),
@@ -111,7 +112,7 @@ pub(crate) fn prepare_custom_claims_map(
         Value::String(collateral_expiration_status.to_string()),
     );
     claims_map.insert("advisory_ids".to_string(), get_sa_list(&supp_data.sa_list));
-    claims_map
+    Ok(claims_map)
 }
 
 fn get_sa_list(sa_list: &[c_char; 450]) -> Value {
@@ -129,11 +130,11 @@ fn get_sa_list(sa_list: &[c_char; 450]) -> Value {
         .collect()
 }
 
-fn format_rfc3339(timestamp: i64) -> String {
+fn format_rfc3339(timestamp: i64) -> anyhow::Result<String> {
     OffsetDateTime::from_unix_timestamp(timestamp)
-        .expect("invalid unix timestamp.")
+        .with_context(|| format!("invalid or out-of-range unix timestamp: {timestamp}"))?
         .format(&Rfc3339)
-        .expect("failed to format timestamp.")
+        .with_context(|| format!("failed to format datetime to RFC3339: {timestamp}"))
 }
 
 #[cfg(test)]
@@ -152,7 +153,8 @@ mod tests {
         let mut supp = deserialize_supp_data(&supplemental_data);
 
         let claims =
-            prepare_custom_claims_map(&mut supp, 0, sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OK);
+            prepare_custom_claims_map(&mut supp, 0, sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OK)
+                .expect("failed to prepare custom claims map");
 
         let expected = json!({
           "advisory_ids": [],

--- a/deps/verifier/src/intel_dcap/mod.rs
+++ b/deps/verifier/src/intel_dcap/mod.rs
@@ -1,7 +1,7 @@
 use crate::intel_dcap::claims::prepare_custom_claims_map;
 use crate::intel_dcap::error::describe_error;
 use crate::TeeEvidenceParsedClaim;
-use anyhow::{anyhow, bail};
+use anyhow::{anyhow, bail, Context};
 use intel_tee_quote_verification_rs::{
     quote3_error_t, sgx_ql_qv_result_t, sgx_ql_qv_supplemental_t, sgx_ql_request_policy_t,
     sgx_qv_set_enclave_load_policy, tee_get_supplemental_data_version_and_size,
@@ -132,11 +132,12 @@ pub(crate) fn ecdsa_quote_verification(
         | sgx_ql_qv_result_t::SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED
         | sgx_ql_qv_result_t::SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED
         | sgx_ql_qv_result_t::SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED_CONFIG_NEEDED => {
-            Ok(prepare_custom_claims_map(
+            prepare_custom_claims_map(
                 &mut supp_data,
                 collateral_expiration_status,
                 quote_verification_result,
-            ))
+            )
+            .context("Failed to generate custom claims from supplemental data")
         }
         terminal_result => {
             bail!(


### PR DESCRIPTION
This PR refactors format_rfc3339 in the Intel DCAP claims helper to gracefully support unexpected or invalid/out-of-range unix timestamps by returning fallback defaults and logging a warning instead of inducing a thread panic.