### PR TITLE
fix(cca): add missing trust_claims object to default CCA OPA policy

### DIFF
--- a/deps/verifier/test_data/cca/conf/default.rego
+++ b/deps/verifier/test_data/cca/conf/default.rego
@@ -33,10 +33,25 @@ default runtime_opaque := 2
 # This is the default, unless the RIM claim matches one of the configured
 # reference values.
 default executables := 33
+
 # The value 3 stands for
 # "Only a recognized genuine set of approved executables have
 #  been loaded during the boot process."
 # the RIM (realm initial measurement) must match
 executables := 3 if {
 	input.cca.realm["cca-realm-initial-measurement"] in data.reference["cca.realm.cca-realm-initial-measurement"]
+}
+
+# For the `configuration` trust claim, the value 36 stands for
+# "Elements of the configuration relevant to security are unavailable to the Verifier."
+default configuration := 36
+
+# trust_claims MUST be defined as an object with kebab-case EAR claim names.
+# Missing this causes the AS to panic at token issuance time.
+trust_claims := {
+	"hardware": hardware,
+	"instance-identity": instance_identity,
+	"runtime-opaque": runtime_opaque,
+	"executables": executables,
+	"configuration": configuration,
 }


### PR DESCRIPTION
## Summary
The default CCA OPA policy (`deps/verifier/test_data/cca/conf/default.rego`) never assembles a `trust_claims` object. The attestation service queries `data.policy.trust_claims` in `attestation-service/src/ear_token/broker.rs` to build the EAR token - if that query returns undefined, the AS panics and every CCA attestation request fails.

The file already defines `hardware`, `instance_identity`, `runtime_opaque`, and `executables` individually, but never wraps them into `trust_claims`, and has no `configuration` claim at all.

## Changes
- Add `default configuration := 36` (EAR value for "unavailable to the Verifier")
- Add a `trust_claims` object assembling all five required claims with kebab-case EAR keys (`instance-identity`, not `instance_identity`) matches the pattern already used by `attestation-service/src/ear_token/ear_default_policy_cpu.rego`

## Testing
Verified by inspection against the working `ear_default_policy_cpu.rego` pattern and by running the real `opa fmt` over the change.

---

Thanks to @shefali-kamal for co-authoring and reviewing this work.