### PR TITLE
toolchain: update rust from 1.93.0 to 1.95.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ alternative options that have been considered.
 
 ### Prerequisites
 
-- **Rust toolchain**: version pinned in `rust-toolchain.toml` (currently `1.93.0`)
+- **Rust toolchain**: version pinned in `rust-toolchain.toml` (currently `1.95.0`)
 - **Protobuf compiler** (`protoc`) for gRPC code generation
 - **OpenSSL** development libraries
 - **tpm2-tss** (for TPM verifier features)

--- a/attestation-service/docker/as-grpc/Dockerfile
+++ b/attestation-service/docker/as-grpc/Dockerfile
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# rust:1.93.0
+# rust:1.95.0
 FROM --platform=${BUILDPLATFORM:-linux/amd64} \
-    docker.io/library/rust@sha256:bbde3ca426faeebab3eb58b8005d3d6da70607817a14bb92a55c94611d4d905f \
+    docker.io/library/rust@sha256:f49565f188ee00bc2a18dd418183f2c5f23ef7d6e691890517ed341a598f67c3 \
     AS builder
 ARG ARCH=x86_64
 ARG VERIFIER=all-verifier

--- a/attestation-service/docker/as-restful/Dockerfile
+++ b/attestation-service/docker/as-restful/Dockerfile
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# rust:1.93.0
+# rust:1.95.0
 FROM --platform=${BUILDPLATFORM:-linux/amd64} \
-    docker.io/library/rust@sha256:bbde3ca426faeebab3eb58b8005d3d6da70607817a14bb92a55c94611d4d905f \
+    docker.io/library/rust@sha256:f49565f188ee00bc2a18dd418183f2c5f23ef7d6e691890517ed341a598f67c3 \
     AS builder
 ARG ARCH=x86_64
 ARG VERIFIER=all-verifier

--- a/deps/verifier/src/nvidia/spdm_response.rs
+++ b/deps/verifier/src/nvidia/spdm_response.rs
@@ -311,12 +311,10 @@ impl OpaqueData {
             bail!("OpaqueDataType is not multiple of {}", MSR_COUNT_SIZE)
         }
         let mut values: Map<String, Value> = Map::new();
-        let mut index: u8 = 1;
-        for chunk in bytes.chunks(MSR_COUNT_SIZE) {
+        for (index, chunk) in (1_u8..).zip(bytes.chunks(MSR_COUNT_SIZE)) {
             let array: [u8; MSR_COUNT_SIZE] = chunk.try_into()?;
             let num: u32 = u32::from_le_bytes(array);
             values.insert(index.to_string(), Value::Number(num.into()));
-            index += 1;
         }
 
         Ok(Value::Object(values))

--- a/kbs/docker/Dockerfile
+++ b/kbs/docker/Dockerfile
@@ -1,6 +1,6 @@
-# rust:1.93.0
+# rust:1.95.0
 FROM --platform=${BUILDPLATFORM:-linux/amd64} \
-    docker.io/library/rust@sha256:bbde3ca426faeebab3eb58b8005d3d6da70607817a14bb92a55c94611d4d905f \
+    docker.io/library/rust@sha256:f49565f188ee00bc2a18dd418183f2c5f23ef7d6e691890517ed341a598f67c3 \
     AS builder
 ARG ARCH=x86_64
 ARG ALIYUN=false

--- a/kbs/docker/coco-as-grpc/Dockerfile
+++ b/kbs/docker/coco-as-grpc/Dockerfile
@@ -1,6 +1,6 @@
-# rust:1.93.0
+# rust:1.95.0
 FROM --platform=${BUILDPLATFORM:-linux/amd64} \
-    docker.io/library/rust@sha256:bbde3ca426faeebab3eb58b8005d3d6da70607817a14bb92a55c94611d4d905f \
+    docker.io/library/rust@sha256:f49565f188ee00bc2a18dd418183f2c5f23ef7d6e691890517ed341a598f67c3 \
     AS builder
 ARG BUILDPLATFORM=linux/amd64
 ARG ARCH=x86_64

--- a/kbs/docker/intel-trust-authority/Dockerfile
+++ b/kbs/docker/intel-trust-authority/Dockerfile
@@ -1,5 +1,5 @@
-# rust:1.93.0
-FROM docker.io/library/rust@sha256:bbde3ca426faeebab3eb58b8005d3d6da70607817a14bb92a55c94611d4d905f \
+# rust:1.95.0
+FROM docker.io/library/rust@sha256:f49565f188ee00bc2a18dd418183f2c5f23ef7d6e691890517ed341a598f67c3 \
     AS builder
 ARG ALIYUN=false
 ARG VAULT=false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.95.0"

--- a/rvps/src/extractors/swid/mod.rs
+++ b/rvps/src/extractors/swid/mod.rs
@@ -84,13 +84,9 @@ impl Extractor for SwidExtractor {
             let mut measurement_value = vec![];
 
             let mut hash_index = 0;
-            loop {
-                let Some(hash) =
-                    resource.attribute((HASH_NS, format!("Hash{hash_index}").as_str()))
-                else {
-                    break;
-                };
-
+            while let Some(hash) =
+                resource.attribute((HASH_NS, format!("Hash{hash_index}").as_str()))
+            {
                 // If the hash only contains '0', move onto the next resource.
                 // This could mean that the RIM is attesting that the hash should
                 // be '0', but more commonly it means that there is no measurement

--- a/tools/trustee-cli/Dockerfile
+++ b/tools/trustee-cli/Dockerfile
@@ -1,6 +1,6 @@
-# rust:1.93.0
+# rust:1.95.0
 FROM --platform=${BUILDPLATFORM:-linux/amd64} \
-    docker.io/library/rust@sha256:bbde3ca426faeebab3eb58b8005d3d6da70607817a14bb92a55c94611d4d905f \
+    docker.io/library/rust@sha256:f49565f188ee00bc2a18dd418183f2c5f23ef7d6e691890517ed341a598f67c3 \
     AS builder
 ARG ARCH=x86_64
 ARG ALIYUN=false


### PR DESCRIPTION
This commit also includes some lint fixes.