### PR TITLE
ci: add concurrency flag to cancel superseded run

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -13,6 +13,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analysis:
     name: Scorecard analysis

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -21,6 +21,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/test-actionlint.yml
+++ b/.github/workflows/test-actionlint.yml
@@ -5,6 +5,10 @@ on:
       - '**/*.md'
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   actionlint:
     name: Workflow Files

--- a/.github/workflows/test-e2e-as.yml
+++ b/.github/workflows/test-e2e-as.yml
@@ -8,6 +8,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Self-hosted runners do not set -o pipefail otherwise
 defaults:
   run:
@@ -15,8 +19,6 @@ defaults:
 
 jobs:
   e2e-test:
-    strategy:
-      fail-fast: false
     name: Attestation Service e2e
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/test-e2e-kbs.yml
+++ b/.github/workflows/test-e2e-kbs.yml
@@ -9,6 +9,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Common checkout + source archive for all e2e jobs
   code-checkout:

--- a/.github/workflows/test-link-check.yml
+++ b/.github/workflows/test-link-check.yml
@@ -10,6 +10,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checklinks:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-rust-ci.yml
+++ b/.github/workflows/test-rust-ci.yml
@@ -10,6 +10,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
With this flag, everytime we push to a same PR will cancel the previous round of job running. This would save a lot of runner resources.