### PR TITLE
ci: rename tdx-vm group name

### DIFF
--- a/.github/workflows/test-e2e-helm-nightly.yml
+++ b/.github/workflows/test-e2e-helm-nightly.yml
@@ -67,6 +67,6 @@ jobs:
       contents: read
     with:
       leg: tdx
-      runs-on: '{"group":"Intel TDX"}'
+      runs-on: '{"group":"tdx-vm"}'
       client-artifact: helm-e2e-kbs-client-tdx-linux-amd64
       self-hosted: true

--- a/.github/workflows/test-e2e-kbs.yml
+++ b/.github/workflows/test-e2e-kbs.yml
@@ -252,6 +252,6 @@ jobs:
     with:
       leg: tdx
       # Runner group hosting the TDX runner(s); add `labels` here to narrow further.
-      runs-on: '{"group":"Intel TDX"}'
+      runs-on: '{"group":"tdx-vm"}'
       client-artifact: helm-e2e-kbs-client-tdx-linux-amd64
       self-hosted: true


### PR DESCRIPTION
Now organization level runners would have a common name format, s.t. xxx-vm

for CVM on arch xxx.