### PR TITLE
kbs: add GCP build flag to Makefile and Dockerfile

### DIFF
--- a/kbs/Makefile
+++ b/kbs/Makefile
@@ -2,6 +2,7 @@ AS_TYPE ?= coco-as
 ALIYUN ?= false
 NEBULA_CA_PLUGIN ?= false
 VAULT ?= true
+GCP ?= false
 EXTERNAL_PLUGIN ?= false
 
 BUILD_ARCH := $(shell uname -m)
@@ -59,6 +60,10 @@ endif
 
 ifeq ($(VAULT), true)
   override FEATURES := $(FEATURES),vault
+endif
+
+ifeq ($(GCP), true)
+  override FEATURES := $(FEATURES),gcp
 endif
 
 ifeq ($(EXTERNAL_PLUGIN), true)

--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -5,6 +5,7 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} \
 ARG ARCH=x86_64
 ARG ALIYUN=false
 ARG VAULT=true
+ARG GCP=false
 ARG EXTERNAL_PLUGIN=false
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -46,7 +47,7 @@ RUN if [ "${ARCH}" = "x86_64" ]; then curl -fsSL https://download.01.org/intel-s
 WORKDIR /usr/src/trustee
 COPY . .
 
-RUN cd kbs && make AS_FEATURE=coco-as-builtin FEATURES=pkcs11 ALIYUN=${ALIYUN} ARCH=${ARCH} VAULT=${VAULT} EXTERNAL_PLUGIN=${EXTERNAL_PLUGIN} && \
+RUN cd kbs && make AS_FEATURE=coco-as-builtin FEATURES=pkcs11 ALIYUN=${ALIYUN} ARCH=${ARCH} VAULT=${VAULT} GCP=${GCP} EXTERNAL_PLUGIN=${EXTERNAL_PLUGIN} && \
     make ARCH=${ARCH} install-kbs
 
 # ubuntu:24.04


### PR DESCRIPTION
## Problem

The `gcp` cargo feature — which enables the Google Secret Manager resource backend added in `kbs/src/plugins/implementations/resource/gcp_sm.rs` — is not in the default feature set:

```
default = ["coco-as-builtin", "coco-as-grpc", "intel-trust-authority-as"]
gcp = ["google-cloud-secretmanager-v1"]
```

and has no build plumbing. `kbs/Makefile` has `ALIYUN`, `VAULT`, `NEBULA_CA_PLUGIN` and `EXTERNAL_PLUGIN` toggles, but nothing for `gcp`, and `kbs/docker/Dockerfile` correspondingly has no `ARG`.

The result is that the backend exists in the tree but cannot be enabled from any image built via `kbs/docker/Dockerfile`.

## Change

- `kbs/Makefile`: add `GCP ?= false` and the matching `ifeq` block, mirroring the existing `VAULT`/`ALIYUN` blocks.
- `kbs/docker/Dockerfile`: add `ARG GCP=false` and thread `GCP=${GCP}` into the `make` invocation.

## Compatibility

Defaults are unchanged — `GCP=false` — so no existing build gains the feature or pulls in the `google-cloud-secretmanager-v1` dependency:

```
$ make -n build           ->  --features coco-as-builtin,,vault
$ make -n build GCP=true  ->  --features coco-as-builtin,,vault,gcp
```

## Notes

- This deliberately does **not** set `GCP=true` for the published staged images in `.github/workflows/build-and-push-staged-images.yml`. Whether the shipped images should carry the GCP SDK is a separate call for maintainers; this PR only makes the feature reachable for those who build their own.
- `aws` has the identical gap (feature exists, no Makefile/Dockerfile toggle). Happy to add it here too, or leave it for a follow-up — kept this PR to one backend for reviewability.