### PR TITLE
as: reject policies that fail to compile in set_policy

### DIFF
--- a/deps/policy-engine/src/lib.rs
+++ b/deps/policy-engine/src/lib.rs
@@ -23,6 +23,11 @@ pub trait EngineTrait {
     fn policy_suffix() -> &'static str {
         ""
     }
+
+    // Check that a policy is well-formed, before it is accepted and stored.
+    fn check_policy_format(_policy: &str) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Clone)]
@@ -36,6 +41,7 @@ impl<T: Send + Sync + EngineTrait> PolicyEngine<T> {
     /// The policy is expected to be provided as string.
     /// Concrete policy engine backend may handle the policy in different ways.
     pub async fn set_policy(&self, policy_id: &str, policy: &str, overwrite: bool) -> Result<()> {
+        T::check_policy_format(policy)?;
         let params = SetParameters { overwrite };
         let policy_id = format!("{}{}", policy_id, T::policy_suffix());
         let _ = self

--- a/deps/policy-engine/src/policy/rego.rs
+++ b/deps/policy-engine/src/policy/rego.rs
@@ -28,6 +28,13 @@ impl EngineTrait for Regorus {
     fn policy_suffix() -> &'static str {
         ".rego"
     }
+    fn check_policy_format(policy: &str) -> Result<()> {
+        let mut engine = regorus::Engine::new();
+        engine
+            .add_policy("".to_string(), policy.to_string())
+            .map_err(PolicyError::LoadPolicyFailed)?;
+        Ok(())
+    }
 }
 
 impl Regorus {


### PR DESCRIPTION
Currently AttestationService::set_policy accepts any policy string without validation, storing it as-is. A syntactically invalid policy is only discovered later, at actual attestation time, with no clear signal that the policy itself was the problem.

This validates that a policy compiles (via the same Regorus engine AS uses internally) before it's stored, returning a clear compiler error immediately if it doesn't. This is the single entry point both gRPC (grpc-as) and RESTful (restful-as) SetPolicy handlers funnel through, so both are covered by this one change.

Note: this is a behavioral change to the SetPolicy/set_policy API - a request that previously succeeded with an invalid policy will now be rejected with an error. Valid policies are unaffected.

Manually verified against a running restful-as instance: a syntactically invalid policy is now rejected with 500 and a specific compiler error (previously would have returned 200), and a valid policy still succeeds with 200 as before.

This follows from discussion on #1526, where @fitzthum suggested validation belongs at the admin endpoint rather than in a client-side CLI tool.