### PR TITLE
verifier: intel_dcap 1.27 update and TD preserving claims

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
     open-pull-requests-limit: 3
     allow:
       - dependency-type: direct
+    ignore:
+      - dependency-name: "intel-tee-quote-verification-rs"
     cooldown:
       default-days: 7
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,17 +1352,15 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "lazy_static",
- "lazycell",
+ "itertools",
  "log",
- "peeking_take_while",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -1370,7 +1368,6 @@ dependencies = [
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.117",
- "which",
 ]
 
 [[package]]
@@ -2756,7 +2753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4008,19 +4005,19 @@ dependencies = [
 
 [[package]]
 name = "intel-tee-quote-verification-rs"
-version = "0.3.0"
-source = "git+https://github.com/intel/confidential-computing.tee.dcap?tag=DCAP_1.26#1f362a6cffc228e290862bd7fffe2d31e290bb4f"
+version = "0.4.0"
+source = "git+https://github.com/intel/confidential-computing.tee.dcap?tag=DCAP_1.27#ecdb68e9854b20d5f6a27cd874f7e89e977e9ca1"
 dependencies = [
  "intel-tee-quote-verification-sys",
 ]
 
 [[package]]
 name = "intel-tee-quote-verification-sys"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c8bc48d598fa48310e41f65a706e0beb2a74f5f9e5a26c5c2ca6cd83416fcc"
+checksum = "773f9c797d4b99e99841bd95ed60b374e3fdf7570a2ae7f2c3856af716fd6115"
 dependencies = [
- "bindgen 0.65.1",
+ "bindgen 0.70.1",
 ]
 
 [[package]]
@@ -4080,7 +4077,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4519,12 +4516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4597,12 +4588,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5253,12 +5238,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5847,7 +5826,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6490,19 +6469,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.13.1",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -6510,8 +6476,8 @@ dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6579,7 +6545,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7683,8 +7649,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8723,18 +8689,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8766,7 +8720,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/attestation-service/docker/as-grpc/Dockerfile
+++ b/attestation-service/docker/as-grpc/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 RUN apt-get update && apt-get install --no-install-recommends -y protobuf-compiler clang libtss2-dev cmake
 
 # Install TDX Build Dependencies
-ARG DCAP_VERSION=1_26_100
+ARG DCAP_VERSION=1_27_100
 RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
     curl -sSLf https://download.01.org/intel-sgx/sgx_repo/ubuntu/apt_preference_files/99dcap_${DCAP_VERSION}_noble_custom_version.cfg | \
     tee -a /etc/apt/preferences.d/99dcap && \
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y openssl libcurl4 && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 # Install TDX Runtime Dependencies
-ARG DCAP_VERSION=1_26_100
+ARG DCAP_VERSION=1_27_100
 RUN if [ "${ARCH}" = "x86_64" ] && ( [ "${VERIFIER}" = "all-verifier" ] || [ "${VERIFIER}" = "tdx-verifier" ] ); \
     then apt-get update && apt-get install curl gnupg -y && \
     curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \

--- a/attestation-service/docker/as-restful/Dockerfile
+++ b/attestation-service/docker/as-restful/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 RUN apt-get update && apt-get install -y protobuf-compiler clang libtss2-dev cmake
 
 # Install TDX Build Dependencies
-ARG DCAP_VERSION=1_26_100
+ARG DCAP_VERSION=1_27_100
 RUN if [ "${ARCH}" = "x86_64" ]; then curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
     curl -sSLf https://download.01.org/intel-sgx/sgx_repo/ubuntu/apt_preference_files/99dcap_${DCAP_VERSION}_noble_custom_version.cfg | \
     tee -a /etc/apt/preferences.d/99dcap && \
@@ -50,7 +50,7 @@ RUN apt-get update && apt-get install openssl -y && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 # Install TDX Runtime Dependencies
-ARG DCAP_VERSION=1_26_100
+ARG DCAP_VERSION=1_27_100
 RUN if [ "${ARCH}" = "x86_64" ] && ( [ "${VERIFIER}" = "all-verifier" ] || [ "${VERIFIER}" = "tdx-verifier" ] ); \
     then apt-get update && apt-get install curl gnupg -y && \
     curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \

--- a/attestation-service/docs/tcb_claims.md
+++ b/attestation-service/docs/tcb_claims.md
@@ -119,6 +119,11 @@ The following fields always exist.
   - `TDRelaunchAdvised` - The platform firmware and software are at the latest security patching level but the TD was launched prior to the application of new TDX TCB components using a TD Preserving update. Re-launching the TD will change the attestation result.
   - `TDRelaunchAdvisedConfigurationNeeded` - The platform firmware and software are at the latest security patching level but there are platform hardware configurations that may expose the TD to vulnerabilities. Re-launching the TD will change the attestation result.
 
+The following fields report the TD's current TCB level, as opposed to the level it originally launched at (reflected by `tdx.tcb_date`/`tdx.tcb_status`/`tdx.advisory_ids` above). They differ from the launch-time fields only for a TD that has undergone a TD Preserving update. _Note: these fields are only provided when the installed DCAP quote verification library reports supplemental data minor_version 5 or later (DCAP 1.27+); an older library omits them entirely._
+- `tdx.tcb_date_current`: String. Date time value in RFC3339 format - TCB date for the current TCB level.
+- `tdx.tcb_status_current`: String. TCB Level Status for the current TCB level. Same set of values as `tdx.tcb_status`.
+- `tdx.advisory_ids_current`: String List. Intel® Product Security Center Advisories applicable to the current TCB level.
+
 ## Intel SGX
 
 - `sgx.header`: Object. SGX quote header.

--- a/deps/verifier/Cargo.toml
+++ b/deps/verifier/Cargo.toml
@@ -104,7 +104,7 @@ sev = { version = "7", default-features = false, features = [
 sha2.workspace = true
 tokio = { workspace = true, optional = true }
 tracing.workspace = true
-intel-tee-quote-verification-rs = { git = "https://github.com/intel/confidential-computing.tee.dcap", tag = "DCAP_1.26", optional = true }
+intel-tee-quote-verification-rs = { git = "https://github.com/intel/confidential-computing.tee.dcap", tag = "DCAP_1.27", optional = true }
 strum.workspace = true
 veraison-apiclient = { git = "https://github.com/veraison/rust-apiclient", rev = "fe149cd", optional = true }
 ccatoken = { git = "https://github.com/veraison/rust-ccatoken", rev = "870c83f", optional = true }

--- a/deps/verifier/src/intel_dcap/claims.rs
+++ b/deps/verifier/src/intel_dcap/claims.rs
@@ -37,6 +37,7 @@ impl SgxQlQvResultWrapper {
 
 pub(crate) fn prepare_custom_claims_map(
     supp_data: &mut sgx_ql_qv_supplemental_t,
+    minor_version: u16,
     collateral_expiration_status: u32,
     quote_verification_result: sgx_ql_qv_result_t,
 ) -> anyhow::Result<Map<String, Value>> {
@@ -112,6 +113,26 @@ pub(crate) fn prepare_custom_claims_map(
         Value::String(collateral_expiration_status.to_string()),
     );
     claims_map.insert("advisory_ids".to_string(), get_sa_list(&supp_data.sa_list));
+
+    // `tcb_date_current`/`tcb_status_current`/`sa_list_current` were appended
+    // in supplemental data minor_version 5 (DCAP 1.27); a runtime QVL older
+    // than that leaves them zeroed, so only surface them once the QVL has
+    // confirmed it actually populated them.
+    if minor_version >= 5 {
+        claims_map.insert(
+            "tcb_date_current".to_string(),
+            Value::String(format_rfc3339(supp_data.tcb_date_current)?),
+        );
+        claims_map.insert(
+            "tcb_status_current".to_string(),
+            SgxQlQvResultWrapper(supp_data.tcb_status_current).as_str(),
+        );
+        claims_map.insert(
+            "advisory_ids_current".to_string(),
+            get_sa_list(&supp_data.sa_list_current),
+        );
+    }
+
     Ok(claims_map)
 }
 
@@ -153,7 +174,7 @@ mod tests {
         let mut supp = deserialize_supp_data(&supplemental_data);
 
         let claims =
-            prepare_custom_claims_map(&mut supp, 0, sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OK)
+            prepare_custom_claims_map(&mut supp, 0, 0, sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OK)
                 .expect("failed to prepare custom claims map");
 
         let expected = json!({
@@ -176,6 +197,39 @@ mod tests {
         });
 
         assert_json_eq!(expected, claims);
+    }
+
+    #[test]
+    fn parse_supplemental_data_minor_version_5() {
+        let mut supp = create_supp_data_v5();
+
+        let claims =
+            prepare_custom_claims_map(&mut supp, 5, 0, sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OK)
+                .expect("failed to prepare custom claims map");
+
+        assert_eq!(
+            claims.get("tcb_date_current").and_then(|v| v.as_str()),
+            Some("2024-03-14T00:00:00Z")
+        );
+        assert_eq!(
+            claims.get("tcb_status_current").and_then(|v| v.as_str()),
+            Some("OutOfDate")
+        );
+        assert_eq!(
+            claims.get("advisory_ids_current"),
+            Some(&json!(["INTEL-SA-1234"]))
+        );
+    }
+
+    fn create_supp_data_v5() -> sgx_ql_qv_supplemental_t {
+        let mut supp: sgx_ql_qv_supplemental_t = Default::default();
+        supp.tcb_date_current = 1710374400;
+        supp.tcb_status_current = sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OUT_OF_DATE;
+        let advisory = b"INTEL-SA-1234\0";
+        for (dst, &b) in supp.sa_list_current.iter_mut().zip(advisory) {
+            *dst = b as std::os::raw::c_char;
+        }
+        supp
     }
 
     fn deserialize_supp_data(encoded: &str) -> sgx_ql_qv_supplemental_t {

--- a/deps/verifier/src/intel_dcap/error.rs
+++ b/deps/verifier/src/intel_dcap/error.rs
@@ -1,7 +1,7 @@
 use intel_tee_quote_verification_rs::quote3_error_t;
 
 /// List of DCAP related errors.
-/// <https://download.01.org/intel-sgx/sgx-dcap/1.26/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf>
+/// <https://download.01.org/intel-sgx/sgx-dcap/1.27/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf>
 pub(super) fn describe_error(error: quote3_error_t) -> String {
     let description = match error {
         quote3_error_t::TEE_SUCCESS => "Success.",
@@ -97,7 +97,7 @@ pub(super) fn describe_error(error: quote3_error_t) -> String {
         _ => "Unrecognized DCAP error code.",
     };
 
-    format!("{:?} ({:#04x}) - {}", error, error as u32, description)
+    format!("{:#04x} - {description}", error.0)
         .trim()
         .to_string()
 }
@@ -108,8 +108,11 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    #[case(quote3_error_t::SGX_QL_QEIDENTITY_MISMATCH, "SGX_QL_QEIDENTITY_MISMATCH (0xe026) - The Quote’s QE doesn’t match the inputted expected QEIdentity.")]
-    #[case(quote3_error_t::SGX_QL_SUCCESS, "SGX_QL_SUCCESS (0x00) - Success.")]
+    #[case(
+        quote3_error_t::SGX_QL_QEIDENTITY_MISMATCH,
+        "0xe026 - The Quote’s QE doesn’t match the inputted expected QEIdentity."
+    )]
+    #[case(quote3_error_t::SGX_QL_SUCCESS, "0x00 - Success.")]
     fn describe_error_test(#[case] test_data: quote3_error_t, #[case] expected_result: &str) {
         let actual_result = describe_error(test_data);
         assert_eq!(actual_result, expected_result);

--- a/deps/verifier/src/intel_dcap/mod.rs
+++ b/deps/verifier/src/intel_dcap/mod.rs
@@ -112,13 +112,20 @@ pub(crate) fn ecdsa_quote_verification(
         .as_secs() as i64;
 
     // call DCAP quote verify library for quote verification
-    let (collateral_expiration_status, quote_verification_result) = tee_verify_quote(
-        quote,
-        collateral.as_ref(),
-        current_time,
-        None,
-        Some(&mut supp_data_desc),
-    )
+    //
+    // Safety: `supp_data_desc.p_data` points to `supp_data`, a live
+    // `sgx_ql_qv_supplemental_t` on the stack, and `data_size` was set to
+    // `supp_size`, matching that struct's size, so the descriptor upholds
+    // tee_verify_quote's size/validity precondition.
+    let (collateral_expiration_status, quote_verification_result) = unsafe {
+        tee_verify_quote(
+            quote,
+            collateral.as_ref(),
+            current_time,
+            None,
+            Some(&mut supp_data_desc),
+        )
+    }
     .map_err(|e| anyhow!("tee_verify_quote failed: {}", describe_error(e)))?;
 
     debug!("tee_verify_quote successfully returned.");
@@ -141,9 +148,8 @@ pub(crate) fn ecdsa_quote_verification(
         }
         terminal_result => {
             bail!(
-                "Verification completed with Terminal result: {:?} ({:#04x})",
-                terminal_result,
-                terminal_result as u32
+                "Verification completed with Terminal result: {:#04x}",
+                terminal_result.0
             );
         }
     }

--- a/deps/verifier/src/intel_dcap/mod.rs
+++ b/deps/verifier/src/intel_dcap/mod.rs
@@ -84,12 +84,17 @@ pub(crate) fn ecdsa_quote_verification(
         }
     });
 
-    let (_, supp_size) = tee_get_supplemental_data_version_and_size(quote).map_err(|e| {
+    let (version, supp_size) = tee_get_supplemental_data_version_and_size(quote).map_err(|e| {
         anyhow!(
             "tee_get_supplemental_data_version_and_size failed: {}",
             describe_error(e)
         )
     })?;
+    // `version` packs major_version in the low 16 bits and minor_version in
+    // the high 16 bits (see `supp_ver_t` in the DCAP headers), matching the
+    // layout the QVL also writes into `sgx_ql_qv_supplemental_t`'s version
+    // union when it populates `supp_data` below.
+    let minor_version = (version >> 16) as u16;
 
     // `sgx_ql_qv_supplemental_t` only ever appends fields for a new minor
     // version, so a runtime QVL older than this build reports a `supp_size`
@@ -145,6 +150,7 @@ pub(crate) fn ecdsa_quote_verification(
         | sgx_ql_qv_result_t::SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED_CONFIG_NEEDED => {
             prepare_custom_claims_map(
                 &mut supp_data,
+                minor_version,
                 collateral_expiration_status,
                 quote_verification_result,
             )

--- a/deps/verifier/src/intel_dcap/mod.rs
+++ b/deps/verifier/src/intel_dcap/mod.rs
@@ -91,11 +91,15 @@ pub(crate) fn ecdsa_quote_verification(
         )
     })?;
 
-    let expected_size = mem::size_of::<sgx_ql_qv_supplemental_t>() as u32;
-    if supp_size != expected_size {
-        bail!(
-            "Supplemental data size mismatch: QVL returned {supp_size}, expected {expected_size}"
-        );
+    // `sgx_ql_qv_supplemental_t` only ever appends fields for a new minor
+    // version, so a runtime QVL older than this build reports a `supp_size`
+    // smaller than `size_of::<sgx_ql_qv_supplemental_t>()`; the unwritten
+    // tail stays at its `Default` (zeroed) value. Only a *larger* report is
+    // unsupported, since that would mean the installed QVL is newer than
+    // this build and expects a bigger buffer than we can provide.
+    let max_size = mem::size_of::<sgx_ql_qv_supplemental_t>() as u32;
+    if supp_size > max_size {
+        bail!("Supplemental data size unsupported: runtime QVL version requires {supp_size} bytes, but this build only supports up to {max_size}");
     }
 
     let mut supp_data: sgx_ql_qv_supplemental_t = Default::default();

--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
 
 RUN if [ "${ARCH}" = "aarch64" ]; then apt-get install -y libc-bin; fi
 
-ARG DCAP_VERSION=1_26_100
+ARG DCAP_VERSION=1_27_100
 RUN if [ "${ARCH}" = "x86_64" ]; then curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
     gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
     curl -sSLf https://download.01.org/intel-sgx/sgx_repo/ubuntu/apt_preference_files/99dcap_${DCAP_VERSION}_noble_custom_version.cfg | \
@@ -57,7 +57,7 @@ ARG ARCH=x86_64
 
 WORKDIR /tmp
 
-ARG DCAP_VERSION=1_26_100
+ARG DCAP_VERSION=1_27_100
 RUN apt-get update && \
     apt-get install -y \
     curl \

--- a/kbs/docker/rhel-ubi/Dockerfile
+++ b/kbs/docker/rhel-ubi/Dockerfile
@@ -8,7 +8,7 @@ tar gzip
 
 # Install build dependencies from Intel repo.
 WORKDIR /root
-RUN curl -O https://download.01.org/intel-sgx/sgx-linux/2.27/distro/centos-stream9/sgx_rpm_local_repo.tgz && \
+RUN curl -O https://download.01.org/intel-sgx/sgx-linux/2.30/distro/centos-stream9/sgx_rpm_local_repo.tgz && \
 tar -xaf sgx_rpm_local_repo.tgz && \
 dnf -y install --nogpgcheck --repofrompath "sgx,file:///root/sgx_rpm_local_repo" libsgx-dcap-quote-verify-devel
 


### PR DESCRIPTION
DCAP_1.27 made two breaking API changes in the Rust wrapper but this PR tries to keep it so that older runtime .so libs can still work regardless of the crate bump.