### PR TITLE
AS: Install libcurl4 on s390x in grpc-as runtime image

### DIFF
--- a/attestation-service/docker/as-grpc/Dockerfile
+++ b/attestation-service/docker/as-grpc/Dockerfile
@@ -42,8 +42,8 @@ ARG VERIFIER=all-verifier
 
 LABEL org.opencontainers.image.source="https://github.com/confidential-containers/trustee/tree/main/attestation-service"
 
-# Install Openssl Suites
-RUN apt-get update && apt-get install openssl -y && \
+# Install Openssl Suites and libcurl (required by grpc-as on all architectures)
+RUN apt-get update && apt-get install -y openssl libcurl4 && \
     apt install --reinstall ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*


### PR DESCRIPTION
The grpc-as binary dynamically links libcurl.so.4 on s390x (pulled in transitively by the SE verifier), but the runtime stage of the container image did not include the package, causing a startup failure like:

```
grpc-as: error while loading shared libraries: libcurl.so.4:
cannot open shared object file: No such file or directory
```

This commit installs the package unconditionally.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>