### PR TITLE
ci: pin source tarball artifact name in kbs e2e

### DIFF
--- a/.github/workflows/test-e2e-kbs.yml
+++ b/.github/workflows/test-e2e-kbs.yml
@@ -44,6 +44,7 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          name: kbs-source
           path: ./kbs.tar.gz
 
   # Sample TEE e2e (reuses kbs-e2e template)

--- a/.github/workflows/workflow-call-kbs-e2e.yml
+++ b/.github/workflows/workflow-call-kbs-e2e.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: kbs-source
 
     - name: Extract tarball
       run: tar xzf "./${INPUTS_TARBALL}"


### PR DESCRIPTION
The build-binaries job of the reusable kbs e2e workflow downloaded all artifacts of the run without specifying a name. download-artifact places a single artifact at the workspace root, but once other jobs (e.g. the helm e2e materials build) have already uploaded their artifacts, each artifact ends up in its own subdirectory and the subsequent "tar xzf ./kbs.tar.gz" fails with "No such file or directory". Whether the leg passed depended on job timing.

Give the source tarball artifact an explicit name and download only that artifact, so the layout no longer depends on what else has been uploaded.