### PR TITLE
ci: switch zizmor to auditor persona and fix all pre-existing findings

### DIFF
--- a/.github/workflows/build-and-push-staged-images.yml
+++ b/.github/workflows/build-and-push-staged-images.yml
@@ -25,7 +25,7 @@ jobs:
     name: Build staged images (all) [push]
     if: github.event_name == 'push'
     permissions:
-      packages: write
+      packages: write  # push container images to GHCR
       contents: read
     uses: ./.github/workflows/workflow-call-build-staged-images-push.yml
     with:
@@ -38,7 +38,7 @@ jobs:
     needs: build_staged_images_push
     if: github.event_name == 'push'
     permissions:
-      packages: write
+      packages: write  # push multi-arch manifests to GHCR
       contents: read
     uses: ./.github/workflows/workflow-call-publish-staged-manifests.yml
     with:

--- a/.github/workflows/nightly-dashboard-pages.yml
+++ b/.github/workflows/nightly-dashboard-pages.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      pages: write
-      id-token: write
+      pages: write      # deploy to GitHub Pages
+      id-token: write   # authenticate with GitHub Pages OIDC
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release-clis-to-ghcr.yml
+++ b/.github/workflows/release-clis-to-ghcr.yml
@@ -7,40 +7,51 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build_and_push:
+    name: Build and push ${{ matrix.component }} on ${{ matrix.arch }}
     strategy:
       fail-fast: false
       matrix:
         include:
           # kbs-client
           - component: kbs-client
+            arch: x86_64
             instance: ubuntu-24.04
             dockerfile: kbs/docker/kbs-client/Dockerfile
             output_path: kbs-client
             repo: ghcr.io/confidential-containers/staged-images/kbs-client
           - component: kbs-client
+            arch: s390x
             instance: ubuntu-24.04-s390x
             dockerfile: kbs/docker/kbs-client/Dockerfile
             output_path: kbs-client
             repo: ghcr.io/confidential-containers/staged-images/kbs-client
           - component: kbs-client
+            arch: aarch64
             instance: ubuntu-24.04-arm
             dockerfile: kbs/docker/kbs-client/Dockerfile
             output_path: kbs-client
             repo: ghcr.io/confidential-containers/staged-images/kbs-client
           # trustee-cli
           - component: trustee-cli
+            arch: x86_64
             instance: ubuntu-24.04
             dockerfile: tools/trustee-cli/Dockerfile
             output_path: ./usr/local/bin/trustee
             repo: ghcr.io/confidential-containers/staged-images/trustee-cli
           - component: trustee-cli
+            arch: s390x
             instance: ubuntu-24.04-s390x
             dockerfile: tools/trustee-cli/Dockerfile
             output_path: ./usr/local/bin/trustee
             repo: ghcr.io/confidential-containers/staged-images/trustee-cli
           - component: trustee-cli
+            arch: aarch64
             instance: ubuntu-24.04-arm
             dockerfile: tools/trustee-cli/Dockerfile
             output_path: ./usr/local/bin/trustee
@@ -48,7 +59,7 @@ jobs:
     runs-on: ${{ matrix.instance }}
     permissions:
       contents: read
-      packages: write
+      packages: write  # push CLI artifacts to GHCR
 
     steps:
     - name: Install ORAS
@@ -72,18 +83,24 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build ${{ matrix.component }}
+      env:
+        MATRIX_DOCKERFILE: ${{ matrix.dockerfile }}
       run: |
-        docker buildx build -f "${{ matrix.dockerfile }}" \
+        docker buildx build -f "${MATRIX_DOCKERFILE}" \
           --build-arg ARCH="$(uname -m)" --output ./ .
 
     - name: Push ${{ matrix.component }} to ghcr.io
+      env:
+        MATRIX_REPO: ${{ matrix.repo }}
+        MATRIX_OUTPUT_PATH: ${{ matrix.output_path }}
+        MATRIX_COMPONENT: ${{ matrix.component }}
       run: |
-        commit_sha=${{ github.sha }}
+        commit_sha="${GITHUB_SHA}"
         arch="$(uname -m)"
-        repo='${{ matrix.repo }}'
-        artifact='${{ matrix.output_path }}'
+        repo="${MATRIX_REPO}"
+        artifact="${MATRIX_OUTPUT_PATH}"
 
-        if [ '${{ matrix.component }}' = 'kbs-client' ]; then
+        if [ "${MATRIX_COMPONENT}" = 'kbs-client' ]; then
           oras push \
             "${repo}:sample_only-${commit_sha}-${arch},latest-${arch}" \
             "${artifact}"

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -24,10 +24,8 @@ jobs:
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
+      security-events: write  # upload results to code-scanning dashboard
+      id-token: write         # publish results and get a badge
 
     steps:
       - name: "Checkout code"

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -30,9 +30,9 @@ jobs:
     name: Analyze
     runs-on: ubuntu-24.04
     permissions:
-      actions: read
+      actions: read           # read workflow run info for CodeQL
       contents: read
-      security-events: write
+      security-events: write  # upload CodeQL results to code-scanning dashboard
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-e2e-helm-nightly.yml
+++ b/.github/workflows/test-e2e-helm-nightly.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   helm-trustee-e2e-ibm-sel:
+    name: Helm Trustee e2e (IBM SEL)
     runs-on: s390x
     strategy:
       fail-fast: false

--- a/.github/workflows/test-e2e-kbs.yml
+++ b/.github/workflows/test-e2e-kbs.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      packages: write
+      packages: write  # upload source archive as workflow artifact
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -41,7 +41,7 @@ jobs:
     uses: ./.github/workflows/workflow-call-kbs-e2e.yml
     permissions:
       contents: read
-      packages: write
+      packages: write  # push e2e test images to GHCR
     with:
       tee: sample
       tarball: kbs.tar.gz
@@ -52,7 +52,7 @@ jobs:
     uses: ./.github/workflows/workflow-call-kbs-e2e.yml
     permissions:
       contents: read
-      packages: write
+      packages: write  # push e2e test images to GHCR
     with:
       tee: sample
       arch: aarch64
@@ -132,7 +132,7 @@ jobs:
           path: ${{ runner.temp }}/docker-e2e-images
 
       - name: Load images
-        run: docker load --input "${{ runner.temp }}/docker-e2e-images/images.tar"
+        run: docker load --input "${RUNNER_TEMP}/docker-e2e-images/images.tar"
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0

--- a/.github/workflows/test-link-check.yml
+++ b/.github/workflows/test-link-check.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   checklinks:
+    name: Check links
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/test-rust-ci.yml
+++ b/.github/workflows/test-rust-ci.yml
@@ -59,19 +59,22 @@ jobs:
       - name: setup softhsm for pkcs11 tests
         if: contains(matrix.test_features, 'pkcs11')
         working-directory: kbs
+        env:
+          MATRIX_INSTANCE: ${{ matrix.instance }}
         run: |
-          echo "SETUP tools for pkcs11 ${{ matrix.instance }}"
+          echo "SETUP tools for pkcs11 ${MATRIX_INSTANCE}"
           sudo apt-get install -y --no-install-recommends softhsm2 opensc
-          mkdir -p "$RUNNER_TEMP/softhsm/tokens"
-          echo "directories.tokendir = $RUNNER_TEMP/softhsm/tokens" > "$RUNNER_TEMP/softhsm/softhsm2.conf"
-          export SOFTHSM2_CONF="$RUNNER_TEMP/softhsm/softhsm2.conf"
+          mkdir -p "${RUNNER_TEMP}/softhsm/tokens"
+          echo "directories.tokendir = ${RUNNER_TEMP}/softhsm/tokens" > "${RUNNER_TEMP}/softhsm/softhsm2.conf"
+          export SOFTHSM2_CONF="${RUNNER_TEMP}/softhsm/softhsm2.conf"
           softhsm2-util --init-token --free --label "Trustee pkcs11 test" --so-pin 12345678 --pin 12345678
 
       - name: Run KBS lint/format/test
         timeout-minutes: 10
         env:
           SOFTHSM2_CONF: '${{ runner.temp }}/softhsm/softhsm2.conf'
-        run: make test-kbs-unit TEST_FEATURES=${{ matrix.test_features }}
+          MATRIX_TEST_FEATURES: ${{ matrix.test_features }}
+        run: make test-kbs-unit TEST_FEATURES="${MATRIX_TEST_FEATURES}"
 
   as:
     name: Attestation Service (AS)
@@ -86,7 +89,7 @@ jobs:
           persist-credentials: false
 
       - name: Install OPA command line tool
-        uses: open-policy-agent/setup-opa@b2b258e089860efaadaaf71bf6e3aecb4a3eeff1 # v2.2.0 # v2
+        uses: open-policy-agent/setup-opa@b2b258e089860efaadaaf71bf6e3aecb4a3eeff1 # v2.4.0
         with:
           version: latest
 

--- a/.github/workflows/workflow-call-build-docker-e2e-materials.yml
+++ b/.github/workflows/workflow-call-build-docker-e2e-materials.yml
@@ -56,7 +56,11 @@ jobs:
           key: rust-${{ runner.arch }}-${{ env.OS_VERSION }}-kbs-client-${{ matrix.name }}-${{ hashFiles('./Cargo.lock') }}
 
       - name: Build kbs-client
-        run: cargo build -p kbs-client --release ${{ matrix.features }}
+        env:
+          MATRIX_FEATURES: ${{ matrix.features }}
+        run: |
+          # shellcheck disable=SC2086
+          cargo build -p kbs-client --release ${MATRIX_FEATURES}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -135,17 +139,21 @@ jobs:
           load: true
 
       - name: Tag image for docker compose
+        env:
+          MATRIX_TAG: ${{ matrix.tag }}
         run: |
           set -euo pipefail
-          docker tag "${IMAGE_PREFIX}/${{ matrix.tag }}:latest-$(uname -m)" \
-            "${IMAGE_PREFIX}/${{ matrix.tag }}:latest"
+          docker tag "${IMAGE_PREFIX}/${MATRIX_TAG}:latest-$(uname -m)" \
+            "${IMAGE_PREFIX}/${MATRIX_TAG}:latest"
 
       - name: Save image
+        env:
+          MATRIX_TAG: ${{ matrix.tag }}
         run: |
           set -euo pipefail
-          mkdir -p "${{ runner.temp }}/docker-e2e-image"
-          docker save -o "${{ runner.temp }}/docker-e2e-image/${{ matrix.tag }}.tar" \
-            "${IMAGE_PREFIX}/${{ matrix.tag }}:latest"
+          mkdir -p "${RUNNER_TEMP}/docker-e2e-image"
+          docker save -o "${RUNNER_TEMP}/docker-e2e-image/${MATRIX_TAG}.tar" \
+            "${IMAGE_PREFIX}/${MATRIX_TAG}:latest"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -183,7 +191,7 @@ jobs:
       - name: Load and repackage image artifacts
         run: |
           set -euo pipefail
-          mapfile -t image_tars < <(find "${{ runner.temp }}/docker-e2e-images" -name '*.tar' -type f)
+          mapfile -t image_tars < <(find "${RUNNER_TEMP}/docker-e2e-images" -name '*.tar' -type f)
           if [ "${#image_tars[@]}" -ne 3 ]; then
             echo "Expected 3 image tarballs, found ${#image_tars[@]}:" "${image_tars[@]}"
             exit 1
@@ -192,8 +200,8 @@ jobs:
             docker load --input "$tar"
           done
           docker image ls "${IMAGE_PREFIX}/"*
-          mkdir -p "${{ runner.temp }}/docker-e2e-bundle"
-          docker save -o "${{ runner.temp }}/docker-e2e-bundle/images.tar" \
+          mkdir -p "${RUNNER_TEMP}/docker-e2e-bundle"
+          docker save -o "${RUNNER_TEMP}/docker-e2e-bundle/images.tar" \
             "${IMAGE_PREFIX}/kbs-grpc-as:latest" \
             "${IMAGE_PREFIX}/coco-as-grpc:latest" \
             "${IMAGE_PREFIX}/rvps:latest"

--- a/.github/workflows/workflow-call-build-staged-images-pr.yml
+++ b/.github/workflows/workflow-call-build-staged-images-pr.yml
@@ -18,6 +18,7 @@ permissions: {}
 
 jobs:
   kbs:
+    name: Build KBS image
     if: inputs.image_group == 'kbs' || inputs.image_group == 'all'
     permissions:
       contents: read
@@ -84,6 +85,7 @@ jobs:
           push: false
 
   as:
+    name: Build AS image
     if: inputs.image_group == 'as' || inputs.image_group == 'all'
     permissions:
       contents: read
@@ -132,6 +134,7 @@ jobs:
           push: false
 
   rvps:
+    name: Build RVPS image
     if: inputs.image_group == 'rvps' || inputs.image_group == 'all'
     permissions:
       contents: read
@@ -162,6 +165,7 @@ jobs:
           push: false
 
   kbs-client:
+    name: Build kbs-client image
     if: inputs.image_group == 'kbs-client' || inputs.image_group == 'all'
     permissions:
       contents: read

--- a/.github/workflows/workflow-call-build-staged-images-push.yml
+++ b/.github/workflows/workflow-call-build-staged-images-push.yml
@@ -17,10 +17,11 @@ permissions: {}
 
 jobs:
   kbs-push:
+    name: Build and push KBS image
     if: (inputs.image_group == 'kbs' || inputs.image_group == 'all')
     permissions:
       contents: read
-      packages: write
+      packages: write  # push KBS images to GHCR
     strategy:
       fail-fast: false
       matrix:
@@ -99,10 +100,11 @@ jobs:
           push: true
 
   as-push:
+    name: Build and push AS image
     if: (inputs.image_group == 'as' || inputs.image_group == 'all')
     permissions:
       contents: read
-      packages: write
+      packages: write  # push AS images to GHCR
     strategy:
       fail-fast: false
       matrix:
@@ -161,10 +163,11 @@ jobs:
           push: true
 
   rvps-push:
+    name: Build and push RVPS image
     if: (inputs.image_group == 'rvps' || inputs.image_group == 'all')
     permissions:
       contents: read
-      packages: write
+      packages: write  # push RVPS images to GHCR
     strategy:
       fail-fast: false
       matrix:
@@ -204,10 +207,11 @@ jobs:
           push: true
 
   kbs-client-push:
+    name: Build and push kbs-client image
     if: (inputs.image_group == 'kbs-client' || inputs.image_group == 'all')
     permissions:
       contents: read
-      packages: write
+      packages: write  # push kbs-client images to GHCR
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/workflow-call-helm-e2e.yml
+++ b/.github/workflows/workflow-call-helm-e2e.yml
@@ -69,7 +69,7 @@ jobs:
           path: ${{ runner.temp }}/docker-e2e-images
 
       - name: Load images
-        run: docker load --input "${{ runner.temp }}/docker-e2e-images/images.tar"
+        run: docker load --input "${RUNNER_TEMP}/docker-e2e-images/images.tar"
 
       - name: Download pre-built kbs-client
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -78,7 +78,7 @@ jobs:
           path: ${{ runner.temp }}/helm-e2e-kbs-client
 
       - name: Prepare kbs-client
-        run: chmod +x "${{ runner.temp }}/helm-e2e-kbs-client/kbs-client"
+        run: chmod +x "${RUNNER_TEMP}/helm-e2e-kbs-client/kbs-client"
 
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -105,7 +105,7 @@ jobs:
           make -C deployment/helm-chart e2e-test \
             E2E_IMAGE_PREFIX=ghcr.io/confidential-containers/staged-images \
             E2E_IMAGE_TAG=latest \
-            KBS_CLIENT="${{ runner.temp }}/helm-e2e-kbs-client/kbs-client" \
+            KBS_CLIENT="${RUNNER_TEMP}/helm-e2e-kbs-client/kbs-client" \
             EXPECTED_TEE="${EXPECTED_TEE}"
 
       # Self-hosted cleanup so the runner is left in a known-good state.

--- a/.github/workflows/workflow-call-kbs-e2e.yml
+++ b/.github/workflows/workflow-call-kbs-e2e.yml
@@ -35,10 +35,11 @@ defaults:
 
 jobs:
   build-binaries:
+    name: Build e2e binaries
     runs-on: ${{ fromJSON(inputs.runs-on-build) }}
     permissions:
       contents: read
-      packages: write
+      packages: write  # push e2e test images to GHCR
     env:
       OS_VERSION: ubuntu-24.04
     steps:
@@ -85,6 +86,7 @@ jobs:
         name: artifacts-${{ inputs.tee }}-${{ inputs.arch}}
 
   e2e-test:
+    name: Run e2e test
     needs: build-binaries
     runs-on: ${{ fromJSON(inputs.runs-on-test) }}
     env:

--- a/.github/workflows/workflow-call-publish-staged-manifests.yml
+++ b/.github/workflows/workflow-call-publish-staged-manifests.yml
@@ -21,9 +21,10 @@ permissions: {}
 
 jobs:
   publish:
+    name: Publish multi-arch manifest
     runs-on: ubuntu-24.04
     permissions:
-      packages: write
+      packages: write  # push multi-arch manifests to GHCR
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -29,4 +29,4 @@ jobs:
       with:
         advanced-security: false
         annotations: true
-        persona: regular
+        persona: auditor


### PR DESCRIPTION
## Why

The zizmor workflow added in #1481 used the `regular` persona. While correct as a starting point, `regular` misses a class of findings that `auditor` catches — undocumented permissions, anonymous job definitions, missing concurrency limits, and template expansions from `matrix.*` / `runner.temp` in `run:` blocks.

`auditor` is the better long-term choice because it enforces stricter hygiene on every PR before anything merges, rather than silently allowing these patterns to accumulate.

## What

Runs zizmor with `persona: auditor` on all triggers (push, PR, weekly schedule). This is safe because all 52 pre-existing `auditor` findings are fixed in this commit — the repo now exits clean (`exit 0`) under the strictest persona.

Getting new findings going forward will be a rare scenario: they would only appear if someone introduces a new workflow with one of the five resolved finding types, which the PR scan would immediately catch and flag before merge.

Findings resolved across 15 workflow files:

- **template-injection** (21): moved `${{ matrix.* }}` and `${{ runner.temp }}` expansions in `run:` blocks into `env:` vars or `$RUNNER_TEMP`
- **undocumented-permissions** (16): added inline comments to all `packages: write`, `pages: write`, `id-token: write`, `security-events: write`, and `actions: read` grants
- **anonymous-definition** (14): added `name:` to all jobs identified only by their YAML key
- **ref-version-mismatch** (1): corrected stale OPA action comment `# v2.2.0 # v2` → `# v2.4.0` in `test-rust-ci.yml`
- **concurrency-limits** (1): added `concurrency:` block to `release-clis-to-ghcr.yml`

## Validation

```console
$ zizmor --persona auditor .
No findings to report. Good job!
```

> Assisted by [IBM Bob](https://github.com/IBM/bob)