### PR TITLE
AS: add HTTPS support to gRPC AS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ dependencies = [
  "regorus",
  "rsa",
  "rstest",
+ "rustls 0.23.41",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -21,7 +21,7 @@ tpm-verifier = ["verifier/tpm-verifier"]
 rvps-grpc = ["prost", "tonic", "mobc"]
 
 # For building gRPC CoCo-AS binary
-grpc-bin = ["clap", "prost", "tonic", "tonic-health", "tonic-prost"]
+grpc-bin = ["clap", "prost", "tonic", "tonic-health", "tonic-prost", "rustls"]
 
 # For restful CoCo-AS binary
 restful-bin = ["actix-cors", "actix-web/openssl", "clap"]
@@ -54,6 +54,9 @@ prost = { workspace = true, optional = true }
 reference-value-provider-service.path = "../rvps"
 regorus.workspace = true
 rsa.workspace = true
+rustls = { version = "0.23", default-features = false, features = [
+    "ring",
+], optional = true }
 serde.workspace = true
 serde_json.workspace = true
 serde_variant = "0.1.2"

--- a/attestation-service/src/bin/grpc-as.rs
+++ b/attestation-service/src/bin/grpc-as.rs
@@ -29,10 +29,28 @@ pub struct Cli {
     /// Socket that the server will listen on to accept requests.
     #[arg(short, long, default_value = "127.0.0.1:3000")]
     pub socket: SocketAddr,
+
+    /// Path to the public key cert for HTTPS. Both public key cert and
+    /// private key must be provided to enable HTTPS.
+    #[arg(short = 't', long)]
+    pub https_pubkey_cert: Option<String>,
+
+    /// Path to the private key for HTTPS. Both public key cert and
+    /// private key must be provided to enable HTTPS.
+    #[arg(short = 'k', long)]
+    pub https_prikey: Option<String>,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Both ring and aws-lc-rs may be compiled in (e.g. via jsonwebtoken);
+    // rustls requires an explicit default crypto provider when multiple
+    // backends are present. Install ring. `.ok()` ignores Err if a provider
+    // is already registered.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
     let env_filter = match std::env::var_os("RUST_LOG") {
         Some(_) => EnvFilter::try_from_default_env().expect("RUST_LOG is present but invalid"),
         None => EnvFilter::new("warn,attestation_service=info,grpc_as=info"),
@@ -65,7 +83,12 @@ loglevel: {env_filter}
 
     let cli = Cli::parse();
 
-    let server = grpc::start(cli.socket, cli.config_file);
+    let server = grpc::start(
+        cli.socket,
+        cli.config_file,
+        cli.https_pubkey_cert,
+        cli.https_prikey,
+    );
     tokio::try_join!(server)?;
 
     Ok(())

--- a/attestation-service/src/bin/grpc/mod.rs
+++ b/attestation-service/src/bin/grpc/mod.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::RwLock;
-use tonic::transport::Server;
+use tonic::transport::{Identity, Server, ServerTlsConfig};
 use tonic::{Request, Response, Status};
 use tonic_health::server::health_reporter;
 use tracing::{debug, info, instrument, Span};
@@ -58,6 +58,12 @@ pub enum GrpcError {
     Service(#[from] ServiceError),
     #[error("tonic transport error: {0}")]
     TonicTransport(#[from] tonic::transport::Error),
+    #[error("failed to read HTTPS public key cert: {0}")]
+    ReadHttpsCert(#[source] std::io::Error),
+    #[error("failed to read HTTPS private key: {0}")]
+    ReadHttpsKey(#[source] std::io::Error),
+    #[error("HTTPS public key cert and private key must be provided to enable HTTPS.")]
+    HttpsConfigError,
 }
 
 pub struct AttestationServer {
@@ -310,12 +316,12 @@ impl ReferenceValueProviderService for Arc<RwLock<AttestationServer>> {
     }
 }
 
-pub async fn start(socket: SocketAddr, config_path: Option<String>) -> Result<(), GrpcError> {
-    info!(
-        "Starting gRPC Attestation Service. Listening on socket: {}",
-        &socket
-    );
-
+pub async fn start(
+    socket: SocketAddr,
+    config_path: Option<String>,
+    https_pubkey_cert: Option<String>,
+    https_prikey: Option<String>,
+) -> Result<(), GrpcError> {
     let attestation_server = Arc::new(RwLock::new(AttestationServer::new(config_path).await?));
 
     let (health_reporter, health_service) = health_reporter();
@@ -323,7 +329,35 @@ pub async fn start(socket: SocketAddr, config_path: Option<String>) -> Result<()
         .set_serving::<AttestationServiceServer<Arc<RwLock<AttestationServer>>>>()
         .await;
 
-    Server::builder()
+    let mut builder = Server::builder();
+
+    match (https_pubkey_cert, https_prikey) {
+        (Some(pubkey_cert), Some(prikey)) => {
+            let cert = tokio::fs::read(pubkey_cert)
+                .await
+                .map_err(GrpcError::ReadHttpsCert)?;
+            let key = tokio::fs::read(prikey)
+                .await
+                .map_err(GrpcError::ReadHttpsKey)?;
+            let identity = Identity::from_pem(cert, key);
+            builder = builder.tls_config(ServerTlsConfig::new().identity(identity))?;
+            info!(
+                "Starting gRPC Attestation Service over HTTPS. Listening on socket: {}",
+                &socket
+            );
+        }
+        (None, None) => {
+            info!(
+                "Starting gRPC Attestation Service over HTTP. Listening on socket: {}",
+                &socket
+            );
+        }
+        _ => {
+            return Err(GrpcError::HttpsConfigError);
+        }
+    }
+
+    builder
         .add_service(health_service)
         .add_service(AttestationServiceServer::new(attestation_server.clone()))
         .add_service(ReferenceValueProviderServiceServer::new(attestation_server))


### PR DESCRIPTION
The gRPC Attestation Service could only serve over plaintext HTTP, while the RESTful AS already supported TLS. Add optional `--https-pubkey-cert` and `--https-prikey` arguments so the gRPC server can be started over TLS, mirroring the RESTful AS behavior: TLS is enabled only when both a certificate and a private key are provided, otherwise it stays on plaintext for backward compatibility.

TLS is built on tonic's `ServerTlsConfig` backed by rustls with the ring provider, which is installed explicitly since aws-lc-rs is also linked in via jsonwebtoken.