### PR TITLE
GHA: Add Helm e2e nightly test for IBM SEL

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -3,3 +3,4 @@ self-hosted-runner:
   labels:
     - ubuntu-24.04-s390x
     - s390x-large
+    - s390x

--- a/.github/workflows/helm-e2e-nightly.yml
+++ b/.github/workflows/helm-e2e-nightly.yml
@@ -1,0 +1,21 @@
+name: Helm Trustee e2e test nightly
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+   helm-trustee-e2e-ibm-sel:
+    runs-on: s390x
+    strategy:
+      fail-fast: false
+      matrix:
+        test_title:
+          - cc-trustee-helm-e2e-tests
+    steps:
+    - name: Fetch a test result for {{ matrix.test_title }}
+      run: |
+        file_name="${TEST_TITLE}-$(date +%Y-%m-%d).log"
+        "/home/${USER}/script/handle_test_log.sh" download "$file_name"
+      env:
+        TEST_TITLE: ${{ matrix.test_title }}


### PR DESCRIPTION
Due to lack of registered IBM SEL self-hosted runners to CoCo, establish a GHA workflow to fetch a test result nightly from an internal IBM SEL LPAR.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>