### PR TITLE
key-value-storage: handle absent features

### DIFF
--- a/deps/key-value-storage/src/lib.rs
+++ b/deps/key-value-storage/src/lib.rs
@@ -107,6 +107,10 @@ impl KeyValueStorageStructConfig {
                         })?;
                 Ok(Arc::new(postgres::PostgresClient::new(config.clone(), namespace).await?) as _)
             }
+            #[cfg(not(feature = "postgres"))]
+            KeyValueStorageType::Postgres => Err(KeyValueStorageError::InvalidConfiguration {
+                message: "PostgreSQL storage support is not enabled".to_string(),
+            }),
             #[cfg(feature = "redis")]
             KeyValueStorageType::Redis => {
                 let config =
@@ -117,6 +121,10 @@ impl KeyValueStorageStructConfig {
                         })?;
                 Ok(Arc::new(redis::RedisClient::new(config.clone(), namespace).await?) as _)
             }
+            #[cfg(not(feature = "redis"))]
+            KeyValueStorageType::Redis => Err(KeyValueStorageError::InvalidConfiguration {
+                message: "Redis storage support is not enabled".to_string(),
+            }),
             KeyValueStorageType::LocalJson => {
                 let config =
                     self.local_json


### PR DESCRIPTION
Currently we can't compile some tests b/c we do not handle the case for absent features:

```bash
 cargo t -p verifier --no-default-features --features az-snp-vtpm-verifier az_snp_vtpm
   Compiling key-value-storage v0.1.0 (... trustee/deps/key-value-storage)
error[E0004]: non-exhaustive patterns: `KeyValueStorageType::Postgres` and `KeyValueStorageType::Redis` not covered
  --> deps/key-value-storage/src/lib.rs:99:15
   |
99 |         match r#type {
   |               ^^^^^^ patterns `KeyValueStorageType::Postgres` and `KeyValueStorageType::Redis` not covered
   |
note: `KeyValueStorageType` defined here
  --> deps/key-value-storage/src/lib.rs:64:10
   |
64 | pub enum KeyValueStorageType {
   |          ^^^^^^^^^^^^^^^^^^^
...
73 |     Postgres,
   |     -------- not covered
74 |     #[serde(alias = "redis")]
75 |     Redis,
   |     ----- not covered
   = note: the matched value is of type `KeyValueStorageType`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or
multiple match arms
   |
140~             },
141+             KeyValueStorageType::Postgres | KeyValueStorageType::Redis => todo!()
   |
```

If we add cfg(not()) arms the test can be compiled.