### PR TITLE
ci: Add zizmor GitHub Actions security analysis workflow

### DIFF
--- a/.github/actions/build-single-image/action.yml
+++ b/.github/actions/build-single-image/action.yml
@@ -48,30 +48,38 @@ runs:
 
     - name: Build image
       shell: bash
+      env:
+        INPUT_PLATFORM: ${{ inputs.platform }}
+        INPUT_BUILD_ARGS: ${{ inputs.build_args }}
+        INPUT_PUSH: ${{ inputs.push }}
+        INPUT_LOAD: ${{ inputs.load }}
+        INPUT_DOCKER_FILE: ${{ inputs.docker_file }}
+        INPUT_TAG: ${{ inputs.tag }}
+        INPUT_CONTEXT: ${{ inputs.context }}
       run: |
         set -euo pipefail
         commit_sha="${GITHUB_SHA}"
         platform_args=()
-        if [ -n "${{ inputs.platform }}" ]; then
-          platform_args+=(--platform "${{ inputs.platform }}")
+        if [ -n "${INPUT_PLATFORM}" ]; then
+          platform_args+=(--platform "${INPUT_PLATFORM}")
         fi
 
         # Parse build args into array to avoid shell injection.
         build_args_array=()
-        if [ -n "${{ inputs.build_args }}" ]; then
-          read -r -a build_args_array <<< "${{ inputs.build_args }}"
+        if [ -n "${INPUT_BUILD_ARGS}" ]; then
+          read -r -a build_args_array <<< "${INPUT_BUILD_ARGS}"
         fi
         build_option_args=()
-        if [ "${{ inputs.push }}" = "true" ]; then
+        if [ "${INPUT_PUSH}" = "true" ]; then
           build_option_args+=(--push)
-        elif [ "${{ inputs.load }}" = "true" ]; then
+        elif [ "${INPUT_LOAD}" = "true" ]; then
           build_option_args+=(--load)
         fi
         docker buildx build --provenance false \
           "${platform_args[@]}" \
-          -f "${{ inputs.docker_file }}" \
+          -f "${INPUT_DOCKER_FILE}" \
           "${build_option_args[@]}" \
           "${build_args_array[@]}" \
-          -t "ghcr.io/confidential-containers/staged-images/${{ inputs.tag }}:${commit_sha}-$(uname -m)" \
-          -t "ghcr.io/confidential-containers/staged-images/${{ inputs.tag }}:latest-$(uname -m)" \
-          "${{ inputs.context }}"
+          -t "ghcr.io/confidential-containers/staged-images/${INPUT_TAG}:${commit_sha}-$(uname -m)" \
+          -t "ghcr.io/confidential-containers/staged-images/${INPUT_TAG}:latest-$(uname -m)" \
+          "${INPUT_CONTEXT}"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "cargo"
     directory: "/"
@@ -12,6 +14,8 @@ updates:
     open-pull-requests-limit: 3
     allow:
       - dependency-type: direct
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -21,3 +25,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,32 @@
+name: GitHub Actions Security Analysis with 🌈zizmor
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+  schedule:
+  - cron: "0 3 * * 1" # Every Monday Weekly
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+        fetch-depth: 0
+
+    - name: Run zizmor
+      uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+      with:
+        advanced-security: false
+        annotations: true
+        persona: regular


### PR DESCRIPTION
## Why

GitHub Actions workflows are a common attack surface — misconfigurations such as template injection, over-broad permissions, and unpinned action refs can lead to secret exfiltration or supply-chain compromise. [zizmor](https://github.com/zizmorcore/zizmor) is a static analysis tool purpose-built to audit workflow files for exactly these classes of issues.

## What

Adds `.github/workflows/zizmor.yaml` which runs zizmor in `regular` persona mode on every push to `main`, every pull request, and on a weekly schedule (Mondays 03:00 UTC).

Key properties of the new workflow:
- `permissions: {}` — no token permissions granted to the job itself
- `concurrency` group — cancels superseded runs on the same PR/ref
- All actions pinned to full commit SHAs (same convention already used across this repo)
- `advanced-security: false` — no GHSA/CodeQL upload required; inline PR annotations are used instead
- `persona: regular` — standard ruleset

Also fixes pre-existing security findings surfaced by zizmor:
- `.github/actions/build-single-image/action.yml` — 10× `template-injection` (high): moved all `inputs.*` template expansions into `env:` vars
- `.github/dependabot.yml` — 3× `dependabot-cooldown` (medium): added `cooldown: default-days: 7` to all three ecosystems

## Local validation

zizmor was run locally against the full repo before this PR:

```console
$ zizmor --persona regular .
No findings to report. Good job!

actionlint also reported no issues:

```
actionlint .github/workflows/zizmor.yaml
```
(clean — no output)

---

> Assisted by [IBM Bob](https://github.com/IBM/bob)