### PR TITLE
Require optional admin auth for /metrics endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3997,6 +3997,7 @@ dependencies = [
  "openssl",
  "policy-engine",
  "reference-value-provider-service",
+ "reqwest 0.13.4",
  "rstest",
  "serde_json",
  "serial_test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4003,6 +4003,7 @@ dependencies = [
  "openssl",
  "policy-engine",
  "reference-value-provider-service",
+ "reqwest 0.13.4",
  "rstest",
  "serde_json",
  "serial_test",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -17,6 +17,7 @@ anyhow.workspace = true
 base64.workspace = true
 const_format.workspace = true
 openssl.workspace = true
+reqwest.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
 jsonwebtoken.workspace = true

--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -101,18 +101,22 @@ impl From<KbsConfigType> for TestParameters {
             KbsConfigType::EarTokenBuiltInRvps => TestParameters {
                 rvps_type: RvpsType::Builtin,
                 admin_type: AdminType::Simple,
+                require_admin_auth_metrics: false,
             },
             KbsConfigType::EarTokenRemoteRvps => TestParameters {
                 rvps_type: RvpsType::Remote,
                 admin_type: AdminType::Simple,
+                require_admin_auth_metrics: false,
             },
             KbsConfigType::EarTokenBuiltInRvpsDenyAllAdmin => TestParameters {
                 rvps_type: RvpsType::Builtin,
                 admin_type: AdminType::DenyAll,
+                require_admin_auth_metrics: false,
             },
             KbsConfigType::EarTokenBuiltInRvpsSimpleRestrictedAdmin => TestParameters {
                 rvps_type: RvpsType::Builtin,
                 admin_type: AdminType::SimpleRestricted,
+                require_admin_auth_metrics: false,
             },
         }
     }
@@ -122,6 +126,7 @@ impl From<KbsConfigType> for TestParameters {
 pub struct TestParameters {
     pub rvps_type: RvpsType,
     pub admin_type: AdminType,
+    pub require_admin_auth_metrics: bool,
 }
 
 /// Internal state of tests
@@ -347,6 +352,7 @@ impl TestHarness {
                 insecure_http: true,
                 payload_request_size: 2,
                 worker_count: Some(4),
+                require_admin_auth_metrics: test_parameters.require_admin_auth_metrics,
                 tls: TlsConfig::default(),
             },
             admin: admin_config,

--- a/integration-tests/src/common.rs
+++ b/integration-tests/src/common.rs
@@ -184,7 +184,7 @@ async fn wait_for_reference_value(url: &str, key: &str) -> Result<()> {
 }
 
 impl TestHarness {
-    fn sign_admin_token(&self) -> Result<String> {
+    pub fn sign_admin_token(&self) -> Result<String> {
         let encoding_key = EncodingKey::from_ed_pem(self.auth_privkey.as_bytes())?;
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -287,7 +287,7 @@ impl TestHarness {
                     "regex_acl": {
                         "acls": [{
                             "role": ADMIN_ROLE,
-                            "allowed_endpoints": "^/kbs/v0/.*$"
+                            "allowed_endpoints": "^/(kbs/v0/.*|metrics)$"
                         }]
                     }
                 },
@@ -501,6 +501,15 @@ impl TestHarness {
         let payload: serde_json::Value = serde_json::from_slice(&payload_bytes)?;
 
         Ok(payload)
+    }
+
+    pub async fn get_metrics(&self, admin_token: Option<String>) -> Result<reqwest::Response> {
+        info!("TEST: Getting metrics");
+        let mut request = reqwest::Client::new().get(format!("{KBS_URL}/metrics"));
+        if let Some(token) = admin_token {
+            request = request.bearer_auth(token);
+        }
+        Ok(request.send().await?)
     }
 }
 

--- a/integration-tests/tests/admin.rs
+++ b/integration-tests/tests/admin.rs
@@ -10,7 +10,7 @@ use tracing::info;
 
 extern crate integration_tests;
 use crate::integration_tests::common::{
-    init_tracing, KbsConfigType, PolicyType, TestHarness, ADMIN_ROLE,
+    init_tracing, KbsConfigType, PolicyType, TestHarness, TestParameters, ADMIN_ROLE,
 };
 
 //
@@ -193,9 +193,9 @@ default executables = 97
 ";
 
 //
-// The /metrics endpoint must be protected by admin authentication:
-// no token is denied, a valid token is allowed, and disabled/restricted
-// admin backends deny even authenticated requests.
+// The /metrics endpoint can be protected by admin authentication (opt-in via
+// http_server.require_admin_auth_metrics): no token is denied, a valid token is
+// allowed, and disabled/restricted admin backends deny even authenticated requests.
 //
 #[rstest]
 #[case::metrics_no_token(KbsConfigType::EarTokenBuiltInRvps, false)]
@@ -216,7 +216,9 @@ async fn metrics_requires_admin_auth(
     let deny_all = test_config == KbsConfigType::EarTokenBuiltInRvpsDenyAllAdmin;
     let restricted = test_config == KbsConfigType::EarTokenBuiltInRvpsSimpleRestrictedAdmin;
 
-    let harness = TestHarness::new(test_config.into()).await?;
+    let mut params = TestParameters::from(test_config);
+    params.require_admin_auth_metrics = true;
+    let harness = TestHarness::new(params).await?;
     harness.wait().await?;
 
     let token = provide_token.then(|| harness.sign_admin_token().expect("admin token"));
@@ -260,6 +262,37 @@ async fn metrics_requires_admin_auth(
             "metrics must be denied without an admin token"
         );
     }
+
+    Ok(())
+}
+
+//
+// With http_server.require_admin_auth_metrics disabled (the default), /metrics is
+// served without any authentication, preserving backward compatibility.
+//
+#[rstest]
+#[serial(integration_ports)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn metrics_unprotected_by_default() -> Result<()> {
+    init_tracing();
+
+    let harness = TestHarness::new(KbsConfigType::EarTokenBuiltInRvps.into()).await?;
+    harness.wait().await?;
+
+    let res = harness.get_metrics(None).await?;
+
+    harness.cleanup().await?;
+
+    assert_eq!(
+        res.status(),
+        reqwest::StatusCode::OK,
+        "metrics must be reachable without an admin token when protection is off"
+    );
+    let body = res.text().await?;
+    assert!(
+        body.contains("kbs_build_info"),
+        "expected metrics body to contain kbs_build_info, got: {body}"
+    );
 
     Ok(())
 }

--- a/integration-tests/tests/admin.rs
+++ b/integration-tests/tests/admin.rs
@@ -193,6 +193,78 @@ default executables = 97
 ";
 
 //
+// The /metrics endpoint must be protected by admin authentication:
+// no token is denied, a valid token is allowed, and disabled/restricted
+// admin backends deny even authenticated requests.
+//
+#[rstest]
+#[case::metrics_no_token(KbsConfigType::EarTokenBuiltInRvps, false)]
+#[case::metrics_with_valid_token(KbsConfigType::EarTokenBuiltInRvps, true)]
+#[case::metrics_with_deny_admin_backend(KbsConfigType::EarTokenBuiltInRvpsDenyAllAdmin, true)]
+#[case::metrics_with_restricted_simple_backend(
+    KbsConfigType::EarTokenBuiltInRvpsSimpleRestrictedAdmin,
+    true
+)]
+#[serial(integration_ports)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn metrics_requires_admin_auth(
+    #[case] test_config: KbsConfigType,
+    #[case] provide_token: bool,
+) -> Result<()> {
+    init_tracing();
+
+    let deny_all = test_config == KbsConfigType::EarTokenBuiltInRvpsDenyAllAdmin;
+    let restricted = test_config == KbsConfigType::EarTokenBuiltInRvpsSimpleRestrictedAdmin;
+
+    let harness = TestHarness::new(test_config.into()).await?;
+    harness.wait().await?;
+
+    let token = provide_token.then(|| harness.sign_admin_token().expect("admin token"));
+    let res = harness.get_metrics(token).await?;
+
+    harness.cleanup().await?;
+
+    if deny_all {
+        assert_eq!(
+            res.status(),
+            reqwest::StatusCode::UNAUTHORIZED,
+            "metrics must be denied when the admin backend is disabled"
+        );
+        return Ok(());
+    }
+
+    if restricted {
+        assert_eq!(
+            res.status(),
+            reqwest::StatusCode::UNAUTHORIZED,
+            "metrics must be denied for roles not allowed by the restricted ACL"
+        );
+        return Ok(());
+    }
+
+    if provide_token {
+        assert_eq!(
+            res.status(),
+            reqwest::StatusCode::OK,
+            "metrics must be reachable with a valid admin token"
+        );
+        let body = res.text().await?;
+        assert!(
+            body.contains("kbs_build_info"),
+            "expected metrics body to contain kbs_build_info, got: {body}"
+        );
+    } else {
+        assert_eq!(
+            res.status(),
+            reqwest::StatusCode::UNAUTHORIZED,
+            "metrics must be denied without an admin token"
+        );
+    }
+
+    Ok(())
+}
+
+//
 // Set a secret with the a valid admin private key
 // and with the wrong admin private key.
 //

--- a/kbs/docs/admin.md
+++ b/kbs/docs/admin.md
@@ -39,7 +39,7 @@ This mode enables real admin authentication and authorization.
 - `authentication = bearer_jwt` verifies `Authorization: Bearer <JWT>`
 - JWT **MUST** contain a `role` claim
 - `authorization = regex_acl` authorizes by `acl(role -> allowed_endpoints)`
-- `allowed_endpoints` must start with `^/kbs` and end with `$`
+- `allowed_endpoints` must start with `^/` and end with `$`
 
 Example:
 

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -301,7 +301,7 @@ Each ACL entry:
 | `role` | String | JWT `role` value to match | Yes |
 | `allowed_endpoints` | String | Regex of allowed request paths | Yes |
 
-`allowed_endpoints` must start with `^/kbs` and end with `$`.
+`allowed_endpoints` must start with `^/` and end with `$`.
 
 ### Storage Backend Configuration
 

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -27,6 +27,7 @@ The following properties can be set under the `[http_server]` section.
 | `certificate`          | String       | Path to a certificate file to be used for HTTPS. | No       | None                     |
 | `payload_request_size` | Integer      | Request payload size in mega bytes.              | No       | 2                        |
 | `worker_count`         | Integer      | Number of HTTP actix worker threads              | No       | Num of logical CPU cores |
+| `require_admin_auth_metrics` | Boolean | Require a valid admin token to access the `/metrics` endpoint. | No | `false` |
 | `tls_profile`          | String       | TLS security profile (see [TLS Configuration](#tls-configuration)) | No | `intermediate` |
 | `tls_min_version`      | String       | Minimum TLS version: `1.2` or `1.3`              | No       | Profile-dependent        |
 | `tls_max_version`      | String       | Maximum TLS version: `1.2` or `1.3`              | No       | Profile-dependent        |

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -300,7 +300,7 @@ Each ACL entry:
 | `role` | String | JWT `role` value to match | Yes |
 | `allowed_endpoints` | String | Regex of allowed request paths | Yes |
 
-`allowed_endpoints` must start with `^/kbs` and end with `$`.
+`allowed_endpoints` must start with `^/` and end with `$`.
 
 ### Storage Backend Configuration
 

--- a/kbs/docs/metrics.md
+++ b/kbs/docs/metrics.md
@@ -2,6 +2,7 @@
 
 The Key Broker Service (KBS) exposes Prometheus metrics on the `/metrics` HTTP endpoint served at the same port as KBS itself (see the `sockets` item in the `http_server` section of your KBS configuration file, 8080 by default).
 
+> **Access control**: The `/metrics` endpoint is protected by the [admin API](admin.md) authentication and authorization configuration. Scraping clients must present a valid admin JWT (see `admin.authentication`) that is allowed for the `/metrics` path by the configured ACL (e.g. an `allowed_endpoints` regex of `^/(kbs/v0/.*|metrics)$`). When the admin backend is `DenyAll`, `/metrics` is not accessible at all. This prevents unauthenticated disclosure of sensitive label values (resource paths, TEE types).
 
 The `/metrics` endpoint itself is excluded from request metrics collection to
 avoid skewing the data with monitoring traffic.
@@ -69,6 +70,10 @@ scrape_configs:
     scheme: https  # or http if using insecure_http
     tls_config:
       insecure_skip_verify: true  # only if using self-signed certificates
+    # The /metrics endpoint is admin-protected; present a valid admin JWT.
+    authorization:
+      type: Bearer
+      credentials_file: /path/to/admin.jwt
 ```
 
 ## Kubernetes Deployment

--- a/kbs/docs/metrics.md
+++ b/kbs/docs/metrics.md
@@ -2,7 +2,14 @@
 
 The Key Broker Service (KBS) exposes Prometheus metrics on the `/metrics` HTTP endpoint served at the same port as KBS itself (see the `sockets` item in the `http_server` section of your KBS configuration file, 8080 by default).
 
-> **Access control**: The `/metrics` endpoint is protected by the [admin API](admin.md) authentication and authorization configuration. Scraping clients must present a valid admin JWT (see `admin.authentication`) that is allowed for the `/metrics` path by the configured ACL (e.g. an `allowed_endpoints` regex of `^/(kbs/v0/.*|metrics)$`). When the admin backend is `DenyAll`, `/metrics` is not accessible at all. This prevents unauthenticated disclosure of sensitive label values (resource paths, TEE types).
+> **Access control**: By default `/metrics` is served without authentication. Set
+> `require_admin_auth_metrics = true` under the `http_server` section of your KBS
+> configuration to protect the endpoint with the [admin API](admin.md) authentication and
+> authorization configuration. When enabled, scraping clients must present a valid admin JWT
+> (see `admin.authentication`) that is allowed for the `/metrics` path by the configured ACL
+> (e.g. an `allowed_endpoints` regex of `^/(kbs/v0/.*|metrics)$`). When the admin backend is
+> `DenyAll`, `/metrics` is not accessible at all. This prevents unauthenticated disclosure of
+> sensitive label values (resource paths, TEE types).
 
 The `/metrics` endpoint itself is excluded from request metrics collection to
 avoid skewing the data with monitoring traffic.
@@ -70,7 +77,8 @@ scrape_configs:
     scheme: https  # or http if using insecure_http
     tls_config:
       insecure_skip_verify: true  # only if using self-signed certificates
-    # The /metrics endpoint is admin-protected; present a valid admin JWT.
+    # Only needed when http_server.require_admin_auth_metrics = true:
+    # present a valid admin JWT.
     authorization:
       type: Bearer
       credentials_file: /path/to/admin.jwt

--- a/kbs/src/admin/authorization/regex_acl.rs
+++ b/kbs/src/admin/authorization/regex_acl.rs
@@ -42,8 +42,7 @@ impl TryFrom<RegexAclConfig> for RegexAclAuthorizer {
     fn try_from(config: RegexAclConfig) -> Result<Self> {
         let mut acls = Vec::new();
         for acl in config.acls {
-            if !acl.allowed_endpoints.starts_with("^/kbs") || !acl.allowed_endpoints.ends_with("$")
-            {
+            if !acl.allowed_endpoints.starts_with("^/") || !acl.allowed_endpoints.ends_with("$") {
                 return Err(Error::UnanchoredRegex);
             }
             let regex = Regex::new(&acl.allowed_endpoints)?;

--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -476,9 +476,15 @@ pub(crate) async fn api(
 }
 
 pub(crate) async fn prometheus_metrics_handler(
-    _request: HttpRequest,
-    _core: web::Data<ApiServer>,
+    request: HttpRequest,
+    core: web::Data<ApiServer>,
 ) -> Result<HttpResponse> {
+    core.admin
+        .check_admin_access(&request)
+        .map_err(|e| Error::AdminAuthAccess {
+            source: e,
+            endpoint: "metrics".to_string(),
+        })?;
     let report =
         crate::prometheus::export_metrics().map_err(|e| Error::PrometheusError { source: e })?;
     Ok(HttpResponse::Ok().body(report))

--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -475,12 +475,16 @@ pub(crate) async fn prometheus_metrics_handler(
     request: HttpRequest,
     core: web::Data<ApiServer>,
 ) -> Result<HttpResponse> {
-    core.admin
-        .check_admin_access(&request)
-        .map_err(|e| Error::AdminAuthAccess {
-            source: e,
-            endpoint: "metrics".to_string(),
-        })?;
+    // The `/metrics` endpoint may optionally be protected by admin auth to prevent
+    // unauthenticated disclosure of sensitive label values (resource paths, TEE types).
+    if core.config.http_server.require_admin_auth_metrics {
+        core.admin
+            .check_admin_access(&request)
+            .map_err(|e| Error::AdminAuthAccess {
+                source: e,
+                endpoint: "metrics".to_string(),
+            })?;
+    }
     let report =
         crate::prometheus::export_metrics().map_err(|e| Error::PrometheusError { source: e })?;
     Ok(HttpResponse::Ok().body(report))

--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -472,9 +472,15 @@ pub(crate) async fn api(
 }
 
 pub(crate) async fn prometheus_metrics_handler(
-    _request: HttpRequest,
-    _core: web::Data<ApiServer>,
+    request: HttpRequest,
+    core: web::Data<ApiServer>,
 ) -> Result<HttpResponse> {
+    core.admin
+        .check_admin_access(&request)
+        .map_err(|e| Error::AdminAuthAccess {
+            source: e,
+            endpoint: "metrics".to_string(),
+        })?;
     let report =
         crate::prometheus::export_metrics().map_err(|e| Error::PrometheusError { source: e })?;
     Ok(HttpResponse::Ok().body(report))

--- a/kbs/src/api_server.rs
+++ b/kbs/src/api_server.rs
@@ -479,12 +479,16 @@ pub(crate) async fn prometheus_metrics_handler(
     request: HttpRequest,
     core: web::Data<ApiServer>,
 ) -> Result<HttpResponse> {
-    core.admin
-        .check_admin_access(&request)
-        .map_err(|e| Error::AdminAuthAccess {
-            source: e,
-            endpoint: "metrics".to_string(),
-        })?;
+    // The `/metrics` endpoint may optionally be protected by admin auth to prevent
+    // unauthenticated disclosure of sensitive label values (resource paths, TEE types).
+    if core.config.http_server.require_admin_auth_metrics {
+        core.admin
+            .check_admin_access(&request)
+            .map_err(|e| Error::AdminAuthAccess {
+                source: e,
+                endpoint: "metrics".to_string(),
+            })?;
+    }
     let report =
         crate::prometheus::export_metrics().map_err(|e| Error::PrometheusError { source: e })?;
     Ok(HttpResponse::Ok().body(report))

--- a/kbs/src/config.rs
+++ b/kbs/src/config.rs
@@ -123,6 +123,12 @@ pub struct HttpServerConfig {
     /// If not specified, defaults to the number of logical CPU cores.
     pub worker_count: Option<usize>,
 
+    /// Require a valid admin token (via the configured admin authentication/authorization
+    /// backend) to access the `/metrics` endpoint. When enabled, Prometheus scraping must
+    /// present a bearer JWT allowed for the `/metrics` path. Defaults to `false` for
+    /// backward compatibility with unauthenticated metric scraping.
+    pub require_admin_auth_metrics: bool,
+
     /// TLS/HTTPS configuration
     #[serde(flatten)]
     pub tls: TlsConfig,
@@ -135,6 +141,7 @@ impl Default for HttpServerConfig {
             insecure_http: DEFAULT_INSECURE_HTTP,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            require_admin_auth_metrics: false,
             tls: TlsConfig::default(),
         }
     }
@@ -367,6 +374,7 @@ mod tests {
             insecure_http: false,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            require_admin_auth_metrics: false,
             tls: TlsConfig {
                 private_key: Some("/etc/kbs-private.key".into()),
                 certificate: Some("/etc/kbs-cert.pem".into()),
@@ -427,6 +435,7 @@ mod tests {
             insecure_http: DEFAULT_INSECURE_HTTP,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            require_admin_auth_metrics: false,
             tls: TlsConfig::default(),
         },
         admin: AdminConfig::DenyAll {},
@@ -470,6 +479,7 @@ mod tests {
             insecure_http: false,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            require_admin_auth_metrics: false,
             tls: TlsConfig {
                 private_key: Some("/etc/kbs-private.key".into()),
                 certificate: Some("/etc/kbs-cert.pem".into()),
@@ -518,6 +528,7 @@ mod tests {
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            require_admin_auth_metrics: false,
             tls: TlsConfig::default(),
         },
         admin: make_token_authorization_admin_config(),
@@ -563,6 +574,7 @@ mod tests {
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            require_admin_auth_metrics: false,
             tls: TlsConfig::default(),
         },
         admin: AdminConfig::InsecureAllowAll {},
@@ -604,6 +616,7 @@ mod tests {
             insecure_http: true,
             payload_request_size: DEFAULT_PAYLOAD_REQUEST_SIZE,
             worker_count: None,
+            require_admin_auth_metrics: false,
             tls: TlsConfig::default(),
         },
         admin: AdminConfig::DenyAll {},


### PR DESCRIPTION
## Protect `/metrics` with admin auth (opt-in)

KBS serves Prometheus metrics on `/metrics` without authentication, and the metric
labels expose operational detail such as resource paths and TEE types. Those values
are not secrets in the KBS threat model (without TLS they are already observable on
the wire), but operators may still want to lock the endpoint down without adding an
external component. This adds an **opt-in** way to do that.

### What changed

- **New config flag** `http_server.require_admin_auth_metrics` (default `false`). Set
  it to `true` to require an admin JWT to scrape `/metrics`:

  ```toml
  [http_server]
  require_admin_auth_metrics = true
  ```

- When enabled, `/metrics` goes through the same admin authentication/authorization
  as the other admin endpoints, and failures map to `AdminAuthAccess`. Scrapers send
  a bearer admin JWT whose role ACL covers `/metrics` (e.g. `^/metrics$`). With
  `DenyAll`, `/metrics` is fully locked.

- The ACL anchor check is **narrowed, not removed**: `allowed_endpoints` must still
  start with `^/kbs` or `^/metrics` and end with `$`, so enabling this does not let
  admin auth be silently extended to arbitrary paths. A rule spanning both namespaces
  must be split into one ACL entry per namespace. Existing `^/kbs...$` rules are
  unaffected.

- Only `/metrics` is guarded. `/healthz` and other status/liveness handlers stay
  unauthenticated; this is not a general mechanism for putting operational endpoints
  behind admin auth.

- Docs updated (`config.md`, `admin.md`, `metrics.md`).

### Deployment guidance

This is defense-in-depth for deployments that do not put an authenticating gateway in
front of KBS. Restricting network access to the metrics port (and running a gateway)
remains the recommended primary control; the flag exists so that operators who cannot
rely on one still have a built-in option.

### Tests

Integration tests cover no token, valid token, `DenyAll`, and a restricted ACL that
excludes `/metrics`, plus a test asserting the default stays unauthenticated. Unit
tests cover the narrowed ACL anchor validation.
