### PR TITLE
kbs: document verbose_token on AttestationTokenBroker

### DIFF
--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -184,7 +184,7 @@ When `type` is set to `coco_as_builtin`, the following properties can be set.
 | `build_name`     | String                 | The build name to be used as part of the Verifier ID in the EAR                | No       | Automatically generated from Cargo package and AS version             |
 | `profile_name`   | String                 | The Profile that describes the EAR token                                       | No       | tag:github.com,2024:confidential-containers/Trustee`                  |
 | `signer`         | [TokenSignerConfig][4] | Signing material of the attestation result token.                              | No       | None                                                                  |
-| `verbose_token`  | Boolean                | Include raw additional-device evidence in the EAR. Multi-GPU guests can produce tokens larger than actix-http's 128 KiB request-head limit (`message head is too large` on CDH `Authorization: Bearer` resource GETs). Set `false` to omit that evidence from the token; verification still runs. | No       | `true`                                                                |
+| `verbose_token`  | Boolean                | Include detailed information in the EAR, such as the raw additional-device evidence. Device evidence (for example a GPU) can produce tokens larger than actix-http's 128 KiB request-head limit (causing errors like `message head is too large` on CDH `Authorization: Bearer` resource GETs). Set `false` to omit that extra detail from the token; verification still runs. | No       | `true`                                                                |
 
 ##### TokenSignerConfig
 

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -184,6 +184,7 @@ When `type` is set to `coco_as_builtin`, the following properties can be set.
 | `build_name`     | String                 | The build name to be used as part of the Verifier ID in the EAR                | No       | Automatically generated from Cargo package and AS version             |
 | `profile_name`   | String                 | The Profile that describes the EAR token                                       | No       | tag:github.com,2024:confidential-containers/Trustee`                  |
 | `signer`         | [TokenSignerConfig][4] | Signing material of the attestation result token.                              | No       | None                                                                  |
+| `verbose_token`  | Boolean                | Include raw additional-device evidence in the EAR. Multi-GPU guests can produce tokens larger than actix-http's 128 KiB request-head limit (`message head is too large` on CDH `Authorization: Bearer` resource GETs). Set `false` to omit that evidence from the token; verification still runs. | No       | `true`                                                                |
 
 ##### TokenSignerConfig
 


### PR DESCRIPTION
## Summary

- Document `verbose_token` on the KBS `AttestationTokenBroker` table. The field already exists on `EarTokenConfiguration` (default `true`) but was only listed in the AS config docs.
- Operators hit `message head is too large` when CDH sends a verbose multi-device EAR as `Authorization: Bearer` (actix-http 128 KiB request-head cap).

Fixes #1563

## Test plan

- [ ] Confirm the table matches `EarTokenConfiguration` in `attestation-service/src/ear_token/mod.rs`
- [ ] No runtime change; docs only


Made with [Cursor](https://cursor.com)