### PR TITLE
ci: remove Azure vTPM e2e legs

### DIFF
--- a/.github/workflows/test-e2e-kbs.yml
+++ b/.github/workflows/test-e2e-kbs.yml
@@ -255,32 +255,3 @@ jobs:
       runs-on: '{"group":"Intel TDX"}'
       client-artifact: helm-e2e-kbs-client-tdx-linux-amd64
       self-hosted: true
-
-  # Azure vTPM TEE e2e (manual trigger only)
-  tdx-e2e-test:
-    name: KBS e2e (Azure TDX vTPM)
-    needs: code-checkout
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/workflow-call-kbs-e2e.yml
-    permissions:
-      packages: write
-      contents: read
-    with:
-      runs-on-test: '["self-hosted","azure-cvm-tdx"]'
-      tee: az-tdx-vtpm
-      tarball: kbs.tar.gz
-      kbs-client-features: az-tdx-vtpm-attester
-
-  snp-e2e-test:
-    name: KBS e2e (Azure SNP vTPM)
-    needs: code-checkout
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/workflow-call-kbs-e2e.yml
-    permissions:
-      packages: write
-      contents: read
-    with:
-      runs-on-test: '["self-hosted","azure-cvm"]'
-      tee: az-snp-vtpm
-      tarball: kbs.tar.gz
-      kbs-client-features: az-snp-vtpm-attester

--- a/.github/workflows/workflow-call-kbs-e2e.yml
+++ b/.github/workflows/workflow-call-kbs-e2e.yml
@@ -98,15 +98,7 @@ jobs:
       run: tar xzf ./test.tar.gz
 
     - name: Install dependencies and run e2e test
-      if: inputs.tee != 'az-tdx-vtpm' && inputs.tee != 'az-snp-vtpm'
       run: |
         sudo apt-get update
         sudo apt-get install -y make --no-install-recommends
         make test-kbs-e2e
-
-    - name: Run e2e test (w/ sudo, includes deps)
-      if: inputs.tee == 'az-tdx-vtpm' || inputs.tee == 'az-snp-vtpm'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y make --no-install-recommends
-        sudo -E make test-kbs-e2e


### PR DESCRIPTION
The Azure TDX/SNP vTPM e2e jobs relied on self-hosted `azure-cvm` runners that are no longer available, so drop the two manual-dispatch jobs and the Azure-specific branching in the reusable e2e workflow.

Now the `kbs/test` is still used by other tests, thus not deleted.

cc @mkulke 