### PR TITLE
ci: dump Helm e2e pod logs on failure

### DIFF
--- a/deployment/helm-chart/Makefile
+++ b/deployment/helm-chart/Makefile
@@ -43,7 +43,7 @@ export KBS_CLIENT
 export EXPECTED_TEE
 
 .PHONY: e2e-test deploy undeploy test-client check-tools wait-ready \
-	check-docker helm-dependency-build helm-lint load-e2e-images-into-kind
+	check-docker helm-dependency-build helm-lint load-e2e-images-into-kind dump-logs
 
 check-tools:
 	@command -v helm >/dev/null || (echo "missing: helm" >&2; exit 1)
@@ -84,11 +84,33 @@ undeploy: check-tools
 	helm uninstall trustee-e2e -n coco-trustee-e2e 2>/dev/null || true
 	kubectl delete namespace coco-trustee-e2e --ignore-not-found --timeout=120s 2>/dev/null || true
 
+# Print pod/cluster diagnostics before teardown so CI failures are actionable.
+# Must run while the namespace still exists (before undeploy).
+dump-logs: check-tools
+	@echo "==> cluster state (namespace coco-trustee-e2e)"
+	-kubectl get pods,jobs,deploy,svc -n coco-trustee-e2e -o wide 2>&1 || true
+	-kubectl get events -n coco-trustee-e2e --sort-by='.lastTimestamp' 2>&1 || true
+	@echo "==> pod descriptions"
+	-kubectl describe pods -n coco-trustee-e2e 2>&1 || true
+	@echo "==> container logs"
+	@pods=$$(kubectl get pods -n coco-trustee-e2e -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true); \
+	if [ -z "$$pods" ]; then \
+		echo "(no pods found in coco-trustee-e2e)"; \
+	else \
+		for pod in $$pods; do \
+			echo "---- logs: $$pod (current) ----"; \
+			kubectl logs -n coco-trustee-e2e "$$pod" --all-containers --prefix --timestamps 2>&1 || true; \
+			echo "---- logs: $$pod (previous) ----"; \
+			kubectl logs -n coco-trustee-e2e "$$pod" --all-containers --prefix --timestamps --previous 2>&1 || true; \
+		done; \
+	fi
+
 test-client: check-tools wait-ready
 	@chmod +x '$(CHART_DIR)/e2e/test.sh'
 	@'$(CHART_DIR)/e2e/test.sh'
 
 # Deploy, test, then always undeploy. Images must already be present in the cluster.
+# On failure, dump container logs before undeploy so they appear in CI output.
 e2e-test: check-tools
 	@status=0; \
 	if [ $$status -eq 0 ]; then \
@@ -96,6 +118,9 @@ e2e-test: check-tools
 	fi; \
 	if [ $$status -eq 0 ]; then \
 		$(MAKE) test-client || status=$$?; \
+	fi; \
+	if [ $$status -ne 0 ]; then \
+		$(MAKE) dump-logs || true; \
 	fi; \
 	$(MAKE) undeploy || true; \
 	exit $$status

--- a/deployment/helm-chart/README.md
+++ b/deployment/helm-chart/README.md
@@ -327,7 +327,8 @@ Steps:
 2. **`helm-lint`**
 3. **`deploy`**
 4. **`test-client`** — [e2e/test.sh](./e2e/test.sh)
-5. **`undeploy`** — always attempted, even after failures
+5. **`dump-logs`** — on failure only: pod status, events, describe, and container logs (current + previous), while the namespace still exists
+6. **`undeploy`** — always attempted, even after failures
 
 Debug individually:
 
@@ -336,6 +337,7 @@ make -C deployment/helm-chart load-e2e-images-into-kind
 make -C deployment/helm-chart helm-lint
 make -C deployment/helm-chart deploy
 make -C deployment/helm-chart test-client
+make -C deployment/helm-chart dump-logs
 make -C deployment/helm-chart undeploy
 ```
 


### PR DESCRIPTION
Emit cluster state and container logs before undeploy so nightly and label-triggered Helm e2e failures are diagnosable in CI output.

Help to locate the errors of CI.