### PR TITLE
snp-verifier: offline certificate store support for multiple VCEKs per hwid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8455,6 +8455,7 @@ dependencies = [
  "sev 7.1.0",
  "sha2 0.11.0",
  "strum 0.28.0",
+ "tempfile",
  "thiserror 2.0.18",
  "time",
  "tokio",

--- a/attestation-service/docs/amd-offline-certificate-cache.md
+++ b/attestation-service/docs/amd-offline-certificate-cache.md
@@ -1,4 +1,4 @@
-# Offline AMD VCEK Caching Guide
+# Offline AMD VCEK Store Guide
 
 This document describes the process to pre-load VCEKs (Versioned Chip
 Endorsement Keys) into the trustee environment to allow normal attestation
@@ -40,27 +40,47 @@ Update the attestation configuration file to use a predefined vcek store:
 ```
 
 With the `OfflineStore` configuration specified, Trustee will inspect the
-configured directory for VCEK values following the following format:
+configured directory for VCEK values.
 
+Given an attestation report, trustee will search first:
 ```
+# Preferred (TCB-based filename, when present):
+/opt/confidential-containers/attestation-service/kds-store/vcek/{hwid}/{tcb_prefix}_vcek.der
+```
+
+And if that lookup fails, the legacy flat format will be searched:
+```
+# Fallback (legacy flat layout):
 /opt/confidential-containers/attestation-service/kds-store/vcek/{hwid}/vcek.der
 ```
 
-Where `{hwid}` is the hardware ID of the AMD EPYC server in lowercase hexadecimal.
+Where:
+- `{hwid}` is the hardware ID of the AMD EPYC server in lowercase hexadecimal
+- `{tcb_prefix}` is a TCB-parameter-based filename prefix in the format:
+  - For non-Turin processors: `bl{BL}_tee{TEE}_snp{SNP}_ucode{UCODE}`
+  - For Turin processors: the above with `_fmc{FMC}` appended
+
+  Each parameter is zero-padded to 2 digits (e.g., `bl02_tee00_snp06_ucode21`)
 
 ### 2. Create and Populate VCEK directory
 
-Create a `vcek` directory populated with the following structure:
+Create a `vcek` directory populated with one of the following structures per
+hardware ID. The TCB-prefixed filename is recommended, to allow loading multiple VCEKs per host.
 
 ```
 vcek/
 ├── <Hex hardware ID>/ (ID must be lowercase)
-│   └── vcek.der (cert pre-downloaded from kdsintf.amd.com)
+│   ├── vcek.der                          # flat layout (fallback)
+│   └── <TCB prefix>_vcek.der             # optional, preferred when present
 ├── <Hex hardware ID>/
 │   └── vcek.der
-├── <Hex hardware ID>/
-    └── vcek.der
+└── <Hex hardware ID>/
+    └── <TCB prefix>_vcek.der
 ```
+
+The `<TCB prefix>` is derived from the certificate's TCB parameters and follows
+the format `bl{BL}_tee{TEE}_snp{SNP}_ucode{UCODE}` (with `_fmc{FMC}` appended for Turin
+processors). For example: `bl02_tee00_snp06_ucode21_vcek.der`
 
 Trustee requires one unique certificate per physical AMD EPYC server that the
 KBS will be servicing. The server's hardware ID and certificate's URL can be
@@ -77,10 +97,20 @@ https://kdsintf.amd.com/vcek/{version}/{machine}/{product_name}/{hwid}?{params}
 ```
 
 You may download it from a browser by pasting that URL, or you can run
-the following command on any server with network access to AMD's KDS.
+the following command on the SNP host itself (it derives the URL from the
+local firmware). Requires network access to AMD's KDS.
 ```
-sudo snphost fetch vcek der .
+sudo snphost fetch vek der .
 ```
+
+To fetch from a different machine (e.g. a build box), pass the URL explicitly
+so the cert matches the originating host's firmware rather than the local one:
+```
+sudo snphost fetch vek der . "<vcek-url>"
+```
+
+> [!Note]
+> Older versions of `snphost` use `snphost fetch vcek` instead of `vek`. However it's recommended to update to the latest version of `snphost`.
 
 > [!IMPORTANT]
 > - Note that the VCEK URL is specific to the hardware AMD firmware of the
@@ -94,7 +124,7 @@ sudo snphost fetch vcek der .
 
 Use docker commands to copy your `vcek` folder into the configured directory:
 ```
-sudo docker exec -it trustee-as-1 mkdir -p /opt/confidential-containers/attestation-service/kds-store/
+sudo docker exec trustee-as-1 mkdir -p /opt/confidential-containers/attestation-service/kds-store/
 sudo docker cp ./vcek/ trustee-as-1:/opt/confidential-containers/attestation-service/kds-store/vcek/
 ```
 
@@ -120,27 +150,39 @@ ssh privileged-user@epyc-host "sudo snphost show vcek-url" >> urls.txt
 
 On a system with network access to AMD KDS:
 ```bash
-
-# Create the vcek folder that will be copied to trustee
 mkdir vcek
+# qval <tcb-key> <query-string>: extract the SPL value for a TCB key
+qval() { grep -oP "$1SPL=\K[0-9]+" <<<"$2"; }
 
-# Fetch certificates using the above URLs file
-# There should be one line for each EPYC host that kds will service
-cat urls.txt | while read line; do
-  hwid="$(echo "$line" | cut -d/ -f7 | cut -d'?' -f1 | tr '[:upper:]' '[:lower:]')"
-  mkdir vcek/$hwid
-  cd vcek/$hwid
-  sudo snphost fetch vcek der .
-  cd ../..
-done
+# url_hwid <vcek-url>: derive the lowercase hardware ID from the URL path
+url_hwid() { tr '[:upper:]' '[:lower:]' <<<"${1##*/}" | cut -d'?' -f1; }
 
-# Copy the archive to your air-gapped trustee attestation-service deployment
+while read -r url; do
+  hwid=$(url_hwid "$url")
+  query="${url#*\?}"  # If no '?', yields whole URL; produces flat layout below
+
+  tcb_prefix=""
+  for key in bl tee snp ucode fmc; do
+    val=$(qval "$key" "$query") || continue
+    tcb_prefix+="${tcb_prefix:+_}${key}$(printf '%02d' "$((10#$val))")"
+  done
+
+  mkdir -p "vcek/$hwid"
+  # snphost writes to vcek.der in the given directory; rename to the
+  # TCB-prefixed filename. If no TCB params were parsed, keep the flat name.
+  (
+    cd "vcek/$hwid" || exit 1
+    sudo snphost fetch vek der . "$url"
+    [ -n "$tcb_prefix" ] && mv vcek.der "${tcb_prefix}_vcek.der"
+  )
+done < urls.txt
+
 scp -r vcek user@target-host:/path/to/trustee
 ```
 
 On the air-gapped trustee attestation-service host:
 ```bash
-# Update as-config.json to enable Disk Caching
+# Update as-config.json to enable the offline VCEK store
 cd /path/to/trustee
 vi kbs/config/docker-compose/as-config.json
 # Update the verifier_config section to:
@@ -158,7 +200,7 @@ vi kbs/config/docker-compose/as-config.json
 docker compose up -d
 
 # Copy the vcek store into the running attestation service container
-sudo docker exec -it trustee-as-1 mkdir -p /opt/confidential-containers/attestation-service/kds-store/
+sudo docker exec trustee-as-1 mkdir -p /opt/confidential-containers/attestation-service/kds-store/
 sudo docker cp ./vcek/ trustee-as-1:/opt/confidential-containers/attestation-service/kds-store/vcek/
 
 # Alternative to docker copy would be to add the following shared mount to

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -130,5 +130,6 @@ assert-json-diff.workspace = true
 openssl.workspace = true
 rstest.workspace = true
 serial_test.workspace = true
+tempfile.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true

--- a/deps/verifier/src/snp/mod.rs
+++ b/deps/verifier/src/snp/mod.rs
@@ -24,15 +24,16 @@ use sev::{
 };
 use std::{
     collections::HashMap,
+    fmt::Write,
     hash::Hash,
+    path::Path,
     result::Result::Ok,
     sync::{LazyLock, OnceLock},
+    time::Instant,
 };
 use strum::{Display, EnumIter, EnumString, IntoEnumIterator};
 use tracing::{debug, instrument, warn};
 use x509_parser::prelude::*;
-
-use std::time::Instant;
 
 #[derive(Serialize, Deserialize)]
 pub struct SnpEvidence {
@@ -107,6 +108,21 @@ fn init_cache_manager() -> MokaManager {
     MokaManager::new(MokaCacheBuilder::new(1024).build())
 }
 
+// convert TCB values into corresponding filename prefix for offline cert
+// caching (only used for OfflineStore option)
+fn format_tcb_prefix(att_report: &AttestationReport) -> String {
+    let tcb = &att_report.reported_tcb;
+    let mut tcb_prefix = format!(
+        "bl{:02}_tee{:02}_snp{:02}_ucode{:02}",
+        tcb.bootloader, tcb.tee, tcb.snp, tcb.microcode,
+    );
+    if let Some(fmc) = tcb.fmc {
+        write!(tcb_prefix, "_fmc{:02}", fmc).unwrap();
+    }
+
+    tcb_prefix
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct Snp {
     verifier_config: SnpVerifierConfig,
@@ -153,9 +169,12 @@ impl Snp {
                 }
             };
 
-            if let Ok(vcek_bytes) = result {
-                debug!("fetched vcek from {:?}", source);
-                return Ok(vcek_bytes);
+            match result {
+                Ok(vcek_bytes) => {
+                    debug!("fetched vcek from {:?}", source);
+                    return Ok(vcek_bytes);
+                }
+                Err(e) => debug!("failed to fetch vcek from {:?}: {:#}", source, e),
             }
         }
 
@@ -175,10 +194,25 @@ impl Snp {
         // default dir should contain the /vcek segment
         let path = path.unwrap_or(KDS_OFFLINE_STORE_PATH.to_string());
         let hw_id = self.parse_hw_id_from_vcek(att_report, proc_gen.clone());
-        let vcek_path = format!("{}/vcek/{}/vcek.der", path, hw_id);
-        let vcek_bytes = std::fs::read(&vcek_path)
-            .with_context(|| format!("Failed to read VCEK from offline store at {}", vcek_path))?;
-        Ok(vcek_bytes)
+        let tcb_vcek_path = format!(
+            "{path}/vcek/{hw_id}/{}_vcek.der",
+            format_tcb_prefix(&att_report)
+        );
+
+        let default_vcek_path = format!("{path}/vcek/{hw_id}/vcek.der");
+        let effective_path = match Path::new(&tcb_vcek_path).try_exists() {
+            Ok(true) => tcb_vcek_path,
+            Ok(false) => {
+                debug!("{tcb_vcek_path} not found, fall back to {default_vcek_path}");
+                default_vcek_path
+            }
+            // A stat failure (e.g. permission denied) is a real error, not an
+            // absent cert, so surface it instead of silently falling back.
+            Err(e) => bail!("Failed to stat VCEK at {tcb_vcek_path}: {e}"),
+        };
+
+        std::fs::read(&effective_path)
+            .with_context(|| format!("Failed to read VCEK from offline store at {effective_path}"))
     }
 
     fn parse_hw_id_from_vcek(
@@ -688,6 +722,41 @@ mod tests {
         include_bytes!("../../../../attestation-service/tests/e2e/evidence.json");
 
     #[test]
+    fn test_format_tcb_prefix() {
+        use sev::firmware::host::TcbVersion;
+
+        // Test non-Turin processor (Milan)
+        let mut report_milan = AttestationReport::from_bytes(VCEK_REPORT).unwrap();
+        report_milan.reported_tcb = TcbVersion {
+            bootloader: 2,
+            tee: 0,
+            snp: 6,
+            microcode: 21,
+            fmc: None,
+        };
+        let result = format_tcb_prefix(&report_milan);
+        assert_eq!(result, "bl02_tee00_snp06_ucode21");
+
+        // Test Turin processor with fmc
+        let mut report_turin = AttestationReport::from_bytes(VCEK_REPORT).unwrap();
+        report_turin.reported_tcb = TcbVersion {
+            bootloader: 3,
+            tee: 1,
+            snp: 8,
+            microcode: 15,
+            fmc: Some(5),
+        };
+        let result = format_tcb_prefix(&report_turin);
+        assert_eq!(result, "bl03_tee01_snp08_ucode15_fmc05");
+
+        // fmc suffix is driven purely by its existence: a None fmc (as
+        // guaranteed for pre-Turin gens by the sev crate) emits no suffix
+        report_turin.reported_tcb.fmc = None;
+        let result = format_tcb_prefix(&report_turin);
+        assert_eq!(result, "bl03_tee01_snp08_ucode15");
+    }
+
+    #[test]
     fn check_milan_certificates() {
         let VendorCertificates { ask, ark, asvk } =
             CERT_CHAINS.get(&ProcessorGeneration::Milan).unwrap();
@@ -1039,5 +1108,68 @@ mod tests {
         hex::decode(measurement).expect("measurement should be valid hex");
         hex::decode(report_data).expect("report_data should be valid hex");
         hex::decode(init_data).expect("init_data should be valid hex");
+    }
+
+    #[test]
+    fn test_fetch_vcek_from_offline_store_fallback() {
+        use tempfile::TempDir;
+
+        let attestation_report = AttestationReport::from_bytes(VCEK_REPORT).unwrap();
+        let snp = Snp::default();
+        let proc_gen = ProcessorGeneration::Milan;
+        let hw_id = snp.parse_hw_id_from_vcek(attestation_report, proc_gen.clone());
+
+        // Test 1: TCB-based path exists, should use it
+        let temp_dir = TempDir::new().unwrap();
+        let store_path = temp_dir.path().to_str().unwrap().to_string();
+        let tcb_prefix = format_tcb_prefix(&attestation_report);
+        let hw_dir = temp_dir.path().join("vcek").join(&hw_id);
+        std::fs::create_dir_all(&hw_dir).unwrap();
+        std::fs::write(hw_dir.join(format!("{tcb_prefix}_vcek.der")), VCEK).unwrap();
+
+        let result = snp.fetch_vcek_from_offline_store(
+            attestation_report,
+            &proc_gen,
+            Some(store_path.clone()),
+        );
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), VCEK);
+
+        // Test 2: Only flat layout exists, should fall back
+        let temp_dir2 = TempDir::new().unwrap();
+        let store_path2 = temp_dir2.path().to_str().unwrap().to_string();
+        let flat_path = temp_dir2.path().join("vcek").join(&hw_id);
+        std::fs::create_dir_all(&flat_path).unwrap();
+        std::fs::write(flat_path.join("vcek.der"), VCEK).unwrap();
+
+        let result =
+            snp.fetch_vcek_from_offline_store(attestation_report, &proc_gen, Some(store_path2));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), VCEK);
+
+        // Test 3: Neither exists, should fail
+        let temp_dir3 = TempDir::new().unwrap();
+        let store_path3 = temp_dir3.path().to_str().unwrap().to_string();
+
+        let result =
+            snp.fetch_vcek_from_offline_store(attestation_report, &proc_gen, Some(store_path3));
+        assert!(result.is_err());
+
+        // Test 4: Both paths exist with distinct contents, TCB path takes precedence
+        let temp_dir4 = TempDir::new().unwrap();
+        let store_path4 = temp_dir4.path().to_str().unwrap().to_string();
+        let flat_content = b"flat-layout-vcek".to_vec();
+
+        let hw_dir4 = temp_dir4.path().join("vcek").join(&hw_id);
+        std::fs::create_dir_all(&hw_dir4).unwrap();
+        std::fs::write(hw_dir4.join(format!("{tcb_prefix}_vcek.der")), VCEK).unwrap();
+        std::fs::write(hw_dir4.join("vcek.der"), &flat_content).unwrap();
+
+        let result =
+            snp.fetch_vcek_from_offline_store(attestation_report, &proc_gen, Some(store_path4));
+        assert!(result.is_ok());
+        let bytes = result.unwrap();
+        assert_eq!(bytes, VCEK);
+        assert_ne!(bytes, flat_content);
     }
 }


### PR DESCRIPTION
Follow-on to https://github.com/confidential-containers/trustee/pull/1142, which enabled specifying a trustee directory which may be preloaded with certs for offline/airgapped trustee deployments.

Current implementation only allows one certificate per hwid path, which makes FW updates more difficult (have to time the trustee cache update together with the fw update). Add support for storing multiple certificates per host/hwid to allow pre-loading certificates.

Notes:
- adds support to append a prefix to certificates under `hwid` path named based on TCB of vcek. Implemented this way to look up the appropriate VCEK rather than search. `vcek/{hwid}/vcek.der` ->`vcek/{hwid}/{tcb_prefix}_vcek.der`. 
  - prefixes are spls in this order: `bl{spl}_tee{spl}_snp{spl}_ucode{spl}[_fmc_{spl}]`
  - SPLs are in decimal, 0-padded to 2 (same as the trustee KDS URL builder code)
- backwards compatible - falls back to legacy non-prefixed name if TCB subdirectory is absent. Docs point out that subdirectory layout is preferred (avoid the extra lookup).

Testing:
- Tested by pinning test host's TCB to several different values with  `snphost config set <tcb values>` and having a set of pods interact with a trustee deployment which had an iptable rule to drop traffic to amd's kds. 

Side note that this `snphost config set <tcb values>` command's main purpose is to help with this FW update case if you're not able to prefetch the next cert before updating - it can pin SPLs to a particular value after updating FW until you're able to locate and fetch the appropriate certs.