### PR TITLE
fix(docker-compose): make cert validity periods overridable, fix token cert's silent 30-day default

### DIFF
--- a/kbs/config/docker-compose/setup.sh
+++ b/kbs/config/docker-compose/setup.sh
@@ -4,6 +4,12 @@ set -euxo pipefail
 KEY_DIR="/opt/confidential-containers/kbs/user-keys"
 cd "${KEY_DIR}"
 
+# Token-signing cert validity in days; defaults to 90 instead of openssl's silent 30.
+TOKEN_CERT_DAYS="${TOKEN_CERT_DAYS:-90}"
+
+# Root CA cert validity in days; default unchanged at 10 years.
+CA_CERT_DAYS="${CA_CERT_DAYS:-3650}"
+
 if [ ! -s private.key ]; then
   openssl genpkey -algorithm ed25519 > private.key
   openssl pkey -in private.key -pubout -out public.pub
@@ -33,9 +39,9 @@ fi
 if [ ! -s token.key ]; then
   openssl genrsa -traditional -out ca.key 2048
   openssl req -new -key ca.key -out ca-req.csr -subj "/O=CNCF/OU=CoCo/CN=KBS-compose-root"
-  openssl req -x509 -days 3650 -key ca.key -in ca-req.csr -out ca-cert.pem
+  openssl req -x509 -days "${CA_CERT_DAYS}" -key ca.key -in ca-req.csr -out ca-cert.pem
   openssl ecparam -name prime256v1 -genkey -noout -out token.key
   openssl req -new -key token.key -out token-req.csr -subj "/O=CNCF/OU=CoCo/CN=CoCo-AS"
-  openssl x509 -req -in token-req.csr -CA ca-cert.pem -CAkey ca.key -CAcreateserial -out token-cert.pem -extensions req_ext
+  openssl x509 -req -days "${TOKEN_CERT_DAYS}" -in token-req.csr -CA ca-cert.pem -CAkey ca.key -CAcreateserial -out token-cert.pem -extensions req_ext
   cat token-cert.pem ca-cert.pem > token-cert-chain.pem
 fi

--- a/kbs/docs/cluster.md
+++ b/kbs/docs/cluster.md
@@ -36,6 +36,13 @@ The `setup` container initializes files under `kbs/config/docker-compose/` autom
   See [Attestation Token Verification](./attestation_token_verification.md#docker-compose-cluster)
   for how these files fit together.
 
+  By default `ca-cert.pem` is valid for 3650 days (10 years) and `token-cert.pem` for
+  90 days. Override either before `docker compose up` if you need different lifetimes:
+
+  ```bash
+  CA_CERT_DAYS=1825 TOKEN_CERT_DAYS=30 docker compose up -d
+  ```
+
 Use the generated admin token with `kbs-client`:
 
 ```bash


### PR DESCRIPTION
## Summary
`kbs/config/docker-compose/setup.sh` generates the token-signing certificate using `openssl x509 -req` without a `-days` argument. OpenSSL defaults to 30 days.

Symptom: ~30 days after initial deployment, all attestation requests return 401 ("JWK cannot be validated by trust anchor"). There is no warning in logs that the certificate has expired - the failure looks identical to a misconfiguration.

## Changes
- Add `TOKEN_CERT_DAYS="${TOKEN_CERT_DAYS:-90}"` and pass it via `-days` to the `openssl x509 -req` call that signs `token-cert.pem`. Defaulting to a fixed 90-day period avoids silently inheriting openssl's own default while still forcing rotation. The env var lets users who want longer-lived dev/test certs opt in explicitly.
- Converted the root CA cert's already-hardcoded `-days 3650` to a `CA_CERT_DAYS="${CA_CERT_DAYS:-3650}"` variable (default unchanged), so both cert lifetimes are controlled the same way instead of one being a magic number.

---

Thanks to @shefali-kamal for co-authoring and reviewing this work.