### PR TITLE
verifier/nvidia: align NRAS response parsing and simplify verifier state

### DIFF
--- a/deps/verifier/src/nvidia/mod.rs
+++ b/deps/verifier/src/nvidia/mod.rs
@@ -47,8 +47,7 @@ const NRAS_ATTESTATION_TIMEOUT: std::time::Duration = std::time::Duration::from_
 
 #[derive(Default, Debug)]
 pub struct Nvidia {
-    verifier_type: NvidiaVerifierType,
-    nras_jwks: Option<NrasJwks>,
+    verifier_type: NvidiaVerifierTypeInternal,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
@@ -65,6 +64,16 @@ pub enum NvidiaVerifierType {
     Local,
     #[serde(alias = "remote")]
     Remote(NvidiaRemoteVerifierConfig),
+}
+
+#[derive(Default, Debug)]
+enum NvidiaVerifierTypeInternal {
+    Remote {
+        config: NvidiaRemoteVerifierConfig,
+        jwks: NrasJwks,
+    },
+    #[default]
+    Local,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
@@ -217,16 +226,15 @@ impl Nvidia {
         let verifier_type = config
             .map(|c| c.verifier)
             .unwrap_or(NvidiaVerifierType::Local);
-
-        let nras_jwks = match verifier_type {
-            NvidiaVerifierType::Remote(_) => Some(NrasJwks::new().await?),
-            _ => None,
+        let verifier_type = match verifier_type {
+            NvidiaVerifierType::Remote(config) => NvidiaVerifierTypeInternal::Remote {
+                config,
+                jwks: NrasJwks::new().await?,
+            },
+            _ => NvidiaVerifierTypeInternal::Local,
         };
 
-        Ok(Nvidia {
-            verifier_type,
-            nras_jwks,
-        })
+        Ok(Nvidia { verifier_type })
     }
 
     /// Evaluate an NVIDIA device using NRAS
@@ -235,6 +243,7 @@ impl Nvidia {
         device: NvDeviceReportAndCert,
         expected_nonce_vec: Vec<u8>,
         config: &NvidiaRemoteVerifierConfig,
+        jwks: &NrasJwks,
     ) -> Result<(TeeEvidenceParsedClaim, String)> {
         let b64_engine = base64::engine::general_purpose::STANDARD;
 
@@ -288,11 +297,7 @@ impl Nvidia {
         };
 
         let response = NrasResponse::from_str(&res.text().await?)?;
-        if let Some(jwks) = &self.nras_jwks {
-            response.validate(jwks)?;
-        } else {
-            bail!("JWKs not available.");
-        }
+        response.validate(jwks)?;
 
         let claims = response.claims()?;
 
@@ -375,11 +380,11 @@ impl Verifier for Nvidia {
 
         for device in devices.device_evidence_list {
             let claims = match &self.verifier_type {
-                NvidiaVerifierType::Local => {
+                NvidiaVerifierTypeInternal::Local => {
                     self.evaluate_device_locally(device, expected_nonce_vec.clone())?
                 }
-                NvidiaVerifierType::Remote(config) => {
-                    self.evaluate_device_nras(device, expected_nonce_vec.clone(), config)
+                NvidiaVerifierTypeInternal::Remote { config, jwks } => {
+                    self.evaluate_device_nras(device, expected_nonce_vec.clone(), config, jwks)
                         .await?
                 }
             };

--- a/deps/verifier/src/nvidia/nras_response.rs
+++ b/deps/verifier/src/nvidia/nras_response.rs
@@ -13,13 +13,20 @@ use std::str::FromStr;
 use super::TeeEvidenceParsedClaim;
 use crate::nvidia::NrasJwks;
 
-// Internal struct for deserializing the NRAS Payload
+/// Internal struct for deserializing the NRAS Payload
+/// The first element is a slice with two fields:
+/// - The first field is "JWT" string
+/// - The second field is the base64 encoded primary JWT
+///
+/// The second element is a HashMap with the device name as the
+///   key and base64 encoded Individual JWTs as the value.
+///
+/// See the following link for more details
+/// https://docs.nvidia.com/attestation/advanced-documentation/latest/claims-guide/introduction.html
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-struct NrasResponseInternal {
-    jwt: Vec<String>,
-    eat: HashMap<String, String>,
-}
+struct NrasResponseInternal(Vec<String>, HashMap<String, String>);
 
+/// Formatted Nras Response
 pub struct NrasResponse {
     jwt: String,
     eat: String,
@@ -31,18 +38,18 @@ impl FromStr for NrasResponse {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let response: NrasResponseInternal = serde_json::from_str(s)?;
 
-        if response.jwt.len() != 2 {
+        if response.1.len() != 2 {
             bail!("Unexpected Payload Format");
         };
-        let jwt = response.jwt[1].clone();
+        let jwt = response.0[1].clone();
 
         // For now, there should only be one EAT.
-        if response.eat.len() != 1 {
+        if response.1.len() != 1 {
             bail!("Unexpected submod count.");
         };
 
         let eat = response
-            .eat
+            .1
             .values()
             .next()
             .ok_or_else(|| anyhow!("Could not find EAT"))?


### PR DESCRIPTION
This PR includes two commits
1. Define structure that aligns with Nvidia NRAS response
2. Simplify the nvidia verifier state by removing dead runtime code arms