### PR TITLE
helm: Rename as.ibmse to as.verifier.se

### DIFF
--- a/deployment/helm-chart/README.md
+++ b/deployment/helm-chart/README.md
@@ -113,7 +113,7 @@ Or use **`scenarios/bring-your-own-keys.yaml`** (adjust Secret name / file paths
 
 On **s390x**, the **IBM Secure Execution (SE)** verifier needs attestation materials at runtime. Because KBS talks to a **remote `coco_as_grpc` AS**, the verifier runs inside the **AS Pod**, so these materials must be mounted on **AS**, not KBS. (This differs from the builtin-AS kustomize overlay in `kbs/config/kubernetes/overlays/ibm-se`, which mounts them on KBS.)
 
-The verifier reads materials from fixed paths under **`/run/confidential-containers/ibmse/`** (overridable via `SE_*` env vars; see `deps/verifier/src/se/README.md`). The chart mounts them from a **local node path** via a PersistentVolume / PersistentVolumeClaim — set **`as.ibmse.credsDir`** to the directory on the node that contains the materials (equivalent to `IBM_SE_CREDS_DIR` used in the kustomize overlay), and **`as.ibmse.nodeName`** to the name of that node.  The chart then creates a `local`-type PV + PVC and mounts the whole directory at `/run/confidential-containers/ibmse/` on the AS Pod.
+The verifier reads materials from fixed paths under **`/run/confidential-containers/ibmse/`** (overridable via `SE_*` env vars; see `deps/verifier/src/se/README.md`). The chart mounts them from a **local node path** via a PersistentVolume / PersistentVolumeClaim — set **`as.verifier.se.credsDir`** to the directory on the node that contains the materials (equivalent to `IBM_SE_CREDS_DIR` used in the kustomize overlay), and **`as.verifier.se.nodeName`** to the name of that node.  The chart then creates a `local`-type PV + PVC and mounts the whole directory at `/run/confidential-containers/ibmse/` on the AS Pod.
 
 | Material | Expected path under `credsDir` | Notes |
 |----------|-------------------------------|-------|
@@ -135,8 +135,8 @@ Set **`CERTS_OFFLINE_VERIFICATION=true`** (via `as.extraEnvVars`) to verify the 
 helm upgrade --install trustee ./deployment/helm-chart \
   --namespace coco-trustee --create-namespace \
   -f ./deployment/helm-chart/scenarios/ibm-se.yaml \
-  --set as.ibmse.credsDir=$IBM_SE_CREDS_DIR \
-  --set as.ibmse.nodeName=<your-s390x-node-name>
+  --set as.verifier.se.credsDir=$IBM_SE_CREDS_DIR \
+  --set as.verifier.se.nodeName=<your-s390x-node-name>
 ```
 
 Use an **s390x** AS image built with the `se-verifier` feature (`as.image.repository` / `as.image.tag`). See **`scenarios/ibm-se.yaml`** for the full override. Set the SE attestation policy afterwards as documented in `deps/verifier/src/se/README.md`.
@@ -195,8 +195,8 @@ Default **`values.yaml`** is intentionally small. Fixed on-disk paths for **Loca
 |-----|------|---------|-------------|
 | as.affinity | object | `{}` | Affinity and anti-affinity scheduling rules for AS Pods. |
 | as.extraEnvVars | list | `[]` | Extra environment variables for the AS container (for example `HTTP(S)_PROXY` and `NO_PROXY`). |
-| as.ibmse.credsDir | string | `""` | Absolute path on the target node to the directory containing IBM SE attestation materials (`rsa/`, `certs/`, `crls/`, `hkds/`, `hdr/hdr.bin`). When non-empty, the chart creates a `local`-type PersistentVolume + PersistentVolumeClaim and mounts the directory at `/run/confidential-containers/ibmse/` on the AS Pod. Requires `as.ibmse.nodeName`. |
-| as.ibmse.nodeName | string | `""` | Kubernetes node name where the IBM SE materials directory (`as.ibmse.credsDir`) resides. Required when `as.ibmse.credsDir` is set; used in the PersistentVolume `nodeAffinity`. |
+| as.verifier.se.credsDir | string | `""` | Absolute path on the target node to the directory containing IBM SE attestation materials (`rsa/`, `certs/`, `crls/`, `hkds/`, `hdr/hdr.bin`). When non-empty, the chart creates a `local`-type PersistentVolume + PersistentVolumeClaim and mounts the directory at `/run/confidential-containers/ibmse/` on the AS Pod. Requires `as.verifier.se.nodeName`. |
+| as.verifier.se.nodeName | string | `""` | Kubernetes node name where the IBM SE materials directory (`as.verifier.se.credsDir`) resides. Required when `as.verifier.se.credsDir` is set; used in the PersistentVolume `nodeAffinity`. |
 | as.image.pullPolicy | string | `"Always"` | AS container image pull policy. |
 | as.image.repository | string | `"ghcr.io/confidential-containers/staged-images/coco-as-grpc"` | AS container image repository. |
 | as.image.tag | string | `"latest"` | AS container image tag. |

--- a/deployment/helm-chart/README.md.gotmpl
+++ b/deployment/helm-chart/README.md.gotmpl
@@ -113,7 +113,7 @@ Or use **`scenarios/bring-your-own-keys.yaml`** (adjust Secret name / file paths
 
 On **s390x**, the **IBM Secure Execution (SE)** verifier needs attestation materials at runtime. Because KBS talks to a **remote `coco_as_grpc` AS**, the verifier runs inside the **AS Pod**, so these materials must be mounted on **AS**, not KBS. (This differs from the builtin-AS kustomize overlay in `kbs/config/kubernetes/overlays/ibm-se`, which mounts them on KBS.)
 
-The verifier reads materials from fixed paths under **`/run/confidential-containers/ibmse/`** (overridable via `SE_*` env vars; see `deps/verifier/src/se/ibmse.rs` and `deps/verifier/src/se/README.md`). The chart mounts them from a **local node path** via a PersistentVolume / PersistentVolumeClaim — set **`as.ibmse.credsDir`** to the directory on the node that contains the materials (equivalent to `IBM_SE_CREDS_DIR` used in the kustomize overlay), and **`as.ibmse.nodeName`** to the name of that node.  The chart then creates a `local`-type PV + PVC and mounts the whole directory at `/run/confidential-containers/ibmse/` on the AS Pod.
+The verifier reads materials from fixed paths under **`/run/confidential-containers/ibmse/`** (overridable via `SE_*` env vars; see `deps/verifier/src/se/ibmse.rs` and `deps/verifier/src/se/README.md`). The chart mounts them from a **local node path** via a PersistentVolume / PersistentVolumeClaim — set **`as.verifier.se.credsDir`** to the directory on the node that contains the materials (equivalent to `IBM_SE_CREDS_DIR` used in the kustomize overlay), and **`as.verifier.se.nodeName`** to the name of that node.  The chart then creates a `local`-type PV + PVC and mounts the whole directory at `/run/confidential-containers/ibmse/` on the AS Pod.
 
 | Material | Expected path under `credsDir` | Notes |
 |----------|-------------------------------|-------|
@@ -135,8 +135,8 @@ Set **`CERTS_OFFLINE_VERIFICATION=true`** (via `as.extraEnvVars`) to verify the 
 helm upgrade --install trustee ./deployment/helm-chart \
   --namespace coco-trustee --create-namespace \
   -f ./deployment/helm-chart/scenarios/ibm-se.yaml \
-  --set as.ibmse.credsDir=$IBM_SE_CREDS_DIR \
-  --set as.ibmse.nodeName=<your-s390x-node-name>
+  --set as.verifier.se.credsDir=$IBM_SE_CREDS_DIR \
+  --set as.verifier.se.nodeName=<your-s390x-node-name>
 ```
 
 Use an **s390x** AS image built with the `se-verifier` feature (`as.image.repository` / `as.image.tag`). See **`scenarios/ibm-se.yaml`** for the full override. Set the SE attestation policy afterwards as documented in `deps/verifier/src/se/README.md`.

--- a/deployment/helm-chart/scenarios/ibm-se.yaml
+++ b/deployment/helm-chart/scenarios/ibm-se.yaml
@@ -26,8 +26,8 @@
 #   helm upgrade --install trustee ./deployment/helm-chart \
 #     --namespace coco-trustee --create-namespace \
 #     -f ./deployment/helm-chart/scenarios/ibm-se.yaml \
-#     --set as.ibmse.nodeName=<your-s390x-node-name> \
-#     --set as.ibmse.credsDir=<absolute-path-to-materials-dir>
+#     --set as.verifier.se.nodeName=<your-s390x-node-name> \
+#     --set as.verifier.se.credsDir=<absolute-path-to-materials-dir>
 #
 # Notes:
 # - CERTS_OFFLINE_VERIFICATION: set to "true" to verify the HKD certificate chain
@@ -45,11 +45,12 @@ as:
   image:
     repository: ghcr.io/confidential-containers/staged-images/coco-as-grpc
     tag: "latest"
-  ibmse:
-    # Set via --set as.ibmse.nodeName=<node> at install time.
-    nodeName: ""
-    # Set via --set as.ibmse.credsDir=<path> at install time.
-    credsDir: ""
+  verifier:
+    se:
+      # Set via --set as.verifier.se.nodeName=<node> at install time.
+      nodeName: ""
+      # Set via --set as.verifier.se.credsDir=<path> at install time.
+      credsDir: ""
   extraEnvVars:
     - name: CERTS_OFFLINE_VERIFICATION
       value: "false"

--- a/deployment/helm-chart/templates/as-deployment.yaml
+++ b/deployment/helm-chart/templates/as-deployment.yaml
@@ -109,7 +109,7 @@ spec:
               mountPath: /opt/confidential-containers/kbs/user-keys
             - name: data
               mountPath: /opt/confidential-containers/attestation-service
-            {{- if (.Values.as.ibmse | default dict).credsDir }}
+            {{- if ((.Values.as.verifier | default dict).se | default dict).credsDir }}
             - name: ibmse
               mountPath: /run/confidential-containers/ibmse
             {{- end }}
@@ -131,7 +131,7 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
-        {{- if (.Values.as.ibmse | default dict).credsDir }}
+        {{- if ((.Values.as.verifier | default dict).se | default dict).credsDir }}
         - name: ibmse
           persistentVolumeClaim:
             claimName: {{ include "coco-trustee.names.ibmse.pvc" . }}

--- a/deployment/helm-chart/templates/ibmse-pv.yaml
+++ b/deployment/helm-chart/templates/ibmse-pv.yaml
@@ -1,6 +1,6 @@
-{{- $credsDir := (.Values.as.ibmse | default dict).credsDir | default "" -}}
+{{- $credsDir := ((.Values.as.verifier | default dict).se | default dict).credsDir | default "" -}}
 {{- if $credsDir -}}
-{{- $nodeName := required "as.ibmse.nodeName is required when as.ibmse.credsDir is set" ((.Values.as.ibmse | default dict).nodeName | default "") -}}
+{{- $nodeName := required "as.verifier.se.nodeName is required when as.verifier.se.credsDir is set" (((.Values.as.verifier | default dict).se | default dict).nodeName | default "") -}}
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/deployment/helm-chart/templates/ibmse-pvc.yaml
+++ b/deployment/helm-chart/templates/ibmse-pvc.yaml
@@ -1,4 +1,4 @@
-{{- $credsDir := (.Values.as.ibmse | default dict).credsDir | default "" -}}
+{{- $credsDir := ((.Values.as.verifier | default dict).se | default dict).credsDir | default "" -}}
 {{- if $credsDir -}}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/deployment/helm-chart/values.yaml
+++ b/deployment/helm-chart/values.yaml
@@ -169,6 +169,17 @@ as:
       collateral_service: "https://api.trustedservices.intel.com/sgx/certification/v4/"
       # -- DCAP TCB update type (for example `early`).
       tcb_update_type: "early"
+    se:
+      # -- IBM Secure Execution (s390x) attestation materials. When `credsDir` is non-empty
+      # the chart creates a `local`-type PersistentVolume + PersistentVolumeClaim and mounts
+      # the directory at `/run/confidential-containers/ibmse/` on the AS Pod.
+      # -- Absolute path on the target node to the directory containing IBM SE attestation
+      # materials (`rsa/`, `certs/`, `crls/`, `hkds/`, `hdr/hdr.bin`). When non-empty,
+      # the chart creates a `local`-type PV + PVC. Requires `as.verifier.se.nodeName`.
+      credsDir: ""
+      # -- Kubernetes node name where the IBM SE materials directory (`as.verifier.se.credsDir`)
+      # resides. Required when `as.verifier.se.credsDir` is set; used in the PV `nodeAffinity`.
+      nodeName: ""
   service:
     # -- AS Service type (`ClusterIP` or `LoadBalancer`).
     type: ClusterIP
@@ -184,17 +195,6 @@ as:
     limits:
       cpu: "4"
       memory: 4Gi
-  # -- IBM Secure Execution (s390x) attestation materials. When `credsDir` is non-empty
-  # the chart creates a `local`-type PersistentVolume + PersistentVolumeClaim and mounts
-  # the directory at `/run/confidential-containers/ibmse/` on the AS Pod.
-  ibmse:
-    # -- Absolute path on the target node to the directory containing IBM SE attestation
-    # materials (`rsa/`, `certs/`, `crls/`, `hkds/`, `hdr/hdr.bin`). When non-empty,
-    # the chart creates a `local`-type PV + PVC. Requires `as.ibmse.nodeName`.
-    credsDir: ""
-    # -- Kubernetes node name where the IBM SE materials directory (`as.ibmse.credsDir`)
-    # resides. Required when `as.ibmse.credsDir` is set; used in the PV `nodeAffinity`.
-    nodeName: ""
   # -- Extra environment variables for the AS container (for example `HTTP(S)_PROXY` and `NO_PROXY`).
   extraEnvVars: []
   # -- Extra Pod annotations.


### PR DESCRIPTION
Move the IBM SE verifier Helm values from the standalone `as.ibmse` key to `as.verifier.se`, consistent with the existing `as.verifier.nvidia` and `as.verifier.dcap` structure.

Updated files:
- values.yaml: move ibmse block under as.verifier.se
- scenarios/ibm-se.yaml: update key and --set examples
- templates/ibmse-pv.yaml: update .Values path and required() message
- templates/ibmse-pvc.yaml: update .Values path
- templates/as-deployment.yaml: update both ibmse guards
- README.md / README.md.gotmpl: update prose and values table

Assisted-by: IBM Bob <noreply@ibm.com>
Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>