### PR TITLE
ci: only run TDX leg when the tdx-e2e label is added

### DIFF
--- a/.github/workflows/test-e2e-kbs.yml
+++ b/.github/workflows/test-e2e-kbs.yml
@@ -13,12 +13,23 @@ permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Adding the `tdx-e2e` label starts an additive run that only exercises the TDX
+  # leg (see the per-job `if` guards below), so it must not cancel an in-progress
+  # full suite for the same PR. A subsequent push (synchronize) still cancels
+  # stale runs as usual.
+  cancel-in-progress: ${{ github.event.action != 'labeled' }}
 
 jobs:
+  # A `labeled` event (adding `tdx-e2e`) must only fan out to the TDX Helm leg,
+  # not re-run the whole suite. Every job that is not part of the TDX leg is
+  # therefore skipped on `labeled` events via `if: github.event.action != 'labeled'`.
+  # `github.event.action` is empty for `workflow_dispatch`, so manual runs still
+  # execute everything.
+
   # Common checkout + source archive for all e2e jobs
   code-checkout:
     name: KBS - checkout & archive
+    if: ${{ github.event.action != 'labeled' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -38,6 +49,7 @@ jobs:
   # Sample TEE e2e (reuses kbs-e2e template)
   sample-e2e-amd64:
     name: Sample TEE e2e (amd64)
+    if: ${{ github.event.action != 'labeled' }}
     needs: code-checkout
     uses: ./.github/workflows/workflow-call-kbs-e2e.yml
     permissions:
@@ -49,6 +61,7 @@ jobs:
 
   sample-e2e-arm64:
     name: Sample TEE e2e (arm64)
+    if: ${{ github.event.action != 'labeled' }}
     needs: code-checkout
     uses: ./.github/workflows/workflow-call-kbs-e2e.yml
     permissions:
@@ -65,6 +78,7 @@ jobs:
   # Vault integration e2e
   vault-e2e-test:
     name: Vault e2e
+    if: ${{ github.event.action != 'labeled' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -97,6 +111,9 @@ jobs:
   # Docker Compose/Helm e2e materials (shared via workflow artifacts)
   build-docker-e2e-materials:
     name: Build Docker/Helm e2e materials
+    # Feeds both the Docker Compose e2e and the Helm legs (incl. TDX), so it must
+    # also run on a `tdx-e2e` label even though most other jobs are skipped then.
+    if: ${{ github.event.action != 'labeled' || contains(github.event.pull_request.labels.*.name, 'tdx-e2e') }}
     uses: ./.github/workflows/workflow-call-build-docker-e2e-materials.yml
     permissions:
       contents: read
@@ -104,6 +121,7 @@ jobs:
   # Docker Compose cluster e2e
   docker-e2e-test:
     name: Docker Compose e2e
+    if: ${{ github.event.action != 'labeled' }}
     needs: build-docker-e2e-materials
     strategy:
       matrix:
@@ -159,6 +177,7 @@ jobs:
   # External plugin e2e
   ext-plugin-e2e-test:
     name: External Plugin e2e
+    if: ${{ github.event.action != 'labeled' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -210,6 +229,7 @@ jobs:
   # Sample TEE Helm e2e on a GitHub-hosted runner (always runs).
   helm-trustee-e2e-amd64:
     name: Helm Trustee e2e (amd64)
+    if: ${{ github.event.action != 'labeled' }}
     needs: build-docker-e2e-materials
     uses: ./.github/workflows/workflow-call-helm-e2e.yml
     permissions:


### PR DESCRIPTION
The KBS e2e suite listens for `labeled` pull_request events so the TDX Helm leg can be triggered on demand. Previously any label change re-ran the entire suite, and the workflow-level `cancel-in-progress` meant adding the label also cancelled an in-progress full run for the same PR.

Guard every non-TDX job with `if: github.event.action != 'labeled'` so a `labeled` event only fans out to the TDX leg (and its image-build dependency), and make `cancel-in-progress` skip cancellation on `labeled` events so the label run is purely additive.

This is firstly found in https://github.com/confidential-containers/trustee/pull/1467