### PR TITLE
helm: add native KBS TLS support

### DIFF
--- a/deployment/helm-chart/Makefile
+++ b/deployment/helm-chart/Makefile
@@ -1,6 +1,6 @@
 # Helm chart end-to-end tests (Trustee deploy + kbs-client + undeploy).
 #
-# Prerequisites: helm, kubectl, base64, diff, and a pre-built kbs-client.
+# Prerequisites: helm, kubectl, base64, diff, openssl, and a pre-built kbs-client.
 # A Kubernetes cluster must already exist (kind recommended). Cluster creation is out of band.
 #
 # Images must already be loaded into the target Kubernetes cluster before running e2e-test.
@@ -43,7 +43,8 @@ export KBS_CLIENT
 export EXPECTED_TEE
 
 .PHONY: e2e-test deploy undeploy test-client check-tools wait-ready \
-	check-docker helm-dependency-build helm-lint load-e2e-images-into-kind dump-logs
+	check-docker helm-dependency-build helm-lint \
+	load-e2e-images-into-kind prepare-e2e-tls dump-logs
 
 check-tools:
 	@command -v helm >/dev/null || (echo "missing: helm" >&2; exit 1)
@@ -58,7 +59,9 @@ helm-dependency-build: check-tools
 	helm dependency build '$(CHART_DIR)'
 
 helm-lint: helm-dependency-build
+	helm lint '$(CHART_DIR)'
 	helm lint '$(CHART_DIR)' -f '$(CHART_DIR)/scenarios/e2e-local-images.yaml' $(HELM_E2E_IMAGE_ARGS)
+	helm lint '$(CHART_DIR)' -f '$(CHART_DIR)/scenarios/native-tls.yaml'
 
 load-e2e-images-into-kind: check-docker
 	@command -v kind >/dev/null || (echo "missing: kind (required to load local images)" >&2; exit 1)
@@ -66,7 +69,25 @@ load-e2e-images-into-kind: check-docker
 	kind load docker-image --name '$(KIND_CLUSTER)' \
 		'$(E2E_KBS_IMAGE)' '$(E2E_AS_IMAGE)' '$(E2E_RVPS_IMAGE)'
 
-deploy: helm-lint
+prepare-e2e-tls: check-tools
+	@command -v openssl >/dev/null || (echo "missing: openssl" >&2; exit 1)
+	@work_dir="$$(mktemp -d)"; \
+	trap 'rm -rf "$$work_dir"' EXIT; \
+	kubectl create namespace coco-trustee-e2e \
+		--dry-run=client -o yaml | kubectl apply -f -; \
+	openssl req -x509 -newkey rsa:2048 -nodes -sha256 -days 1 \
+		-keyout "$$work_dir/tls.key" \
+		-out "$$work_dir/tls.crt" \
+		-subj '/CN=127.0.0.1' \
+		-addext 'subjectAltName=IP:127.0.0.1,DNS:localhost' \
+		-addext 'basicConstraints=CA:FALSE' >/dev/null 2>&1; \
+	kubectl create secret tls trustee-e2e-kbs-tls \
+		--namespace coco-trustee-e2e \
+		--key "$$work_dir/tls.key" \
+		--cert "$$work_dir/tls.crt" \
+		--dry-run=client -o yaml | kubectl apply -f -
+
+deploy: helm-lint prepare-e2e-tls
 	helm upgrade --install trustee-e2e '$(CHART_DIR)' \
 		--namespace coco-trustee-e2e \
 		--create-namespace \

--- a/deployment/helm-chart/README.md
+++ b/deployment/helm-chart/README.md
@@ -153,6 +153,39 @@ helm upgrade --install trustee ./deployment/helm-chart \
 
 Or use **`scenarios/bring-your-own-keys.yaml`** (adjust Secret name / file paths in the comments there).
 
+### Native KBS HTTPS
+
+The default KBS listener uses plaintext HTTP. For a KBS endpoint that clients or
+confidential guests reach directly, enable native HTTPS and provide an existing
+Secret containing the endpoint private key and certificate chain. The chart does
+not generate this identity material because its certificate SAN must match the
+address used by KBS clients.
+
+```bash
+kubectl create namespace coco-trustee
+kubectl create secret tls trustee-kbs-tls \
+  --namespace coco-trustee \
+  --key ./kbs.key \
+  --cert ./kbs.crt
+
+helm upgrade --install trustee ./deployment/helm-chart \
+  --namespace coco-trustee \
+  -f ./deployment/helm-chart/scenarios/native-tls.yaml
+```
+
+With `kbs.tls.enabled=true`, the chart leaves `insecure_http` at its secure
+default (`false`), mounts the standard `tls.key` and `tls.crt` data keys from the
+selected Kubernetes TLS Secret, and changes the KBS health probes to HTTPS.
+
+KBS does not reload endpoint identity material dynamically, so restart the KBS
+Deployment after replacing the TLS Secret contents.
+
+Ingress TLS termination is a separate mode: leave native KBS TLS disabled and
+configure `ingress.tls` when the Ingress controller should serve HTTPS and
+forward plaintext HTTP to KBS. Do not combine native KBS TLS with Ingress unless
+the chosen Ingress controller is explicitly configured to use HTTPS for its
+backend connection.
+
 ### IBM Secure Execution (s390x)
 
 On **s390x**, the **IBM Secure Execution (SE)** verifier needs attestation materials at runtime. Because KBS talks to a **remote `coco_as_grpc` AS**, the verifier runs inside the **AS Pod**, so these materials must be mounted on **AS**, not KBS. (This differs from the builtin-AS kustomize overlay in `kbs/config/kubernetes/overlays/ibm-se`, which mounts them on KBS.)
@@ -296,6 +329,8 @@ Default **`values.yaml`** is intentionally small. Fixed on-disk paths for **Loca
 | kbs.service.exposeLoadBalancer | bool | `false` | When `true`, create an additional external `LoadBalancer` Service (`<fullname>-kbs-lb`). The primary KBS Service (`<fullname>-kbs`) is always internal `ClusterIP`. |
 | kbs.service.loadBalancerAnnotations | object | `{}` | Annotations applied to the optional KBS `LoadBalancer` Service when `exposeLoadBalancer=true`. |
 | kbs.service.port | int | `8080` | Service port for KBS; used by both the internal `ClusterIP` Service and the optional external `LoadBalancer` Service. |
+| kbs.tls.enabled | bool | `false` | Enable native HTTPS on the KBS listener. Requires `secretName`; the chart does not generate endpoint identity material. |
+| kbs.tls.secretName | string | `""` | Secret containing the KBS HTTPS private key and certificate chain. Required when `enabled=true`. |
 | kbs.tolerations | list | `[]` | Tolerations for scheduling KBS Pods onto tainted nodes. |
 | log_level | string | `"info"` | Container `RUST_LOG` for KBS, AS, and RVPS (`info`, `debug`, `warn`, `error`). |
 | nameOverride | string | `""` | Override the chart name used in labels and resource names. |
@@ -381,21 +416,24 @@ make test-helm-e2e
 - **CI images**: reuses `docker-e2e-images-linux-amd64` from `workflow-call-build-docker-e2e-materials.yml` as `ghcr.io/confidential-containers/staged-images/*:latest`
 - **Storage**: bundled Postgres KV backend (`storageBackend.type: Postgres`)
 - **KBS sessions**: bundled Valkey (`sessionStorageType: Redis`)
+- **KBS endpoint**: native HTTPS using an ephemeral, test-only certificate
 
 Steps:
 
 1. **`helm-dependency-build`**
-2. **`helm-lint`**
-3. **`deploy`**
-4. **`test-client`** — [e2e/test.sh](./e2e/test.sh)
-5. **`dump-logs`** — on failure only: pod status, events, describe, and container logs (current + previous), while the namespace still exists
-6. **`undeploy`** — always attempted, even after failures
+2. **`helm-lint`** — validates the default HTTP, e2e, and native-HTTPS configurations
+3. **`prepare-e2e-tls`** — creates a test Kubernetes TLS Secret
+4. **`deploy`**
+5. **`test-client`** — [e2e/test.sh](./e2e/test.sh) validates the certificate and exercises KBS over HTTPS
+6. **`dump-logs`** — on failure only: pod status, events, describe, and container logs (current + previous), while the namespace still exists
+7. **`undeploy`** — always attempted, even after failures
 
 Debug individually:
 
 ```bash
 make -C deployment/helm-chart load-e2e-images-into-kind
 make -C deployment/helm-chart helm-lint
+make -C deployment/helm-chart prepare-e2e-tls
 make -C deployment/helm-chart deploy
 make -C deployment/helm-chart test-client
 make -C deployment/helm-chart dump-logs

--- a/deployment/helm-chart/README.md.gotmpl
+++ b/deployment/helm-chart/README.md.gotmpl
@@ -153,6 +153,39 @@ helm upgrade --install trustee ./deployment/helm-chart \
 
 Or use **`scenarios/bring-your-own-keys.yaml`** (adjust Secret name / file paths in the comments there).
 
+### Native KBS HTTPS
+
+The default KBS listener uses plaintext HTTP. For a KBS endpoint that clients or
+confidential guests reach directly, enable native HTTPS and provide an existing
+Secret containing the endpoint private key and certificate chain. The chart does
+not generate this identity material because its certificate SAN must match the
+address used by KBS clients.
+
+```bash
+kubectl create namespace coco-trustee
+kubectl create secret tls trustee-kbs-tls \
+  --namespace coco-trustee \
+  --key ./kbs.key \
+  --cert ./kbs.crt
+
+helm upgrade --install trustee ./deployment/helm-chart \
+  --namespace coco-trustee \
+  -f ./deployment/helm-chart/scenarios/native-tls.yaml
+```
+
+With `kbs.tls.enabled=true`, the chart leaves `insecure_http` at its secure
+default (`false`), mounts the standard `tls.key` and `tls.crt` data keys from the
+selected Kubernetes TLS Secret, and changes the KBS health probes to HTTPS.
+
+KBS does not reload endpoint identity material dynamically, so restart the KBS
+Deployment after replacing the TLS Secret contents.
+
+Ingress TLS termination is a separate mode: leave native KBS TLS disabled and
+configure `ingress.tls` when the Ingress controller should serve HTTPS and
+forward plaintext HTTP to KBS. Do not combine native KBS TLS with Ingress unless
+the chosen Ingress controller is explicitly configured to use HTTPS for its
+backend connection.
+
 ### IBM Secure Execution (s390x)
 
 On **s390x**, the **IBM Secure Execution (SE)** verifier needs attestation materials at runtime. Because KBS talks to a **remote `coco_as_grpc` AS**, the verifier runs inside the **AS Pod**, so these materials must be mounted on **AS**, not KBS. (This differs from the builtin-AS kustomize overlay in `kbs/config/kubernetes/overlays/ibm-se`, which mounts them on KBS.)
@@ -251,20 +284,23 @@ make test-helm-e2e
 - **CI images**: reuses `docker-e2e-images-linux-amd64` from `workflow-call-build-docker-e2e-materials.yml` as `ghcr.io/confidential-containers/staged-images/*:latest`
 - **Storage**: bundled Postgres KV backend (`storageBackend.type: Postgres`)
 - **KBS sessions**: bundled Valkey (`sessionStorageType: Redis`)
+- **KBS endpoint**: native HTTPS using an ephemeral, test-only certificate
 
 Steps:
 
 1. **`helm-dependency-build`**
-2. **`helm-lint`**
-3. **`deploy`**
-4. **`test-client`** — [e2e/test.sh](./e2e/test.sh)
-5. **`undeploy`** — always attempted, even after failures
+2. **`helm-lint`** — validates the default HTTP, e2e, and native-HTTPS configurations
+3. **`prepare-e2e-tls`** — creates a test Kubernetes TLS Secret
+4. **`deploy`**
+5. **`test-client`** — [e2e/test.sh](./e2e/test.sh) validates the certificate and exercises KBS over HTTPS
+6. **`undeploy`** — always attempted, even after failures
 
 Debug individually:
 
 ```bash
 make -C deployment/helm-chart load-e2e-images-into-kind
 make -C deployment/helm-chart helm-lint
+make -C deployment/helm-chart prepare-e2e-tls
 make -C deployment/helm-chart deploy
 make -C deployment/helm-chart test-client
 make -C deployment/helm-chart undeploy

--- a/deployment/helm-chart/README.md.gotmpl
+++ b/deployment/helm-chart/README.md.gotmpl
@@ -293,7 +293,8 @@ Steps:
 3. **`prepare-e2e-tls`** — creates a test Kubernetes TLS Secret
 4. **`deploy`**
 5. **`test-client`** — [e2e/test.sh](./e2e/test.sh) validates the certificate and exercises KBS over HTTPS
-6. **`undeploy`** — always attempted, even after failures
+6. **`dump-logs`** — on failure only: pod status, events, describe, and container logs (current + previous), while the namespace still exists
+7. **`undeploy`** — always attempted, even after failures
 
 Debug individually:
 
@@ -303,6 +304,7 @@ make -C deployment/helm-chart helm-lint
 make -C deployment/helm-chart prepare-e2e-tls
 make -C deployment/helm-chart deploy
 make -C deployment/helm-chart test-client
+make -C deployment/helm-chart dump-logs
 make -C deployment/helm-chart undeploy
 ```
 

--- a/deployment/helm-chart/e2e/test.sh
+++ b/deployment/helm-chart/e2e/test.sh
@@ -18,7 +18,7 @@ KBS_CLIENT="${KBS_CLIENT:-${REPO_ROOT}/target/release/kbs-client}"
 # Override with `KBS_CLIENT_SUDO=` to disable (e.g. local dev without
 # passwordless sudo, or when already running as root).
 KBS_CLIENT_SUDO="${KBS_CLIENT_SUDO:-sudo -E}"
-KBS_URL="http://127.0.0.1:8080"
+KBS_URL="https://127.0.0.1:8080"
 TEST_RESOURCE_FILE="${SCRIPT_DIR}/fixtures/test-resource.txt"
 RESOURCE_PATH="helm-e2e/test-repo/test-secret"
 
@@ -30,6 +30,7 @@ EXPECTED_TEE="${EXPECTED_TEE:-}"
 
 WORK_DIR="$(mktemp -d)"
 ADMIN_TOKEN_FILE="${WORK_DIR}/admin-token"
+KBS_CERT_FILE="${WORK_DIR}/kbs-tls.crt"
 ROUNDTRIP_FILE="${WORK_DIR}/roundtrip.txt"
 PORT_FORWARD_PID=""
 
@@ -55,7 +56,7 @@ require_cmd() {
 # elevated; kubectl/helm keep running as the current user (their kubeconfig is
 # user-scoped). ${KBS_CLIENT_SUDO} is intentionally left unquoted for word split.
 kbs_client() {
-	${KBS_CLIENT_SUDO} "${KBS_CLIENT}" "$@"
+	${KBS_CLIENT_SUDO} "${KBS_CLIENT}" --cert-file "${KBS_CERT_FILE}" "$@"
 }
 
 # Emit a resource policy that only releases resources when the attestation
@@ -153,6 +154,12 @@ main() {
 
 	wait_for_bootstrap_secret
 	start_port_forward
+
+	kubectl get secret trustee-e2e-kbs-tls -n coco-trustee-e2e \
+		-o "jsonpath={.data.tls\\.crt}" \
+		| base64 -d >"${KBS_CERT_FILE}"
+	[[ -s "${KBS_CERT_FILE}" ]] ||
+		die "certificate data key tls.crt is empty in Secret trustee-e2e-kbs-tls"
 
 	kubectl get secret trustee-e2e-bootstrap-user-keys -n coco-trustee-e2e \
 		-o "jsonpath={.data.KBS_ADMIN_TOKEN}" | base64 -d >"${ADMIN_TOKEN_FILE}"

--- a/deployment/helm-chart/files/kbs-config.toml.template
+++ b/deployment/helm-chart/files/kbs-config.toml.template
@@ -2,9 +2,15 @@
 session_storage_type = "{{ include "coco-trustee.kbs.sessionStorageType" . }}"
 {{- end }}
 
+{{- $tlsEnabled := eq (include "coco-trustee.kbs.tlsEnabled" . | trim) "true" }}
 [http_server]
 sockets = ["0.0.0.0:{{ include "coco-trustee.port.kbs" . }}"]
+{{- if $tlsEnabled }}
+private_key = "/etc/kbs/tls/tls.key"
+certificate = "/etc/kbs/tls/tls.crt"
+{{- else }}
 insecure_http = true
+{{- end }}
 
 [attestation_token]
 trusted_certs_paths = ["/opt/confidential-containers/kbs/user-keys/token-cert-chain.pem"]

--- a/deployment/helm-chart/scenarios/e2e-local-images.yaml
+++ b/deployment/helm-chart/scenarios/e2e-local-images.yaml
@@ -4,6 +4,11 @@
 
 sessionStorageType: Redis
 
+kbs:
+  tls:
+    enabled: true
+    secretName: trustee-e2e-kbs-tls
+
 storageBackend:
   type: Postgres
   postgres:

--- a/deployment/helm-chart/scenarios/native-tls.yaml
+++ b/deployment/helm-chart/scenarios/native-tls.yaml
@@ -1,0 +1,18 @@
+# Native KBS HTTPS with a pre-created Kubernetes TLS Secret.
+#
+# Create endpoint identity material whose SAN matches the address used by KBS
+# clients, then create the Secret before installing this scenario:
+#
+#   kubectl create namespace coco-trustee
+#   kubectl create secret tls trustee-kbs-tls \
+#     --namespace coco-trustee \
+#     --key ./kbs.key \
+#     --cert ./kbs.crt
+#   helm upgrade --install trustee ./deployment/helm-chart \
+#     --namespace coco-trustee \
+#     -f ./deployment/helm-chart/scenarios/native-tls.yaml
+
+kbs:
+  tls:
+    enabled: true
+    secretName: trustee-kbs-tls

--- a/deployment/helm-chart/templates/_helpers.tpl
+++ b/deployment/helm-chart/templates/_helpers.tpl
@@ -507,6 +507,21 @@ KBS admin JWT settings (bootstrap token + kbs-config.toml).
 {{- end }}
 
 {{/*
+KBS HTTPS settings. TLS material is supplied separately from the admin and
+attestation-token keys because it represents the externally visible KBS identity.
+*/}}
+{{- define "coco-trustee.kbs.tlsEnabled" -}}
+{{- $tls := ((.Values.kbs | default dict).tls | default dict) -}}
+{{- if ($tls.enabled | default false) }}true{{- end -}}
+{{- end }}
+{{- define "coco-trustee.kbs.tlsSecretName" -}}
+{{- $tls := ((.Values.kbs | default dict).tls | default dict) -}}
+{{- if ($tls.enabled | default false) -}}
+{{- required "kbs.tls.secretName must be set when kbs.tls.enabled is true" (trim (default "" $tls.secretName)) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Secret name for KBS + AS user-keys volume. Ephemeral path uses hook-created Secret; otherwise secrets.existingSecretName.
 */}}
 {{- define "coco-trustee.userKeysSecretNameResolved" -}}

--- a/deployment/helm-chart/templates/kbs-deployment.yaml
+++ b/deployment/helm-chart/templates/kbs-deployment.yaml
@@ -1,6 +1,10 @@
 {{- if not .Values.secrets.useEphemeralGeneratedKeys }}
 {{- $_ := required "secrets.existingSecretName must be set when secrets.useEphemeralGeneratedKeys is false" (trim (default "" .Values.secrets.existingSecretName)) }}
 {{- end }}
+{{- $tlsEnabled := eq (include "coco-trustee.kbs.tlsEnabled" . | trim) "true" }}
+{{- if $tlsEnabled }}
+{{- $_ := include "coco-trustee.kbs.tlsSecretName" . }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -91,12 +95,14 @@ spec:
             httpGet:
               path: /healthz
               port: http
+              scheme: {{ ternary "HTTPS" "HTTP" $tlsEnabled }}
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz
               port: http
+              scheme: {{ ternary "HTTPS" "HTTP" $tlsEnabled }}
             initialDelaySeconds: 15
             periodSeconds: 20
           {{- with .Values.kbs.resources }}
@@ -108,6 +114,11 @@ spec:
               mountPath: /etc/kbs
             - name: user-keys
               mountPath: /opt/confidential-containers/kbs/user-keys
+            {{- if $tlsEnabled }}
+            - name: kbs-tls
+              mountPath: /etc/kbs/tls
+              readOnly: true
+            {{- end }}
             {{- if $needLocalFs }}
             - name: data
               mountPath: {{ include "coco-trustee.storage.kbsLocalDir" . }}
@@ -133,6 +144,11 @@ spec:
           secret:
             secretName: {{ include "coco-trustee.userKeysSecretNameResolved" . | trim }}
 {{- include "coco-trustee.userKeysSecretVolumeItems" . | nindent 12 }}
+        {{- if $tlsEnabled }}
+        - name: kbs-tls
+          secret:
+            secretName: {{ include "coco-trustee.kbs.tlsSecretName" . }}
+        {{- end }}
         {{- if $needDataVolume }}
         {{- $kbsClaim := include "coco-trustee.persistence.kbsDataClaimName" . | trim }}
         - name: data

--- a/deployment/helm-chart/values.yaml
+++ b/deployment/helm-chart/values.yaml
@@ -151,6 +151,11 @@ kbs:
       poolSize: 200
       # -- Request timeout in seconds for the KBS -> gRPC AS client (`timeout` in `files/kbs-config.toml.template`).
       timeout: 30
+  tls:
+    # -- Enable native HTTPS on the KBS listener. Requires `secretName`; the chart does not generate endpoint identity material.
+    enabled: false
+    # -- Secret containing the KBS HTTPS private key and certificate chain. Required when `enabled=true`.
+    secretName: ""
   image:
     # -- KBS container image repository.
     repository: ghcr.io/confidential-containers/staged-images/kbs-grpc-as


### PR DESCRIPTION
Allow deployments to opt into KBS HTTPS with a pre-created Kubernetes TLS Secret. Keep insecure_http=true as the default so
existing chart deployments remain unchanged.

Mount a Kubernetes TLS Secret and configure KBS to read the standard tls.crt and tls.key files. Switch health probes to HTTPS when native TLS is enabled, and exercise the HTTPS path in the Helm end-to-end test.

Fixes: #1532 

If we have this capability, I would like to add deployment with the helm chart to `Checkpoint 2: Deploy Trustee and Install kbs-client` in https://confidentialcontainers.org/docs/examples/nvidia-nim-confidential-gpu-attestation/