### PR TITLE
Helm: Add e2e test with sample attester

### DIFF
--- a/.github/workflows/test-e2e-kbs.yml
+++ b/.github/workflows/test-e2e-kbs.yml
@@ -92,17 +92,17 @@ jobs:
       - name: Run KBS Vault integration e2e (no SSL + SSL)
         run: make test-kbs-vault-e2e
 
-  # Docker Compose cluster images (shared with docker-e2e-test via workflow artifacts)
-  build-docker-e2e-images:
-    name: Build Docker Compose e2e images
-    uses: ./.github/workflows/workflow-call-build-docker-e2e-images.yml
+  # Docker Compose/Helm e2e materials (shared via workflow artifacts)
+  build-docker-e2e-materials:
+    name: Build Docker/Helm e2e materials
+    uses: ./.github/workflows/workflow-call-build-docker-e2e-materials.yml
     permissions:
       contents: read
 
   # Docker Compose cluster e2e
   docker-e2e-test:
     name: Docker Compose e2e
-    needs: build-docker-e2e-images
+    needs: build-docker-e2e-materials
     strategy:
       matrix:
         instance:
@@ -204,6 +204,61 @@ jobs:
     - name: Run external plugin e2e tests
       working-directory: kbs/test
       run: make e2e-ext-plugin
+
+  helm-trustee-e2e:
+    name: Helm Trustee e2e
+    needs: build-docker-e2e-materials
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      OS_VERSION: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download pre-built images
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docker-e2e-images-linux-amd64
+          path: ${{ runner.temp }}/docker-e2e-images
+
+      - name: Load images
+        run: docker load --input "${{ runner.temp }}/docker-e2e-images/images.tar"
+
+      - name: Download pre-built kbs-client
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: helm-e2e-kbs-client-linux-amd64
+          path: ${{ runner.temp }}/helm-e2e-kbs-client
+
+      - name: Prepare kbs-client
+        run: chmod +x "${{ runner.temp }}/helm-e2e-kbs-client/kbs-client"
+
+      - name: Install Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - name: Install Kubectl
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
+
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          cluster_name: kind
+
+      - name: Load Trustee images into kind
+        run: |
+          make -C deployment/helm-chart load-e2e-images-into-kind \
+            E2E_IMAGE_PREFIX=ghcr.io/confidential-containers/staged-images \
+            E2E_IMAGE_TAG=latest
+
+      - name: Run Helm Trustee e2e
+        run: |
+          make -C deployment/helm-chart e2e-test \
+            E2E_IMAGE_PREFIX=ghcr.io/confidential-containers/staged-images \
+            E2E_IMAGE_TAG=latest \
+            KBS_CLIENT="${{ runner.temp }}/helm-e2e-kbs-client/kbs-client"
 
   # Azure vTPM TEE e2e (manual trigger only)
   tdx-e2e-test:

--- a/.github/workflows/workflow-call-build-docker-e2e-materials.yml
+++ b/.github/workflows/workflow-call-build-docker-e2e-materials.yml
@@ -1,8 +1,10 @@
-name: Build Docker Compose e2e Images
+name: Build Docker/Helm e2e Materials
 
-# Builds the docker-compose cluster images (kbs-grpc-as, coco-as-grpc, rvps) in
-# parallel (one matrix job per image/arch), then packages them per arch for
-# docker-e2e-test. See https://docs.docker.com/build/ci/github-actions/share-image-jobs/
+# Builds the materials consumed by Docker Compose and Helm e2e jobs:
+# - kbs-client for the Helm e2e client checks
+# - cluster images (kbs-grpc-as, coco-as-grpc, rvps), built in parallel and
+#   packaged per arch for docker-e2e-test and helm-trustee-e2e.
+# See https://docs.docker.com/build/ci/github-actions/share-image-jobs/
 
 on:
   workflow_call:
@@ -10,8 +12,47 @@ on:
 permissions: {}
 
 jobs:
+  build-kbs-client:
+    name: Build kbs-client (linux/amd64)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      OS_VERSION: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          rustflags: ""
+          cache: false
+
+      - name: Set up rust build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            target/
+          key: rust-${{ runner.arch }}-${{ env.OS_VERSION }}-${{ hashFiles('./Cargo.lock') }}
+
+      - name: Build kbs-client
+        run: cargo build -p kbs-client --release
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: helm-e2e-kbs-client-linux-amd64
+          path: target/release/kbs-client
+          retention-days: 1
+          if-no-files-found: error
+
   build-image:
-    name: Build ${{ matrix.tag }} (${{ matrix.platform }})
+    name: Build image ${{ matrix.tag }} (${{ matrix.platform }})
     strategy:
       fail-fast: false
       matrix:
@@ -100,7 +141,7 @@ jobs:
           if-no-files-found: error
 
   package-images:
-    name: Package docker e2e images (${{ matrix.platform }})
+    name: Package Docker e2e image bundle (${{ matrix.platform }})
     needs: build-image
     strategy:
       fail-fast: false
@@ -118,14 +159,14 @@ jobs:
     env:
       IMAGE_PREFIX: ghcr.io/confidential-containers/staged-images
     steps:
-      - name: Download built images
+      - name: Download built image artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: docker-e2e-image-${{ matrix.platform_slug }}-*
           path: ${{ runner.temp }}/docker-e2e-images
           merge-multiple: true
 
-      - name: Load and repackage images (KBS-GRPC-AS, COCO-AS-GRPC, RVPS) in a single tarball
+      - name: Load and repackage image artifacts
         run: |
           set -euo pipefail
           mapfile -t image_tars < <(find "${{ runner.temp }}/docker-e2e-images" -name '*.tar' -type f)

--- a/.github/workflows/workflow-call-build-staged-images-pr.yml
+++ b/.github/workflows/workflow-call-build-staged-images-pr.yml
@@ -1,9 +1,9 @@
 name: Build Staged Images (PR)
 
-# linux/amd64 and linux/arm64 images used by docker-compose e2e are built once in
-# workflow-call-build-docker-e2e-images.yml (called from test-e2e-kbs.yml) and
-# passed to docker-e2e-test via workflow artifacts. They are omitted here on PR to
-# avoid rebuilding the same Dockerfiles.
+# linux/amd64 and linux/arm64 images used by Docker Compose/Helm e2e are built
+# once in workflow-call-build-docker-e2e-materials.yml (called from
+# test-e2e-kbs.yml) and passed via workflow artifacts. They are omitted here on
+# PR to avoid rebuilding the same Dockerfiles.
 
 on:
   workflow_call:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test-all test-unit test-e2e \
 	test-kbs-unit test-as-unit test-trustee-cli-unit \
 	test-kbs-e2e test-as-e2e \
-	test-kbs-vault-e2e test-kbs-docker-e2e \
+	test-kbs-vault-e2e test-kbs-docker-e2e test-helm-e2e \
 	kbs-e2e-build kbs-e2e-install-deps kbs-e2e-build-bins \
 	kbs-vault-e2e-install-deps kbs-vault-e2e-run \
 	as-e2e-install-deps as-e2e-run
@@ -94,4 +94,8 @@ as-e2e-run:
 	$(MAKE) -C attestation-service/tests/e2e e2e-restful-test
 
 test-as-e2e: as-e2e-install-deps as-e2e-run
+
+# Helm chart e2e (deploy Trustee, kbs-client, undeploy; images must already be loaded)
+test-helm-e2e:
+	$(MAKE) -C deployment/helm-chart e2e-test
 

--- a/deployment/helm-chart/Makefile
+++ b/deployment/helm-chart/Makefile
@@ -1,0 +1,92 @@
+# Helm chart end-to-end tests (Trustee deploy + kbs-client + undeploy).
+#
+# Prerequisites: helm, kubectl, base64, diff, and a pre-built kbs-client.
+# A Kubernetes cluster must already exist (kind recommended). Cluster creation is out of band.
+#
+# Images must already be loaded into the target Kubernetes cluster before running e2e-test.
+
+REPO_ROOT := $(abspath ../..)
+CHART_DIR := $(abspath .)
+KBS_CLIENT ?= $(REPO_ROOT)/target/release/kbs-client
+
+E2E_IMAGE_PREFIX ?= trustee-e2e
+E2E_IMAGE_TAG ?= e2e
+
+E2E_KBS_IMAGE_REPOSITORY := $(E2E_IMAGE_PREFIX)/kbs-grpc-as
+E2E_AS_IMAGE_REPOSITORY := $(E2E_IMAGE_PREFIX)/coco-as-grpc
+E2E_RVPS_IMAGE_REPOSITORY := $(E2E_IMAGE_PREFIX)/rvps
+
+E2E_KBS_IMAGE := $(E2E_KBS_IMAGE_REPOSITORY):$(E2E_IMAGE_TAG)
+E2E_AS_IMAGE := $(E2E_AS_IMAGE_REPOSITORY):$(E2E_IMAGE_TAG)
+E2E_RVPS_IMAGE := $(E2E_RVPS_IMAGE_REPOSITORY):$(E2E_IMAGE_TAG)
+
+HELM_E2E_IMAGE_ARGS := \
+	--set-string kbs.image.repository='$(E2E_KBS_IMAGE_REPOSITORY)' \
+	--set-string kbs.image.tag='$(E2E_IMAGE_TAG)' \
+	--set-string kbs.image.pullPolicy='Never' \
+	--set-string as.image.repository='$(E2E_AS_IMAGE_REPOSITORY)' \
+	--set-string as.image.tag='$(E2E_IMAGE_TAG)' \
+	--set-string as.image.pullPolicy='Never' \
+	--set-string rvps.image.repository='$(E2E_RVPS_IMAGE_REPOSITORY)' \
+	--set-string rvps.image.tag='$(E2E_IMAGE_TAG)' \
+	--set-string rvps.image.pullPolicy='Never'
+
+export KBS_CLIENT
+
+.PHONY: e2e-test deploy undeploy test-client check-tools wait-ready \
+	check-docker helm-dependency-build helm-lint load-e2e-images-into-kind
+
+check-tools:
+	@command -v helm >/dev/null || (echo "missing: helm" >&2; exit 1)
+	@command -v kubectl >/dev/null || (echo "missing: kubectl" >&2; exit 1)
+	@command -v base64 >/dev/null || (echo "missing: base64" >&2; exit 1)
+	@command -v diff >/dev/null || (echo "missing: diff" >&2; exit 1)
+
+check-docker:
+	@command -v docker >/dev/null || (echo "missing: docker" >&2; exit 1)
+
+helm-dependency-build: check-tools
+	helm dependency build '$(CHART_DIR)'
+
+helm-lint: helm-dependency-build
+	helm lint '$(CHART_DIR)' -f '$(CHART_DIR)/scenarios/e2e-local-images.yaml' $(HELM_E2E_IMAGE_ARGS)
+
+load-e2e-images-into-kind: check-docker
+	@command -v kind >/dev/null || (echo "missing: kind (required to load local images)" >&2; exit 1)
+	@echo "==> loading images into kind cluster kind"
+	kind load docker-image --name kind \
+		'$(E2E_KBS_IMAGE)' '$(E2E_AS_IMAGE)' '$(E2E_RVPS_IMAGE)'
+
+deploy: helm-lint
+	helm upgrade --install trustee-e2e '$(CHART_DIR)' \
+		--namespace coco-trustee-e2e \
+		--create-namespace \
+		-f '$(CHART_DIR)/scenarios/e2e-local-images.yaml' \
+		$(HELM_E2E_IMAGE_ARGS) \
+		--wait \
+		--timeout 20m
+
+wait-ready: check-tools
+	kubectl wait --for=condition=available deployment/trustee-e2e-rvps -n coco-trustee-e2e --timeout=600s
+	kubectl wait --for=condition=available deployment/trustee-e2e-as -n coco-trustee-e2e --timeout=600s
+	kubectl wait --for=condition=available deployment/trustee-e2e-kbs -n coco-trustee-e2e --timeout=600s
+
+undeploy: check-tools
+	helm uninstall trustee-e2e -n coco-trustee-e2e 2>/dev/null || true
+	kubectl delete namespace coco-trustee-e2e --ignore-not-found --timeout=120s 2>/dev/null || true
+
+test-client: check-tools wait-ready
+	@chmod +x '$(CHART_DIR)/e2e/test.sh'
+	@'$(CHART_DIR)/e2e/test.sh'
+
+# Deploy, test, then always undeploy. Images must already be present in the cluster.
+e2e-test: check-tools
+	@status=0; \
+	if [ $$status -eq 0 ]; then \
+		$(MAKE) deploy || status=$$?; \
+	fi; \
+	if [ $$status -eq 0 ]; then \
+		$(MAKE) test-client || status=$$?; \
+	fi; \
+	$(MAKE) undeploy || true; \
+	exit $$status

--- a/deployment/helm-chart/README.md
+++ b/deployment/helm-chart/README.md
@@ -270,6 +270,47 @@ Default **`values.yaml`** is intentionally small. Fixed on-disk paths for **Loca
 | storageBackend.postgres.mode | string | `"internal"` | Postgres source: `internal` (Bitnami subchart) or `external` (pre-created Secret). |
 | storageBackend.type | string | `"LocalFs"` | Backend type: `LocalFs`, `LocalJson`, `Postgres`, or `Memory`. When `Postgres` (or `sessionStorageType` is `Postgres`), the chart injects `POSTGRES_URL`. Only settings for the selected type take effect. |
 
+## End-to-end test
+
+Provision a **kind** cluster out of band, preload the Trustee images into it, point `kubectl` at it, then from the repository root:
+
+```bash
+kind create cluster --name kind --wait 5m
+make -C deployment/helm-chart load-e2e-images-into-kind
+make test-helm-e2e
+```
+
+`make e2e-test` assumes **KBS / AS / RVPS** images are already loaded into the cluster and deploys with [scenarios/e2e-local-images.yaml](./scenarios/e2e-local-images.yaml). The Makefile injects image repositories, tags, and `pullPolicy: Never` at install time so local runs and CI can use different preloaded image names without changing the scenario file.
+
+- **Local preloaded images**: `trustee-e2e/*:e2e`, `pullPolicy: Never` (not GHCR `:latest`)
+- **CI images**: reuses `docker-e2e-images-linux-amd64` from `workflow-call-build-docker-e2e-materials.yml` as `ghcr.io/confidential-containers/staged-images/*:latest`
+- **Storage**: bundled Postgres KV backend (`storageBackend.type: Postgres`)
+- **KBS sessions**: `sessionStorageType: Memory`
+
+Steps:
+
+1. **`helm-dependency-build`**
+2. **`helm-lint`**
+3. **`deploy`**
+4. **`test-client`** — [e2e/test.sh](./e2e/test.sh)
+5. **`undeploy`** — always attempted, even after failures
+
+Debug individually:
+
+```bash
+make -C deployment/helm-chart load-e2e-images-into-kind
+make -C deployment/helm-chart helm-lint
+make -C deployment/helm-chart deploy
+make -C deployment/helm-chart test-client
+make -C deployment/helm-chart undeploy
+```
+
+Optional variables: `E2E_IMAGE_PREFIX`, `E2E_IMAGE_TAG`, `KBS_CLIENT`.
+
+CI (`test-e2e-kbs.yml`) reuses the Docker Compose e2e image build workflow artifacts: it loads the pre-built Trustee images into kind and uses the pre-built `kbs-client` binary before running Helm e2e.
+
+`make test-client` alone does not build images or undeploy.
+
 ## Development notes
 
 1. Do not change the files under [files](./files/) unless you are updating the corresponding Helm template logic. Service config is rendered from `*.template` files; Postgres KV init SQL lives in `files/postgres-initkv.sql`.

--- a/deployment/helm-chart/README.md.gotmpl
+++ b/deployment/helm-chart/README.md.gotmpl
@@ -159,6 +159,47 @@ Default **`values.yaml`** is intentionally small. Fixed on-disk paths for **Loca
 
 {{ template "chart.valuesSection" . }}
 
+## End-to-end test
+
+Provision a **kind** cluster out of band, preload the Trustee images into it, point `kubectl` at it, then from the repository root:
+
+```bash
+kind create cluster --name kind --wait 5m
+make -C deployment/helm-chart load-e2e-images-into-kind
+make test-helm-e2e
+```
+
+`make e2e-test` assumes **KBS / AS / RVPS** images are already loaded into the cluster and deploys with [scenarios/e2e-local-images.yaml](./scenarios/e2e-local-images.yaml). The Makefile injects image repositories, tags, and `pullPolicy: Never` at install time so local runs and CI can use different preloaded image names without changing the scenario file.
+
+- **Local preloaded images**: `trustee-e2e/*:e2e`, `pullPolicy: Never` (not GHCR `:latest`)
+- **CI images**: reuses `docker-e2e-images-linux-amd64` from `workflow-call-build-docker-e2e-materials.yml` as `ghcr.io/confidential-containers/staged-images/*:latest`
+- **Storage**: bundled Postgres KV backend (`storageBackend.type: Postgres`)
+- **KBS sessions**: `sessionStorageType: Memory`
+
+Steps:
+
+1. **`helm-dependency-build`**
+2. **`helm-lint`**
+3. **`deploy`**
+4. **`test-client`** — [e2e/test.sh](./e2e/test.sh)
+5. **`undeploy`** — always attempted, even after failures
+
+Debug individually:
+
+```bash
+make -C deployment/helm-chart load-e2e-images-into-kind
+make -C deployment/helm-chart helm-lint
+make -C deployment/helm-chart deploy
+make -C deployment/helm-chart test-client
+make -C deployment/helm-chart undeploy
+```
+
+Optional variables: `E2E_IMAGE_PREFIX`, `E2E_IMAGE_TAG`, `KBS_CLIENT`.
+
+CI (`test-e2e-kbs.yml`) reuses the Docker Compose e2e image build workflow artifacts: it loads the pre-built Trustee images into kind and uses the pre-built `kbs-client` binary before running Helm e2e.
+
+`make test-client` alone does not build images or undeploy.
+
 ## Development notes
 
 1. Do not change the files under [files](./files/) unless you are updating the corresponding Helm template logic. Service config is rendered from `*.template` files; Postgres KV init SQL lives in `files/postgres-initkv.sql`.

--- a/deployment/helm-chart/e2e/fixtures/test-resource.txt
+++ b/deployment/helm-chart/e2e/fixtures/test-resource.txt
@@ -1,0 +1,1 @@
+helm-e2e-trustee-secret-payload

--- a/deployment/helm-chart/e2e/test.sh
+++ b/deployment/helm-chart/e2e/test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# kbs-client checks against an already-deployed Trustee Helm release.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${CHART_DIR}/../.." && pwd)"
+
+KBS_CLIENT="${KBS_CLIENT:-${REPO_ROOT}/target/release/kbs-client}"
+KBS_URL="http://127.0.0.1:8080"
+TEST_RESOURCE_FILE="${SCRIPT_DIR}/fixtures/test-resource.txt"
+RESOURCE_PATH="helm-e2e/test-repo/test-secret"
+
+WORK_DIR="$(mktemp -d)"
+ADMIN_TOKEN_FILE="${WORK_DIR}/admin-token"
+ROUNDTRIP_FILE="${WORK_DIR}/roundtrip.txt"
+PORT_FORWARD_PID=""
+
+cleanup() {
+	local code=$?
+	if [[ -n "${PORT_FORWARD_PID}" ]] && kill -0 "${PORT_FORWARD_PID}" 2>/dev/null; then
+		kill "${PORT_FORWARD_PID}" 2>/dev/null || true
+		wait "${PORT_FORWARD_PID}" 2>/dev/null || true
+	fi
+	rm -rf "${WORK_DIR}"
+	exit "${code}"
+}
+trap cleanup EXIT
+
+log() { printf '==> %s\n' "$*"; }
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+require_cmd() {
+	command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+wait_for_bootstrap_secret() {
+	local secret_name="trustee-e2e-bootstrap-user-keys"
+	local i
+	for i in $(seq 1 120); do
+		if kubectl get secret "${secret_name}" -n coco-trustee-e2e >/dev/null 2>&1; then
+			return 0
+		fi
+		sleep 2
+	done
+	die "timed out waiting for Secret ${secret_name}"
+}
+
+start_port_forward() {
+	log "port-forward KBS -> 127.0.0.1:8080"
+	kubectl port-forward -n coco-trustee-e2e svc/trustee-e2e-kbs 8080:8080 >/dev/null 2>&1 &
+	PORT_FORWARD_PID=$!
+	for _ in $(seq 1 60); do
+		if ! kill -0 "${PORT_FORWARD_PID}" 2>/dev/null; then
+ 			die "kubectl port-forward exited unexpectedly"
+ 		fi
+		if (echo >/dev/tcp/127.0.0.1/8080) >/dev/null 2>&1; then
+			sleep 2
+			return 0
+		fi
+		sleep 1
+	done
+	die "KBS not reachable on 127.0.0.1:8080 after port-forward"
+}
+
+main() {
+	require_cmd base64
+	require_cmd diff
+	require_cmd kubectl
+	require_cmd seq
+
+	[[ -x "${KBS_CLIENT}" ]] || die "kbs-client not found at ${KBS_CLIENT} (set KBS_CLIENT to a pre-built binary)"
+	[[ -f "${TEST_RESOURCE_FILE}" ]] || die "test resource fixture not found: ${TEST_RESOURCE_FILE}"
+
+	wait_for_bootstrap_secret
+	start_port_forward
+
+	kubectl get secret trustee-e2e-bootstrap-user-keys -n coco-trustee-e2e \
+		-o "jsonpath={.data.KBS_ADMIN_TOKEN}" | base64 -d >"${ADMIN_TOKEN_FILE}"
+
+	log "set confidential resource"
+	"${KBS_CLIENT}" --url "${KBS_URL}" config \
+		--admin-token-file "${ADMIN_TOKEN_FILE}" \
+		set-resource \
+		--path "${RESOURCE_PATH}" \
+		--resource-file "${TEST_RESOURCE_FILE}"
+
+	log "set resource policy (allow_all)"
+	"${KBS_CLIENT}" --url "${KBS_URL}" config \
+		--admin-token-file "${ADMIN_TOKEN_FILE}" \
+		set-resource-policy \
+		--allow-all
+
+	log "get resource (expect success with allow_all)"
+	"${KBS_CLIENT}" --url "${KBS_URL}" get-resource \
+		--path "${RESOURCE_PATH}" \
+		| base64 -d >"${ROUNDTRIP_FILE}"
+	diff -u "${TEST_RESOURCE_FILE}" "${ROUNDTRIP_FILE}"
+
+	log "set resource policy (deny_all)"
+	"${KBS_CLIENT}" --url "${KBS_URL}" config \
+		--admin-token-file "${ADMIN_TOKEN_FILE}" \
+		set-resource-policy \
+		--deny-all
+
+	log "get resource (expect failure with deny_all)"
+	if "${KBS_CLIENT}" --url "${KBS_URL}" get-resource \
+		--path "${RESOURCE_PATH}" >/dev/null 2>&1; then
+		die "get-resource succeeded but should have been denied by deny_all resource policy"
+	fi
+
+	log "helm client e2e passed"
+}
+
+main "$@"

--- a/deployment/helm-chart/scenarios/e2e-local-images.yaml
+++ b/deployment/helm-chart/scenarios/e2e-local-images.yaml
@@ -1,0 +1,20 @@
+# Helm e2e scenario: Postgres KV + Memory KBS sessions.
+# Used by `make e2e-test` (see deployment/helm-chart/Makefile). The Makefile injects
+# image repositories, tags, and pullPolicy so local runs and CI can share this scenario.
+
+sessionStorageType: Memory
+
+storageBackend:
+  type: Postgres
+  postgres:
+    mode: internal
+
+postgresql:
+  enabled: true
+  primary:
+    # The e2e test does not validate persistence; avoid relying on a default
+    # StorageClass in local CI clusters.
+    persistence:
+      enabled: false
+      existingClaim: ""
+      storageClass: ""


### PR DESCRIPTION
The test uses github runner + kind to set up a k8s cluster. Then, use images built from the PR code to launch a trustee service with helm-chart.

Then use kbs-client to interact with the trustee.

Close #1444

Note that the image building process is reused from the docker e2e test. During implementing this, I get some more ideas about optimizing the current shape - which contains some duplicated tasks. I will take an eye on them in other PRs.