### PR TITLE
helm: support IBM SE material mounting to use PV/PVC

### DIFF
--- a/deployment/helm-chart/README.md
+++ b/deployment/helm-chart/README.md
@@ -109,6 +109,38 @@ helm upgrade --install trustee ./deployment/helm-chart \
 
 Or use **`scenarios/bring-your-own-keys.yaml`** (adjust Secret name / file paths in the comments there).
 
+### IBM Secure Execution (s390x)
+
+On **s390x**, the **IBM Secure Execution (SE)** verifier needs attestation materials at runtime. Because KBS talks to a **remote `coco_as_grpc` AS**, the verifier runs inside the **AS Pod**, so these materials must be mounted on **AS**, not KBS. (This differs from the builtin-AS kustomize overlay in `kbs/config/kubernetes/overlays/ibm-se`, which mounts them on KBS.)
+
+The verifier reads materials from fixed paths under **`/run/confidential-containers/ibmse/`** (overridable via `SE_*` env vars; see `deps/verifier/src/se/README.md`). The chart mounts them from a **local node path** via a PersistentVolume / PersistentVolumeClaim — set **`as.ibmse.credsDir`** to the directory on the node that contains the materials (equivalent to `IBM_SE_CREDS_DIR` used in the kustomize overlay), and **`as.ibmse.nodeName`** to the name of that node.  The chart then creates a `local`-type PV + PVC and mounts the whole directory at `/run/confidential-containers/ibmse/` on the AS Pod.
+
+| Material | Expected path under `credsDir` | Notes |
+|----------|-------------------------------|-------|
+| RSA measurement key pair | `rsa/encrypt_key.{pem,pub}` | Private key is **sensitive** — restrict node access. |
+| Signing / intermediate certs | `certs/` | **Directory**; all files are read. |
+| CRLs | `crls/` | **Directory**; all files are read. |
+| Host Key Documents (HKD) | `hkds/` | **Directory**; all files are read. |
+| SE image header | `hdr/hdr.bin` | Binary file. |
+| Root CA (optional) | `root_ca.crt` | Single file. |
+
+Set **`CERTS_OFFLINE_VERIFICATION=true`** (via `as.extraEnvVars`) to verify the HKD certificate chain offline. Do **not** set `SE_SKIP_CERTS_VERIFICATION=true` outside development — it disables HKD certificate chain verification.
+
+```bash
+# 1. Place all materials under a directory on the target s390x node, e.g.:
+#    $IBM_SE_CREDS_DIR/{rsa/,certs/,crls/,hkds/,hdr/hdr.bin}
+#    See deps/verifier/src/se/README.md for how to obtain the materials.
+
+# 2. Install, pointing the chart at the node and directory:
+helm upgrade --install trustee ./deployment/helm-chart \
+  --namespace coco-trustee --create-namespace \
+  -f ./deployment/helm-chart/scenarios/ibm-se.yaml \
+  --set as.ibmse.credsDir=$IBM_SE_CREDS_DIR \
+  --set as.ibmse.nodeName=<your-s390x-node-name>
+```
+
+Use an **s390x** AS image built with the `se-verifier` feature (`as.image.repository` / `as.image.tag`). See **`scenarios/ibm-se.yaml`** for the full override. Set the SE attestation policy afterwards as documented in `deps/verifier/src/se/README.md`.
+
 ## Testing
 
 **Inspect resources**:
@@ -163,6 +195,8 @@ Default **`values.yaml`** is intentionally small. Fixed on-disk paths for **Loca
 |-----|------|---------|-------------|
 | as.affinity | object | `{}` | Affinity and anti-affinity scheduling rules for AS Pods. |
 | as.extraEnvVars | list | `[]` | Extra environment variables for the AS container (for example `HTTP(S)_PROXY` and `NO_PROXY`). |
+| as.ibmse.credsDir | string | `""` | Absolute path on the target node to the directory containing IBM SE attestation materials (`rsa/`, `certs/`, `crls/`, `hkds/`, `hdr/hdr.bin`). When non-empty, the chart creates a `local`-type PersistentVolume + PersistentVolumeClaim and mounts the directory at `/run/confidential-containers/ibmse/` on the AS Pod. Requires `as.ibmse.nodeName`. |
+| as.ibmse.nodeName | string | `""` | Kubernetes node name where the IBM SE materials directory (`as.ibmse.credsDir`) resides. Required when `as.ibmse.credsDir` is set; used in the PersistentVolume `nodeAffinity`. |
 | as.image.pullPolicy | string | `"Always"` | AS container image pull policy. |
 | as.image.repository | string | `"ghcr.io/confidential-containers/staged-images/coco-as-grpc"` | AS container image repository. |
 | as.image.tag | string | `"latest"` | AS container image tag. |

--- a/deployment/helm-chart/README.md.gotmpl
+++ b/deployment/helm-chart/README.md.gotmpl
@@ -109,6 +109,38 @@ helm upgrade --install trustee ./deployment/helm-chart \
 
 Or use **`scenarios/bring-your-own-keys.yaml`** (adjust Secret name / file paths in the comments there).
 
+### IBM Secure Execution (s390x)
+
+On **s390x**, the **IBM Secure Execution (SE)** verifier needs attestation materials at runtime. Because KBS talks to a **remote `coco_as_grpc` AS**, the verifier runs inside the **AS Pod**, so these materials must be mounted on **AS**, not KBS. (This differs from the builtin-AS kustomize overlay in `kbs/config/kubernetes/overlays/ibm-se`, which mounts them on KBS.)
+
+The verifier reads materials from fixed paths under **`/run/confidential-containers/ibmse/`** (overridable via `SE_*` env vars; see `deps/verifier/src/se/ibmse.rs` and `deps/verifier/src/se/README.md`). The chart mounts them from a **local node path** via a PersistentVolume / PersistentVolumeClaim — set **`as.ibmse.credsDir`** to the directory on the node that contains the materials (equivalent to `IBM_SE_CREDS_DIR` used in the kustomize overlay), and **`as.ibmse.nodeName`** to the name of that node.  The chart then creates a `local`-type PV + PVC and mounts the whole directory at `/run/confidential-containers/ibmse/` on the AS Pod.
+
+| Material | Expected path under `credsDir` | Notes |
+|----------|-------------------------------|-------|
+| RSA measurement key pair | `rsa/encrypt_key.{pem,pub}` | Private key is **sensitive** — restrict node access. |
+| Signing / intermediate certs | `certs/` | **Directory**; all files are read. |
+| CRLs | `crls/` | **Directory**; all files are read. |
+| Host Key Documents (HKD) | `hkds/` | **Directory**; all files are read. |
+| SE image header | `hdr/hdr.bin` | Binary file. |
+| Root CA (optional) | `root_ca.crt` | Single file. |
+
+Set **`CERTS_OFFLINE_VERIFICATION=true`** (via `as.extraEnvVars`) to verify the HKD certificate chain offline. Do **not** set `SE_SKIP_CERTS_VERIFICATION=true` outside development — it disables HKD certificate chain verification.
+
+```bash
+# 1. Place all materials under a directory on the target s390x node, e.g.:
+#    $IBM_SE_CREDS_DIR/{rsa/,certs/,crls/,hkds/,hdr/hdr.bin}
+#    See deps/verifier/src/se/README.md for how to obtain the materials.
+
+# 2. Install, pointing the chart at the node and directory:
+helm upgrade --install trustee ./deployment/helm-chart \
+  --namespace coco-trustee --create-namespace \
+  -f ./deployment/helm-chart/scenarios/ibm-se.yaml \
+  --set as.ibmse.credsDir=$IBM_SE_CREDS_DIR \
+  --set as.ibmse.nodeName=<your-s390x-node-name>
+```
+
+Use an **s390x** AS image built with the `se-verifier` feature (`as.image.repository` / `as.image.tag`). See **`scenarios/ibm-se.yaml`** for the full override. Set the SE attestation policy afterwards as documented in `deps/verifier/src/se/README.md`.
+
 ## Testing
 
 **Inspect resources**:

--- a/deployment/helm-chart/scenarios/ibm-se.yaml
+++ b/deployment/helm-chart/scenarios/ibm-se.yaml
@@ -1,0 +1,59 @@
+# IBM Secure Execution (s390x): mount SE attestation materials into the AS Pod.
+#
+# The SE verifier runs inside the gRPC Attestation Service Pod (KBS talks to a
+# remote `coco_as_grpc` AS), so the materials MUST be mounted on the AS Pod, not
+# on KBS. This differs from the builtin-AS kustomize overlay in
+# kbs/config/kubernetes/overlays/ibm-se, which mounts them on KBS.
+#
+# The SE verifier reads materials from fixed paths under
+# /run/confidential-containers/ibmse/ (overridable via SE_* env vars; see
+# deps/verifier/src/se/ibmse.rs).
+#
+# 1) Place all SE materials under a single directory on the target s390x node.
+#    See deps/verifier/src/se/README.md for how to obtain the materials.
+#    The directory must contain:
+#      rsa/encrypt_key.pem   - RSA measurement encryption private key (sensitive)
+#      rsa/encrypt_key.pub   - RSA measurement encryption public key
+#      certs/                - signing / intermediate certs (directory)
+#      crls/                 - CRLs (directory)
+#      hkds/                 - Host Key Documents (directory)
+#      hdr/hdr.bin           - SE image header (binary)
+#      root_ca.crt           - root CA (optional, single file)
+#
+# 2) Install with an s390x AS image that includes the SE verifier, supplying the
+#    node name and credentials directory:
+#
+#   helm upgrade --install trustee ./deployment/helm-chart \
+#     --namespace coco-trustee --create-namespace \
+#     -f ./deployment/helm-chart/scenarios/ibm-se.yaml \
+#     --set as.ibmse.nodeName=<your-s390x-node-name> \
+#     --set as.ibmse.credsDir=<absolute-path-to-materials-dir>
+#
+# Notes:
+# - CERTS_OFFLINE_VERIFICATION: set to "true" to verify the HKD certificate chain
+#   offline (recommended for production). Defaults to "false".
+# - SE_SKIP_CERTS_VERIFICATION: set to "true" ONLY for local development to skip
+#   HKD certificate chain verification entirely. Must be "false" in production.
+# - podSecurityContext.fsGroup must match the owning GID of the files under
+#   credsDir on the node (typically 1000 for a user). Kubernetes applies a chgrp to
+#   the mounted volume so the container can read owner-restricted files even though
+#   CAP_DAC_OVERRIDE is dropped.
+
+as:
+  # Use an s390x AS image built with the se-verifier feature. The default
+  # staged coco-as-grpc image tag must match your cluster architecture (s390x).
+  image:
+    repository: ghcr.io/confidential-containers/staged-images/coco-as-grpc
+    tag: "latest"
+  ibmse:
+    # Set via --set as.ibmse.nodeName=<node> at install time.
+    nodeName: ""
+    # Set via --set as.ibmse.credsDir=<path> at install time.
+    credsDir: ""
+  extraEnvVars:
+    - name: CERTS_OFFLINE_VERIFICATION
+      value: "false"
+    - name: SE_SKIP_CERTS_VERIFICATION
+      value: "false"
+  podSecurityContext:
+    fsGroup: 1000

--- a/deployment/helm-chart/templates/_helpers.tpl
+++ b/deployment/helm-chart/templates/_helpers.tpl
@@ -99,6 +99,12 @@ Each helper truncates `coco-trustee.fullname` to leave room for its suffix befor
 {{- define "coco-trustee.names.postgresInitdb" -}}
 {{- printf "%s-postgres-initdb" .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end }}
+{{- define "coco-trustee.names.ibmse.pv" -}}
+{{- printf "%s-ibmse-pv" (include "coco-trustee.fullname" . | trunc 54 | trimSuffix "-") | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+{{- define "coco-trustee.names.ibmse.pvc" -}}
+{{- printf "%s-ibmse-pvc" (include "coco-trustee.fullname" . | trunc 53 | trimSuffix "-") | trunc 63 | trimSuffix "-" -}}
+{{- end }}
 
 {{/*
 Fixed workload ports (override only via undocumented values for advanced use).

--- a/deployment/helm-chart/templates/as-deployment.yaml
+++ b/deployment/helm-chart/templates/as-deployment.yaml
@@ -109,6 +109,10 @@ spec:
               mountPath: /opt/confidential-containers/kbs/user-keys
             - name: data
               mountPath: /opt/confidential-containers/attestation-service
+            {{- if (.Values.as.ibmse | default dict).credsDir }}
+            - name: ibmse
+              mountPath: /run/confidential-containers/ibmse
+            {{- end }}
       volumes:
         - name: config
           configMap:
@@ -126,6 +130,11 @@ spec:
             claimName: {{ $asClaim }}
         {{- else }}
           emptyDir: {}
+        {{- end }}
+        {{- if (.Values.as.ibmse | default dict).credsDir }}
+        - name: ibmse
+          persistentVolumeClaim:
+            claimName: {{ include "coco-trustee.names.ibmse.pvc" . }}
         {{- end }}
       {{- with .Values.as.nodeSelector }}
       nodeSelector:

--- a/deployment/helm-chart/templates/ibmse-pv.yaml
+++ b/deployment/helm-chart/templates/ibmse-pv.yaml
@@ -1,0 +1,26 @@
+{{- $credsDir := (.Values.as.ibmse | default dict).credsDir | default "" -}}
+{{- if $credsDir -}}
+{{- $nodeName := required "as.ibmse.nodeName is required when as.ibmse.credsDir is set" ((.Values.as.ibmse | default dict).nodeName | default "") -}}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "coco-trustee.names.ibmse.pv" . }}
+  labels:
+    {{- include "coco-trustee.labels" . | nindent 4 }}
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-storage
+  local:
+    path: {{ $credsDir }}
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - {{ $nodeName }}
+{{- end }}

--- a/deployment/helm-chart/templates/ibmse-pvc.yaml
+++ b/deployment/helm-chart/templates/ibmse-pvc.yaml
@@ -1,0 +1,17 @@
+{{- $credsDir := (.Values.as.ibmse | default dict).credsDir | default "" -}}
+{{- if $credsDir -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "coco-trustee.names.ibmse.pvc" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "coco-trustee.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-storage
+  resources:
+    requests:
+      storage: 1Gi
+{{- end }}

--- a/deployment/helm-chart/values.yaml
+++ b/deployment/helm-chart/values.yaml
@@ -184,6 +184,17 @@ as:
     limits:
       cpu: "4"
       memory: 4Gi
+  # -- IBM Secure Execution (s390x) attestation materials. When `credsDir` is non-empty
+  # the chart creates a `local`-type PersistentVolume + PersistentVolumeClaim and mounts
+  # the directory at `/run/confidential-containers/ibmse/` on the AS Pod.
+  ibmse:
+    # -- Absolute path on the target node to the directory containing IBM SE attestation
+    # materials (`rsa/`, `certs/`, `crls/`, `hkds/`, `hdr/hdr.bin`). When non-empty,
+    # the chart creates a `local`-type PV + PVC. Requires `as.ibmse.nodeName`.
+    credsDir: ""
+    # -- Kubernetes node name where the IBM SE materials directory (`as.ibmse.credsDir`)
+    # resides. Required when `as.ibmse.credsDir` is set; used in the PV `nodeAffinity`.
+    nodeName: ""
   # -- Extra environment variables for the AS container (for example `HTTP(S)_PROXY` and `NO_PROXY`).
   extraEnvVars: []
   # -- Extra Pod annotations.


### PR DESCRIPTION
The gRPC AS Pod runs the verifiers, so IBM Secure Execution materials (RSA measurement key pair, signing certs, CRLs, host key documents and the SE image header) must be mounted on the AS Pod rather than KBS. The AS deployment previously only exposed `as.extraEnvVars`, leaving no way to attach these volumes.

Add `as.extraVolumes` / `as.extraVolumeMounts` (mirroring the existing KBS hooks), wire them into the AS deployment template, document the s390x SE flow in the chart README, and provide a ready-to-use `scenarios/ibm-se.yaml` override that mounts the materials at their default `/run/confidential-containers/ibmse/` paths.

cc @BbolroC 