### PR TITLE
kbs: resolve trusted JWKS via direct URL or OpenID discovery, with opt-in HTTP

### DIFF
--- a/kbs/docs/admin.md
+++ b/kbs/docs/admin.md
@@ -85,12 +85,16 @@ Each `identity_providers` entry:
 - `issuer` (optional string): expected JWT `iss` value; empty means no issuer check
 - `audience` (optional string): expected JWT `aud` value; empty means no audience check
 - `public_key_uri` (optional string): PEM public key source
-- `jwk_set_uri` (optional string): JWKS source
+- `jwk_set_uri` (optional string): trusted JWKS source (see formats below)
 
 Each entry must provide at least one of `public_key_uri` or `jwk_set_uri`.
 
-Supported source formats:
+`jwk_set_uri` formats:
 
-- `https://...` (remote fetch)
-- `file://...` (local file URI)
-- local path without scheme (for example `./keys/admin.pem`)
+- `file://...` or local path (for example `./keys/admin.jwks`): JWKS JSON file, read directly
+- `https://...`: remote JWKS URL or OpenID issuer base URL (see note below)
+
+> [!NOTE]
+> For remote `jwk_set_uri` values, KBS first tries to load JWKS from the configured URL
+> directly (for example a `/jwks/` endpoint). If that fails, it falls back to OpenID discovery
+> at `{uri}/.well-known/openid-configuration` and loads keys from the returned `jwks_uri`.

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -114,7 +114,7 @@ The following properties can be set under the `[attestation_token]` section.
 
 | Property              | Type         | Description                                                                                                                       | Default |
 |-----------------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------|---------|
-| `trusted_jwk_sets`    | String Array | Trusted JWKS/OpenID sources (`file://` or `https://`) used to verify attestation tokens                                         | Empty   |
+| `trusted_jwk_sets`    | String Array | Trusted JWKS sources (`file://` or `https://`). Loads JWKS directly when possible, otherwise via OpenID discovery. The keys are used to verify attestation tokens.               | Empty   |
 | `trusted_certs_paths` | String Array | Trusted Certificates file (PEM format) for Attestation Tokens trustworthy verification                                            | Empty   |
 | `extra_teekey_paths`  | String Array | User defined paths to the tee public key in the JWT body                                                                          | Empty   |
 | `insecure_header_jwk`        | Boolean      | Skip `x5c`/`trusted_certs_paths` endorsement for a JWK in the JWT header; signature is still verified | `false` |
@@ -281,7 +281,7 @@ Each `identity_providers` item:
 | `issuer` | String | Expected JWT `iss` value (leave empty to skip issuer check) | No |
 | `audience` | String | Expected JWT `aud` value (leave empty to skip audience check) | No |
 | `public_key_uri` | String | PEM public key source (`https://`, `file://`, local path) | No* |
-| `jwk_set_uri` | String | JWKS source (`https://`, `file://`, or local path) | No* |
+| `jwk_set_uri` | String | JWKS source (`https://`, `file://`, or local path). Remote `https://` URLs load JWKS directly when possible, otherwise via OpenID discovery. | No* |
 
 \* At least one of `public_key_uri` or `jwk_set_uri` is required.
 

--- a/kbs/src/crypto/jwk.rs
+++ b/kbs/src/crypto/jwk.rs
@@ -7,7 +7,7 @@ use reqwest::{get, Url};
 use serde::Deserialize;
 use std::fs;
 use thiserror::Error;
-use tracing::info;
+use tracing::{debug, info};
 
 pub(crate) const OPENID_CONFIG_URL_SUFFIX: &str = ".well-known/openid-configuration";
 
@@ -29,38 +29,15 @@ pub(crate) struct OpenIDConfig {
     jwks_uri: String,
 }
 
+/// Load a JWK set from a configured source.
+///
+/// - `file://` and local paths: JWKS JSON file, read directly.
+/// - `https://`: remote source. KBS tries to load JWKS from the configured URL directly; if that
+///   fails or returns no keys, it falls back to OpenID discovery at
+///   `{uri}/.well-known/openid-configuration` and loads the returned `jwks_uri`.
 pub async fn read_jwk_from_uri(uri: &str) -> Result<JwkSet, JwksGetError> {
     let url = Url::parse(uri).map_err(|e| JwksGetError::InvalidSourcePath(e.to_string()))?;
     match url.scheme() {
-        "https" => {
-            let openid_config_url = url
-                .join(OPENID_CONFIG_URL_SUFFIX)
-                .map_err(|e| JwksGetError::InvalidSourcePath(e.to_string()))?;
-
-            info!(
-                "Getting OpenID configuration from {}",
-                openid_config_url.as_str()
-            );
-
-            let oidc = get(openid_config_url.as_str())
-                .await
-                .map_err(|e| JwksGetError::AccessFailed(e.to_string()))?
-                .json::<OpenIDConfig>()
-                .await
-                .map_err(|e| JwksGetError::FailedToGetKeyMaterial {
-                    source: Into::<anyhow::Error>::into(e)
-                        .context("failed to get OpenID configuration"),
-                })?;
-
-            get(oidc.jwks_uri)
-                .await
-                .map_err(|e| JwksGetError::AccessFailed(e.to_string()))?
-                .json::<JwkSet>()
-                .await
-                .map_err(|e| JwksGetError::FailedToGetKeyMaterial {
-                    source: Into::<anyhow::Error>::into(e).context("failed to get JWK set"),
-                })
-        }
         "file" => {
             let data = fs::read(url.path())
                 .map_err(|e| JwksGetError::AccessFailed(format!("open {}: {}", url.path(), e)))?;
@@ -68,17 +45,86 @@ pub async fn read_jwk_from_uri(uri: &str) -> Result<JwkSet, JwksGetError> {
                 source: Into::<anyhow::Error>::into(e).context("failed to deserialize JWK set"),
             })
         }
-        _ => Err(JwksGetError::InvalidSourcePath(format!(
-            "unsupported scheme {} (must be either file or https)",
-            url.scheme()
+        "https" => {
+            // Try to load a JWK set directly from the configured URL first.
+            match get(uri)
+                .await
+                .map_err(|source| JwksGetError::FailedToGetKeyMaterial {
+                    source: Into::<anyhow::Error>::into(source).context("failed to get JWK set"),
+                })?
+                .json::<JwkSet>()
+                .await
+                .map_err(|source| JwksGetError::FailedToGetKeyMaterial {
+                    source: Into::<anyhow::Error>::into(source)
+                        .context("failed to deserialize into JWK set"),
+                }) {
+                Ok(jwks) if !jwks.keys.is_empty() => return Ok(jwks),
+                Ok(_) => debug!("empty JWK set at {uri}, trying OpenID discovery"),
+                Err(e) => debug!(
+                    "failed to load JWK set directly from {uri}: {e}, trying OpenID discovery"
+                ),
+            }
+
+            // Fall back to OpenID discovery at `{uri}/.well-known/openid-configuration`.
+            let openid_config_url = build_openid_config_url(&url)?;
+            info!("Getting OpenID configuration from {openid_config_url}");
+            let oidc: OpenIDConfig = get(openid_config_url.as_str())
+                .await
+                .map_err(|source| JwksGetError::FailedToGetKeyMaterial {
+                    source: Into::<anyhow::Error>::into(source)
+                        .context("failed to get OpenID configuration"),
+                })?
+                .json::<OpenIDConfig>()
+                .await
+                .map_err(|source| JwksGetError::FailedToGetKeyMaterial {
+                    source: Into::<anyhow::Error>::into(source)
+                        .context("failed to deserialize into OpenID configuration"),
+                })?;
+
+            let jwks_url = Url::parse(&oidc.jwks_uri).map_err(|e| {
+                JwksGetError::InvalidSourcePath(format!("invalid jwks_uri {}: {e}", oidc.jwks_uri))
+            })?;
+
+            let jwks = get(jwks_url.as_str())
+                .await
+                .map_err(|source| JwksGetError::FailedToGetKeyMaterial {
+                    source: Into::<anyhow::Error>::into(source).context("failed to get JWK set"),
+                })?
+                .json::<JwkSet>()
+                .await
+                .map_err(|source| JwksGetError::FailedToGetKeyMaterial {
+                    source: Into::<anyhow::Error>::into(source)
+                        .context("failed to deserialize into JWK set"),
+                })?;
+
+            Ok(jwks)
+        }
+        scheme => Err(JwksGetError::InvalidSourcePath(format!(
+            "unsupported scheme {scheme} (must be either file or https)"
         ))),
     }
 }
 
+/// Build the OpenID configuration discovery URL (`{base}/.well-known/openid-configuration`).
+///
+/// A trailing slash on the base path is significant for [`Url::join`]: without it the last path
+/// segment is treated as a file name and dropped (so `https://host/realms/foo` would lose `foo`),
+/// hence we ensure one is present first.
+fn build_openid_config_url(base: &Url) -> Result<Url, JwksGetError> {
+    let mut issuer_url = base.clone();
+    if !issuer_url.path().ends_with('/') {
+        issuer_url.set_path(&format!("{}/", issuer_url.path()));
+    }
+    issuer_url
+        .join(OPENID_CONFIG_URL_SUFFIX)
+        .map_err(|e| JwksGetError::InvalidSourcePath(e.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::crypto::jwk::read_jwk_from_uri;
+    use super::{build_openid_config_url, read_jwk_from_uri};
     use jsonwebtoken::jwk::KeyAlgorithm;
+    use reqwest::Url;
     use rstest::rstest;
 
     #[rstest]
@@ -111,5 +157,24 @@ mod tests {
         let jwtks = read_jwk_from_uri(&p).await.expect("to get jwks");
         assert_eq!(jwtks.keys.len(), 1);
         assert_eq!(jwtks.keys[0].common.key_algorithm, Some(alg));
+    }
+
+    /// `Url::join` drops the last path segment unless the base ends with `/`, so verify the
+    /// discovery URL is built correctly for issuer bases with and without a trailing slash.
+    #[rstest]
+    #[case(
+        "https://host/realms/foo",
+        "https://host/realms/foo/.well-known/openid-configuration"
+    )]
+    #[case(
+        "https://host/realms/foo/",
+        "https://host/realms/foo/.well-known/openid-configuration"
+    )]
+    #[case("https://host", "https://host/.well-known/openid-configuration")]
+    #[case("https://host/", "https://host/.well-known/openid-configuration")]
+    fn test_build_openid_config_url(#[case] base: &str, #[case] expected: &str) {
+        let url = Url::parse(base).expect("valid base url");
+        let got = build_openid_config_url(&url).expect("build discovery url");
+        assert_eq!(got.as_str(), expected);
     }
 }


### PR DESCRIPTION
Improve how attestation-token verification keys (`trusted_jwk_sets`) are loaded:
- **Direct JWKS URLs**: try loading JWKS straight from the configured URL first,
  and only fall back to OpenID discovery (`.well-known/openid-configuration`)
  if that fails. Previously discovery was the only option.
- **Opt-in HTTP**: new `[attestation_token] insecure_public_key_from_uri` flag
  (default `false`) allows plaintext `http://` sources for controlled/dev
  environments. When off, HTTP is rejected — including any `jwks_uri` returned
  by discovery.
Secure defaults are unchanged (`https://`/`file://`/local paths always work).
Two separate commits; unit-tested without network.