### PR TITLE
helm: generalize Helm e2e scenario overrides for IBM SE nightly

### DIFF
--- a/deployment/helm-chart/Makefile
+++ b/deployment/helm-chart/Makefile
@@ -16,6 +16,13 @@ EXPECTED_TEE ?=
 
 E2E_IMAGE_PREFIX ?= trustee-e2e
 E2E_IMAGE_TAG ?= e2e
+E2E_IMAGE_PULL_POLICY ?= Never
+
+# Base e2e scenario file. Override this to switch scenario per run.
+E2E_BASE_SCENARIO ?= $(CHART_DIR)/scenarios/e2e-local-images.yaml
+
+# Optional extra Helm args for scenario-specific runtime settings.
+HELM_E2E_EXTRA_ARGS ?=
 
 # kind cluster used by load-e2e-images-into-kind (override for parallel/self-hosted runs).
 KIND_CLUSTER ?= kind
@@ -31,13 +38,16 @@ E2E_RVPS_IMAGE := $(E2E_RVPS_IMAGE_REPOSITORY):$(E2E_IMAGE_TAG)
 HELM_E2E_IMAGE_ARGS := \
 	--set-string kbs.image.repository='$(E2E_KBS_IMAGE_REPOSITORY)' \
 	--set-string kbs.image.tag='$(E2E_IMAGE_TAG)' \
-	--set-string kbs.image.pullPolicy='Never' \
+	--set-string kbs.image.pullPolicy='$(E2E_IMAGE_PULL_POLICY)' \
 	--set-string as.image.repository='$(E2E_AS_IMAGE_REPOSITORY)' \
 	--set-string as.image.tag='$(E2E_IMAGE_TAG)' \
-	--set-string as.image.pullPolicy='Never' \
+	--set-string as.image.pullPolicy='$(E2E_IMAGE_PULL_POLICY)' \
 	--set-string rvps.image.repository='$(E2E_RVPS_IMAGE_REPOSITORY)' \
 	--set-string rvps.image.tag='$(E2E_IMAGE_TAG)' \
-	--set-string rvps.image.pullPolicy='Never'
+	--set-string rvps.image.pullPolicy='$(E2E_IMAGE_PULL_POLICY)' \
+	$(HELM_E2E_EXTRA_ARGS)
+
+HELM_E2E_SCENARIO_YAML := -f '$(E2E_BASE_SCENARIO)'
 
 export KBS_CLIENT
 export EXPECTED_TEE
@@ -60,7 +70,7 @@ helm-dependency-build: check-tools
 
 helm-lint: helm-dependency-build
 	helm lint '$(CHART_DIR)'
-	helm lint '$(CHART_DIR)' -f '$(CHART_DIR)/scenarios/e2e-local-images.yaml' $(HELM_E2E_IMAGE_ARGS)
+	helm lint '$(CHART_DIR)' $(HELM_E2E_SCENARIO_YAML) $(HELM_E2E_IMAGE_ARGS)
 	helm lint '$(CHART_DIR)' -f '$(CHART_DIR)/scenarios/native-tls.yaml'
 
 load-e2e-images-into-kind: check-docker
@@ -91,7 +101,7 @@ deploy: helm-lint prepare-e2e-tls
 	helm upgrade --install trustee-e2e '$(CHART_DIR)' \
 		--namespace coco-trustee-e2e \
 		--create-namespace \
-		-f '$(CHART_DIR)/scenarios/e2e-local-images.yaml' \
+		$(HELM_E2E_SCENARIO_YAML) \
 		$(HELM_E2E_IMAGE_ARGS) \
 		--wait \
 		--timeout 20m

--- a/deployment/helm-chart/scenarios/ibm-se-nightly-e2e.yaml
+++ b/deployment/helm-chart/scenarios/ibm-se-nightly-e2e.yaml
@@ -1,0 +1,37 @@
+# IBM SE nightly e2e scenario (s390x): standalone values for the nightly leg.
+#
+# This file is standalone and does not inherit from e2e-local-images.yaml.
+# It mirrors ibm-se.yaml and additionally enables KBS TLS for the e2e test flow.
+#
+# Example:
+#   make -C deployment/helm-chart e2e-test \
+#     E2E_IMAGE_PULL_POLICY=Always \
+#     E2E_BASE_SCENARIO=scenarios/ibm-se-nightly-e2e.yaml \
+#     HELM_E2E_EXTRA_ARGS="--set as.verifier.se.nodeName=<your-s390x-node-name> --set as.verifier.se.credsDir=<absolute-path-to-materials-dir>"
+#
+# See deps/verifier/src/se/README.md for SE material preparation.
+
+kbs:
+  tls:
+    enabled: true
+    secretName: trustee-e2e-kbs-tls
+
+as:
+  # Use an s390x AS image built with the se-verifier feature. The default
+  # staged coco-as-grpc image tag must match your cluster architecture (s390x).
+  image:
+    repository: ghcr.io/confidential-containers/staged-images/coco-as-grpc
+    tag: "latest"
+  verifier:
+    se:
+      # Set via --set as.verifier.se.nodeName=<node> at install time.
+      nodeName: ""
+      # Set via --set as.verifier.se.credsDir=<path> at install time.
+      credsDir: ""
+  extraEnvVars:
+    - name: CERTS_OFFLINE_VERIFICATION
+      value: "false"
+    - name: SE_SKIP_CERTS_VERIFICATION
+      value: "false"
+  podSecurityContext:
+    fsGroup: 1000


### PR DESCRIPTION
Align Helm chart e2e configuration, so users can switch scenarios and runtime values without adding a dedicated make target.

Add overridable e2e knobs in deployment/helm-chart/Makefile:

- E2E_IMAGE_PULL_POLICY
- E2E_BASE_SCENARIO
- HELM_E2E_EXTRA_ARGS

This keeps the e2e entrypoint generic while allowing IBM SE nightly to be selected explicitly by users through make variable overrides.

Test result: https://github.com/confidential-containers/trustee/actions/runs/31357406073/job/93430782073#step:3:5256

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>