### PR TITLE
Enable CI on SNP 

### DIFF
--- a/.github/workflows/test-e2e-helm-nightly.yml
+++ b/.github/workflows/test-e2e-helm-nightly.yml
@@ -70,3 +70,15 @@ jobs:
       runs-on: '{"group":"tdx-vm"}'
       client-artifact: helm-e2e-kbs-client-tdx-linux-amd64
       self-hosted: true
+
+  helm-trustee-e2e-snp:
+    name: Helm Trustee e2e (SNP)
+    needs: build-docker-e2e-materials
+    uses: ./.github/workflows/workflow-call-helm-e2e.yml
+    permissions:
+      contents: read
+    with:
+      leg: snp
+      runs-on: '{"group":"snp-vm"}'
+      client-artifact: helm-e2e-kbs-client-snp-linux-amd64
+      self-hosted: true

--- a/.github/workflows/test-e2e-kbs-hw.yml
+++ b/.github/workflows/test-e2e-kbs-hw.yml
@@ -41,3 +41,18 @@ jobs:
       runs-on: '{"group":"tdx-vm"}'
       client-artifact: helm-e2e-kbs-client-tdx-linux-amd64
       self-hosted: true
+
+  helm-trustee-e2e-snp:
+    name: Helm Trustee e2e (SNP)
+    needs: build-docker-e2e-materials
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'tee-e2e')
+    uses: ./.github/workflows/workflow-call-helm-e2e.yml
+    permissions:
+      contents: read
+    with:
+      leg: snp
+      runs-on: '{"group":"snp-vm"}'
+      client-artifact: helm-e2e-kbs-client-snp-linux-amd64
+      self-hosted: true

--- a/.github/workflows/workflow-call-build-docker-e2e-materials.yml
+++ b/.github/workflows/workflow-call-build-docker-e2e-materials.yml
@@ -27,6 +27,10 @@ jobs:
           - name: tdx
             features: "--features tdx-attester"
             artifact: helm-e2e-kbs-client-tdx-linux-amd64
+          - name: snp
+            features: "--features snp-attester"
+            artifact: helm-e2e-kbs-client-snp-linux-amd64
+
     env:
       OS_VERSION: ubuntu-24.04
     steps:


### PR DESCRIPTION
Enable CI on SNP VM runner. This will run nightly and on PRs with the `tee-e2e` label.