### PR TITLE
kbs: add AWS build flag to Makefile and Dockerfile

### DIFF
--- a/kbs/Makefile
+++ b/kbs/Makefile
@@ -3,6 +3,7 @@ ALIYUN ?= false
 NEBULA_CA_PLUGIN ?= false
 VAULT ?= true
 GCP ?= false
+AWS ?= false
 EXTERNAL_PLUGIN ?= false
 
 BUILD_ARCH := $(shell uname -m)
@@ -64,6 +65,10 @@ endif
 
 ifeq ($(GCP), true)
   override FEATURES := $(FEATURES),gcp
+endif
+
+ifeq ($(AWS), true)
+  override FEATURES := $(FEATURES),aws
 endif
 
 ifeq ($(EXTERNAL_PLUGIN), true)

--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -6,6 +6,7 @@ ARG ARCH=x86_64
 ARG ALIYUN=false
 ARG VAULT=true
 ARG GCP=false
+ARG AWS=false
 ARG EXTERNAL_PLUGIN=false
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -47,7 +48,7 @@ RUN if [ "${ARCH}" = "x86_64" ]; then curl -fsSL https://download.01.org/intel-s
 WORKDIR /usr/src/trustee
 COPY . .
 
-RUN cd kbs && make AS_FEATURE=coco-as-builtin FEATURES=pkcs11 ALIYUN=${ALIYUN} ARCH=${ARCH} VAULT=${VAULT} GCP=${GCP} EXTERNAL_PLUGIN=${EXTERNAL_PLUGIN} && \
+RUN cd kbs && make AS_FEATURE=coco-as-builtin FEATURES=pkcs11 ALIYUN=${ALIYUN} ARCH=${ARCH} VAULT=${VAULT} GCP=${GCP} AWS=${AWS} EXTERNAL_PLUGIN=${EXTERNAL_PLUGIN} && \
     make ARCH=${ARCH} install-kbs
 
 # ubuntu:24.04


### PR DESCRIPTION
## Problem

The `aws` cargo feature — which enables the AWS Secrets Manager resource backend in `kbs/src/plugins/implementations/resource/aws_kms.rs` — is not in the default feature set:

```
default = ["coco-as-builtin", "coco-as-grpc", "intel-trust-authority-as"]
aws = ["aws-config", "aws-sdk-secretsmanager"]
```

and has no build plumbing. `kbs/Makefile` has `ALIYUN`, `VAULT`, `NEBULA_CA_PLUGIN` and `EXTERNAL_PLUGIN` toggles, but nothing for `aws`, and `kbs/docker/Dockerfile` correspondingly has no `ARG`.

The result is that the backend exists in the tree but cannot be enabled from any image built via `kbs/docker/Dockerfile`.

## Change

- `kbs/Makefile`: add `AWS ?= false` and the matching `ifeq` block, mirroring the existing `VAULT`/`ALIYUN` blocks.
- `kbs/docker/Dockerfile`: add `ARG AWS=false` and thread `AWS=${AWS}` into the `make` invocation.

## Compatibility

Defaults are unchanged — `AWS=false` — so no existing build gains the feature or pulls in the `aws-config` / `aws-sdk-secretsmanager` dependencies:

```
$ make -n build           ->  --features coco-as-builtin,,vault
$ make -n build AWS=true  ->  --features coco-as-builtin,,vault,aws
```

## Notes

- Companion to #1495, which does the same for the `gcp` / Secret Manager backend. The two were kept separate for reviewability; they touch adjacent lines, so whichever merges second will need a trivial rebase. Happy to squash them into one PR if maintainers prefer.
- This deliberately does **not** set `AWS=true` for the published staged images in `.github/workflows/build-and-push-staged-images.yml`. Whether the shipped images should carry the AWS SDK is a separate call for maintainers; this PR only makes the feature reachable for those who build their own.