### PR TITLE
deployment: Adds Helm chart support for offline VCEK certificate store, enabling SNP attestation without AMD KDS connectivity

### DIFF
--- a/.github/workflows/test-e2e-helm-nightly.yml
+++ b/.github/workflows/test-e2e-helm-nightly.yml
@@ -72,6 +72,9 @@ jobs:
       client-artifact: helm-e2e-kbs-client-tdx-linux-amd64
       self-hosted: true
 
+  # Exercises the offline VCEK certificate store, so the SNP runner must have the
+  # store staged at /opt/confidential-containers/attestation-service/kds-store as
+  # part of host setup. See deployment/helm-chart/scenarios/snp-e2e.yaml.
   helm-trustee-e2e-snp:
     name: Helm Trustee e2e (SNP)
     needs: build-docker-e2e-materials
@@ -83,3 +86,5 @@ jobs:
       runs-on: '{"group":"snp-vm"}'
       client-artifact: helm-e2e-kbs-client-snp-linux-amd64
       self-hosted: true
+      kind-config: deployment/helm-chart/e2e/snp/kind-config.yaml
+      scenario: scenarios/snp-e2e.yaml

--- a/.github/workflows/test-e2e-kbs-hw.yml
+++ b/.github/workflows/test-e2e-kbs-hw.yml
@@ -42,6 +42,9 @@ jobs:
       client-artifact: helm-e2e-kbs-client-tdx-linux-amd64
       self-hosted: true
 
+  # Exercises the offline VCEK certificate store; the SNP runner must have the
+  # store staged at /opt/confidential-containers/attestation-service/kds-store as
+  # part of host setup. See deployment/helm-chart/scenarios/snp-e2e.yaml.
   helm-trustee-e2e-snp:
     name: Helm Trustee e2e (SNP)
     needs: build-docker-e2e-materials
@@ -56,3 +59,5 @@ jobs:
       runs-on: '{"group":"snp-vm"}'
       client-artifact: helm-e2e-kbs-client-snp-linux-amd64
       self-hosted: true
+      kind-config: deployment/helm-chart/e2e/snp/kind-config.yaml
+      scenario: scenarios/snp-e2e.yaml

--- a/.github/workflows/workflow-call-helm-e2e.yml
+++ b/.github/workflows/workflow-call-helm-e2e.yml
@@ -29,6 +29,20 @@ on:
         type: boolean
         default: false
         description: When true, run pre/post cleanup to keep a persistent runner tidy.
+      kind-config:
+        type: string
+        default: ''
+        description: >-
+          Optional path (relative to repo root) to a kind cluster config file.
+          When non-empty, passed to the kind-action `config` parameter to
+          customize the kind cluster (e.g. extraMounts for host certificates).
+      scenario:
+        type: string
+        default: ''
+        description: >-
+          Optional path (relative to deployment/helm-chart/) to a Helm values
+          file passed as E2E_BASE_SCENARIO. When empty, the default
+          scenarios/e2e-local-images.yaml is used.
 
 permissions: {}
 
@@ -90,6 +104,7 @@ jobs:
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           cluster_name: ${{ env.KIND_CLUSTER }}
+          config: ${{ inputs.kind-config || '' }}
 
       - name: Load Trustee images into kind
         run: |
@@ -101,12 +116,18 @@ jobs:
       - name: Run Helm Trustee e2e
         env:
           EXPECTED_TEE: ${{ inputs.leg }}
+          HELM_E2E_SCENARIO: ${{ inputs.scenario }}
         run: |
+          MAKE_EXTRA_ARGS=()
+          if [ -n "${HELM_E2E_SCENARIO}" ]; then
+            MAKE_EXTRA_ARGS=("E2E_BASE_SCENARIO=${HELM_E2E_SCENARIO}")
+          fi
           make -C deployment/helm-chart e2e-test \
             E2E_IMAGE_PREFIX=ghcr.io/confidential-containers/staged-images \
             E2E_IMAGE_TAG=latest \
             KBS_CLIENT="${RUNNER_TEMP}/helm-e2e-kbs-client/kbs-client" \
-            EXPECTED_TEE="${EXPECTED_TEE}"
+            EXPECTED_TEE="${EXPECTED_TEE}" \
+            "${MAKE_EXTRA_ARGS[@]}"
 
       # Self-hosted cleanup so the runner is left in a known-good state.
       - name: Cleanup kind cluster

--- a/attestation-service/docs/amd-offline-certificate-cache.md
+++ b/attestation-service/docs/amd-offline-certificate-cache.md
@@ -6,9 +6,8 @@ without connection to the AMD KDS. This guide mainly targets air-gapped
 environments.
 
 > [!Note]
-> Currently this guide shows a method that builds on using
-> [docker](https://confidentialcontainers.org/docs/attestation/installation/docker/)
-> to manage kbs services. Additional deployment methods will be covered in future releases.
+> This guide covers both [Docker Compose](https://confidentialcontainers.org/docs/attestation/installation/docker/)
+> and [Helm](https://confidentialcontainers.org/docs/attestation/installation/helm/) deployments.
 
 ## Enabling Offline VCEK Store in Attestation Service
 
@@ -120,6 +119,41 @@ sudo snphost fetch vek der . "<vcek-url>"
 
 ### 3. Install `vcek` directory into trustee deployment
 
+#### Helm Deployment
+
+1. Stage the VCEK certificates on the Kubernetes node at:
+   ```
+   /opt/confidential-containers/attestation-service/kds-store/vcek/{hwid}/{tcb_prefix}_vcek.der  (preferred)
+   ```
+   or
+   ```
+   /opt/confidential-containers/attestation-service/kds-store/vcek/{hwid}/vcek.der  (fallback)
+   ```
+
+2. Install Trustee with offline VCEK store enabled:
+   ```bash
+   helm install trustee ./deployment/helm-chart \
+     --namespace coco-trustee --create-namespace \
+     --set as.verifier.snp.kdsStoreHostPath=/opt/confidential-containers/attestation-service/kds-store \
+     --set as.verifier.snp.nodeName=<node-name> \
+     --set 'as.verifier.snp.vcekSources[0].type=OfflineStore'
+   ```
+
+   Replace `<node-name>` with the Kubernetes node hostname where the VCEK
+   certificates are stored (use `kubectl get nodes` to find it).
+
+   `as.verifier.snp.vcekSources` defaults to `[]`, which omits the `snp_verifier`
+   block and lets the AS use its built-in default (KDS). An `OfflineStore` source
+   has to be requested explicitly. It requires `kdsStoreHostPath` and `nodeName`,
+   since those are what get the certificate store mounted into the AS Pod. To
+   keep AMD KDS as a fallback for certificates that are missing locally:
+   ```bash
+   --set 'as.verifier.snp.vcekSources[0].type=OfflineStore' \
+   --set 'as.verifier.snp.vcekSources[1].type=KDS'
+   ```
+
+#### Docker Compose Deployment
+
 - **Install in running trustee deployment**
 
 Use docker commands to copy your `vcek` folder into the configured directory:
@@ -217,10 +251,16 @@ VCEK stores must be updated/rebuilt in the following events:
 
 ## Troubleshooting
 
-Enable debug and check logs for `vcek` keyword. Ensure configured sources match
-expected values.
+Enable debug logging and check logs for `vcek` keyword.
 
+**Helm:**
+```bash
+helm upgrade trustee ./deployment/helm-chart -n coco-trustee --set log_level=debug
+kubectl logs -n coco-trustee deploy/trustee-as -c as | grep -i vcek
 ```
+
+**Docker Compose:**
+```bash
 echo "RUST_LOG=debug" > debug.env
 docker compose --env-file debug.env up -d
 docker logs trustee-as-1 | grep -i vcek

--- a/deployment/helm-chart/README.md
+++ b/deployment/helm-chart/README.md
@@ -218,6 +218,27 @@ helm upgrade --install trustee ./deployment/helm-chart \
 
 Use an **s390x** AS image built with the `se-verifier` feature (`as.image.repository` / `as.image.tag`). See **`scenarios/ibm-se.yaml`** for the full override. Set the SE attestation policy afterwards as documented in `deps/verifier/src/se/README.md`.
 
+### AMD SEV-SNP offline VCEK store
+
+The **SNP** verifier needs a **VCEK** certificate to validate an attestation report. By default it fetches one from **AMD KDS**, which requires outbound connectivity from the AS Pod. Air-gapped clusters can instead stage the certificates on the node and have the verifier read them locally.
+
+Set **`as.verifier.snp.kdsStoreHostPath`** to the directory on the node that holds the store, **`as.verifier.snp.nodeName`** to the name of that node, and add an **`OfflineStore`** entry to **`as.verifier.snp.vcekSources`**. The chart then creates a `local`-type PV + PVC and mounts the directory at `/opt/confidential-containers/attestation-service/kds-store` on the AS Pod. The three values are required together: rendering fails if the store is mounted without an `OfflineStore` source, or an `OfflineStore` source is configured without the mount, so a misconfiguration cannot silently fall back to KDS.
+
+```bash
+# 1. Place the certificates under a directory on the target SNP node, laid out as
+#    $KDS_STORE/vcek/{hwid}/{tcb_prefix}_vcek.der  (preferred)
+#    $KDS_STORE/vcek/{hwid}/vcek.der               (fallback)
+
+# 2. Install, pointing the chart at the node and directory:
+helm upgrade --install trustee ./deployment/helm-chart \
+  --namespace coco-trustee --create-namespace \
+  --set as.verifier.snp.kdsStoreHostPath=$KDS_STORE \
+  --set as.verifier.snp.nodeName=<your-snp-node-name> \
+  --set 'as.verifier.snp.vcekSources[0].type=OfflineStore'
+```
+
+Sources are tried in the order given, so appending `--set 'as.verifier.snp.vcekSources[1].type=KDS'` keeps AMD KDS as a fallback for certificates that are missing locally. See [the AMD offline certificate cache guide](../../attestation-service/docs/amd-offline-certificate-cache.md) for how to build the `vcek/` directory and when it has to be refreshed.
+
 ## Testing
 
 **Inspect resources**:
@@ -272,8 +293,6 @@ Default **`values.yaml`** is intentionally small. Fixed on-disk paths for **Loca
 |-----|------|---------|-------------|
 | as.affinity | object | `{}` | Affinity and anti-affinity scheduling rules for AS Pods. |
 | as.extraEnvVars | list | `[]` | Extra environment variables for the AS container (for example `HTTP(S)_PROXY` and `NO_PROXY`). |
-| as.verifier.se.credsDir | string | `""` | Absolute path on the target node to the directory containing IBM SE attestation materials (`rsa/`, `certs/`, `crls/`, `hkds/`, `hdr/hdr.bin`). When non-empty, the chart creates a `local`-type PersistentVolume + PersistentVolumeClaim and mounts the directory at `/run/confidential-containers/ibmse/` on the AS Pod. Requires `as.verifier.se.nodeName`. |
-| as.verifier.se.nodeName | string | `""` | Kubernetes node name where the IBM SE materials directory (`as.verifier.se.credsDir`) resides. Required when `as.verifier.se.credsDir` is set; used in the PersistentVolume `nodeAffinity`. |
 | as.image.pullPolicy | string | `"Always"` | AS container image pull policy. |
 | as.image.repository | string | `"ghcr.io/confidential-containers/staged-images/coco-as-grpc"` | AS container image repository. |
 | as.image.tag | string | `"latest"` | AS container image tag. |
@@ -291,6 +310,11 @@ Default **`values.yaml`** is intentionally small. Fixed on-disk paths for **Loca
 | as.verifier.dcap.tcb_update_type | string | `"early"` | DCAP TCB update type (for example `early`). |
 | as.verifier.nvidia.type | string | `"Local"` | NVIDIA verifier type: `Local` or `Remote`. When `Remote`, `verifierUrl` must be set. |
 | as.verifier.nvidia.verifierUrl | string | `"https://nras.attestation.nvidia.com/v4/attest"` | NRAS URL when `as.verifier.nvidia.type` is `Remote`. |
+| as.verifier.se.credsDir | string | `""` | Absolute path on the target node to the directory containing IBM SE attestation materials (`rsa/`, `certs/`, `crls/`, `hkds/`, `hdr/hdr.bin`). When non-empty, the chart creates a `local`-type PersistentVolume + PersistentVolumeClaim and mounts the directory at `/run/confidential-containers/ibmse/` on the AS Pod. Requires `as.verifier.se.nodeName`. |
+| as.verifier.se.nodeName | string | `""` | Kubernetes node name where the IBM SE materials directory (`as.verifier.se.credsDir`) resides. Required when `as.verifier.se.credsDir` is set; used in the PersistentVolume `nodeAffinity`. |
+| as.verifier.snp.kdsStoreHostPath | string | `""` | Absolute path on the target node to the directory containing the AMD SNP offline VCEK certificate store (must contain a `vcek/` subdirectory). When non-empty, the chart creates a `local`-type PV + PVC and mounts it at `/opt/confidential-containers/attestation-service/kds-store` on the AS Pod, which is where an `OfflineStore` entry in `as.verifier.snp.vcekSources` reads from. Requires `as.verifier.snp.nodeName`. See [the offline certificate cache guide](../../attestation-service/docs/amd-offline-certificate-cache.md) for the directory layout. |
+| as.verifier.snp.nodeName | string | `""` | Kubernetes node name where the kds-store directory (`as.verifier.snp.kdsStoreHostPath`) resides. Required when `as.verifier.snp.kdsStoreHostPath` is set; used in the PV `nodeAffinity`. |
+| as.verifier.snp.vcekSources | list | `[]` | VCEK certificate sources for the SNP verifier, tried in the order given. When empty (the default), no `snp_verifier` block is emitted and the AS uses its built-in default (KDS). `KDS` fetches from AMD's Key Distribution Service and requires outbound connectivity. To configure an `OfflineStore` source, `as.verifier.snp.nodeName` and `as.verifier.snp.kdsStoreHostPath` must be provided as well, so the certificate store gets mounted into the AS Pod. |
 | bootstrapUserKeysJob | object | `{"keygenImage":{"pullPolicy":"IfNotPresent","repository":"alpine/openssl","tag":"3.5.6"},"kubectlImage":{"pullPolicy":"IfNotPresent","repository":"quay.io/kata-containers/kubectl","tag":"20260112"},"resources":{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}}` | Bootstrap hook Job settings (pre-install/pre-upgrade key generation and post-delete cleanup when `secrets.useEphemeralGeneratedKeys=true`). |
 | bootstrapUserKeysJob.keygenImage.pullPolicy | string | `"IfNotPresent"` | OpenSSL `initContainer` image pull policy. |
 | bootstrapUserKeysJob.keygenImage.repository | string | `"alpine/openssl"` | OpenSSL `initContainer` image repository that generates demo keys. |

--- a/deployment/helm-chart/README.md.gotmpl
+++ b/deployment/helm-chart/README.md.gotmpl
@@ -190,7 +190,7 @@ backend connection.
 
 On **s390x**, the **IBM Secure Execution (SE)** verifier needs attestation materials at runtime. Because KBS talks to a **remote `coco_as_grpc` AS**, the verifier runs inside the **AS Pod**, so these materials must be mounted on **AS**, not KBS. (This differs from the builtin-AS kustomize overlay in `kbs/config/kubernetes/overlays/ibm-se`, which mounts them on KBS.)
 
-The verifier reads materials from fixed paths under **`/run/confidential-containers/ibmse/`** (overridable via `SE_*` env vars; see `deps/verifier/src/se/ibmse.rs` and `deps/verifier/src/se/README.md`). The chart mounts them from a **local node path** via a PersistentVolume / PersistentVolumeClaim — set **`as.verifier.se.credsDir`** to the directory on the node that contains the materials (equivalent to `IBM_SE_CREDS_DIR` used in the kustomize overlay), and **`as.verifier.se.nodeName`** to the name of that node.  The chart then creates a `local`-type PV + PVC and mounts the whole directory at `/run/confidential-containers/ibmse/` on the AS Pod.
+The verifier reads materials from fixed paths under **`/run/confidential-containers/ibmse/`** (overridable via `SE_*` env vars; see `deps/verifier/src/se/README.md`). The chart mounts them from a **local node path** via a PersistentVolume / PersistentVolumeClaim — set **`as.verifier.se.credsDir`** to the directory on the node that contains the materials (equivalent to `IBM_SE_CREDS_DIR` used in the kustomize overlay), and **`as.verifier.se.nodeName`** to the name of that node.  The chart then creates a `local`-type PV + PVC and mounts the whole directory at `/run/confidential-containers/ibmse/` on the AS Pod.
 
 | Material | Expected path under `credsDir` | Notes |
 |----------|-------------------------------|-------|

--- a/deployment/helm-chart/README.md.gotmpl
+++ b/deployment/helm-chart/README.md.gotmpl
@@ -218,6 +218,27 @@ helm upgrade --install trustee ./deployment/helm-chart \
 
 Use an **s390x** AS image built with the `se-verifier` feature (`as.image.repository` / `as.image.tag`). See **`scenarios/ibm-se.yaml`** for the full override. Set the SE attestation policy afterwards as documented in `deps/verifier/src/se/README.md`.
 
+### AMD SEV-SNP offline VCEK store
+
+The **SNP** verifier needs a **VCEK** certificate to validate an attestation report. By default it fetches one from **AMD KDS**, which requires outbound connectivity from the AS Pod. Air-gapped clusters can instead stage the certificates on the node and have the verifier read them locally.
+
+Set **`as.verifier.snp.kdsStoreHostPath`** to the directory on the node that holds the store, **`as.verifier.snp.nodeName`** to the name of that node, and add an **`OfflineStore`** entry to **`as.verifier.snp.vcekSources`**. The chart then creates a `local`-type PV + PVC and mounts the directory at `/opt/confidential-containers/attestation-service/kds-store` on the AS Pod. The three values are required together: rendering fails if the store is mounted without an `OfflineStore` source, or an `OfflineStore` source is configured without the mount, so a misconfiguration cannot silently fall back to KDS.
+
+```bash
+# 1. Place the certificates under a directory on the target SNP node, laid out as
+#    $KDS_STORE/vcek/{hwid}/{tcb_prefix}_vcek.der  (preferred)
+#    $KDS_STORE/vcek/{hwid}/vcek.der               (fallback)
+
+# 2. Install, pointing the chart at the node and directory:
+helm upgrade --install trustee ./deployment/helm-chart \
+  --namespace coco-trustee --create-namespace \
+  --set as.verifier.snp.kdsStoreHostPath=$KDS_STORE \
+  --set as.verifier.snp.nodeName=<your-snp-node-name> \
+  --set 'as.verifier.snp.vcekSources[0].type=OfflineStore'
+```
+
+Sources are tried in the order given, so appending `--set 'as.verifier.snp.vcekSources[1].type=KDS'` keeps AMD KDS as a fallback for certificates that are missing locally. See [the AMD offline certificate cache guide](../../attestation-service/docs/amd-offline-certificate-cache.md) for how to build the `vcek/` directory and when it has to be refreshed.
+
 ## Testing
 
 **Inspect resources**:

--- a/deployment/helm-chart/e2e/snp/kind-config.yaml
+++ b/deployment/helm-chart/e2e/snp/kind-config.yaml
@@ -1,0 +1,10 @@
+# Kind cluster config that mounts the host's VCEK certificate store into
+# the kind node for offline SNP attestation.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraMounts:
+      - hostPath: /opt/confidential-containers/attestation-service/kds-store
+        containerPath: /opt/confidential-containers/attestation-service/kds-store
+        readOnly: true

--- a/deployment/helm-chart/scenarios/snp-e2e.yaml
+++ b/deployment/helm-chart/scenarios/snp-e2e.yaml
@@ -1,0 +1,30 @@
+# Helm values for the SNP offline VCEK store e2e leg (PR and nightly CI).
+#
+# Runner prerequisite: the VCEK certificate store must already exist on the SNP
+# host at `kdsStoreHostPath` below, laid out as `vcek/{hwid}/{tcb_prefix}_vcek.der`
+# (see attestation-service/docs/amd-offline-certificate-cache.md). It is staged
+# out of band as part of host setup, not by this workflow; the kind cluster only
+# bind-mounts it via e2e/snp/kind-config.yaml. Certificates have to be refreshed
+# whenever the host firmware/TCB changes.
+
+# The SNP verifier reports why an individual VCEK source failed only at debug
+# level; on `info` a failed run just says no configured source worked.
+log_level: debug
+
+kbs:
+  tls:
+    enabled: true
+    secretName: trustee-e2e-kbs-tls
+
+as:
+  verifier:
+    snp:
+      kdsStoreHostPath: /opt/confidential-containers/attestation-service/kds-store
+      # kind names the node `<cluster>-control-plane`, and the cluster for this
+      # leg is `kind-snp`, hence `kind-snp-control-plane`.
+      nodeName: kind-snp-control-plane
+      # KDS is the primary source; the offline store backs it up so the leg still
+      # passes when AMD KDS is unreachable or rate limited.
+      vcekSources:
+        - type: KDS
+        - type: OfflineStore

--- a/deployment/helm-chart/templates/_helpers.tpl
+++ b/deployment/helm-chart/templates/_helpers.tpl
@@ -112,6 +112,12 @@ with `valkey.nameOverride: valkey` => `<release>-valkey-primary`).
 {{- define "coco-trustee.names.ibmse.pvc" -}}
 {{- printf "%s-ibmse-pvc" (include "coco-trustee.fullname" . | trunc 53 | trimSuffix "-") | trunc 63 | trimSuffix "-" -}}
 {{- end }}
+{{- define "coco-trustee.names.snp-kds-store.pv" -}}
+{{- printf "%s-snp-kds-pv" (include "coco-trustee.fullname" . | trunc 52 | trimSuffix "-") | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+{{- define "coco-trustee.names.snp-kds-store.pvc" -}}
+{{- printf "%s-snp-kds-pvc" (include "coco-trustee.fullname" . | trunc 51 | trimSuffix "-") | trunc 63 | trimSuffix "-" -}}
+{{- end }}
 
 {{/*
 Fixed workload ports (override only via undocumented values for advanced use).
@@ -143,6 +149,17 @@ AS verifier config JSON fragment
 {{- define "coco-trustee.as.verifier" -}}
 {{- $nv := dig "verifier" "nvidia" (dict) (default dict .Values.as) | default dict -}}
 {{- $dcap := dig "verifier" "dcap" (dict) (default dict .Values.as) | default dict -}}
+{{- $snp := dig "verifier" "snp" (dict) (default dict .Values.as) | default dict -}}
+{{- $snpKdsStorePath := $snp.kdsStoreHostPath | default "" -}}
+{{- $snpNodeName := $snp.nodeName | default "" -}}
+{{- $snpVcekSources := $snp.vcekSources | default list -}}
+{{- $snpHasOfflineStore := contains "\"type\":\"OfflineStore\"" ($snpVcekSources | toJson) -}}
+{{- if and $snpHasOfflineStore (not (and $snpKdsStorePath $snpNodeName)) -}}
+{{- fail "as.verifier.snp.kdsStoreHostPath and as.verifier.snp.nodeName must be set when as.verifier.snp.vcekSources contains an OfflineStore source" -}}
+{{- end -}}
+{{- if and $snpKdsStorePath (not $snpHasOfflineStore) -}}
+{{- fail "as.verifier.snp.vcekSources must contain an OfflineStore source when as.verifier.snp.kdsStoreHostPath is set, otherwise the mounted certificate store is never read" -}}
+{{- end -}}
 {{- if $nv -}}
 {{- if eq $nv.type "Remote" -}}
 {{- $_ := required "as.verifier.nvidia.verifierUrl must be set when as.verifier.nvidia.type is Remote" (trim (default "" $nv.verifierUrl)) -}}
@@ -164,6 +181,13 @@ AS verifier config JSON fragment
     {{- if $dcap.tcb_update_type }},
     "tcb_update_type": "{{ $dcap.tcb_update_type }}"
     {{- end }}
+}
+{{- end -}}
+{{- if and $snpVcekSources (or $nv $dcap) }},
+{{- end }}
+{{ if $snpVcekSources -}}
+"snp_verifier": {
+    "vcek_sources": {{ $snpVcekSources | toJson }}
 }
 {{- end -}}
 {{- end }}

--- a/deployment/helm-chart/templates/as-deployment.yaml
+++ b/deployment/helm-chart/templates/as-deployment.yaml
@@ -116,6 +116,11 @@ spec:
               mountPath: /opt/confidential-containers/kbs/user-keys
             - name: data
               mountPath: /opt/confidential-containers/attestation-service
+            {{- if ((.Values.as.verifier | default dict).snp | default dict).kdsStoreHostPath }}
+            - name: snp-kds-store
+              mountPath: /opt/confidential-containers/attestation-service/kds-store
+              readOnly: true
+            {{- end }}
             {{- if ((.Values.as.verifier | default dict).se | default dict).credsDir }}
             - name: ibmse
               mountPath: /run/confidential-containers/ibmse
@@ -137,6 +142,11 @@ spec:
             claimName: {{ $asClaim }}
         {{- else }}
           emptyDir: {}
+        {{- end }}
+        {{- if ((.Values.as.verifier | default dict).snp | default dict).kdsStoreHostPath }}
+        - name: snp-kds-store
+          persistentVolumeClaim:
+            claimName: {{ include "coco-trustee.names.snp-kds-store.pvc" . }}
         {{- end }}
         {{- if ((.Values.as.verifier | default dict).se | default dict).credsDir }}
         - name: ibmse

--- a/deployment/helm-chart/templates/snp-kds-store-pv.yaml
+++ b/deployment/helm-chart/templates/snp-kds-store-pv.yaml
@@ -1,0 +1,26 @@
+{{- $kdsStorePath := ((.Values.as.verifier | default dict).snp | default dict).kdsStoreHostPath | default "" -}}
+{{- if $kdsStorePath -}}
+{{- $nodeName := required "as.verifier.snp.nodeName is required when as.verifier.snp.kdsStoreHostPath is set" (((.Values.as.verifier | default dict).snp | default dict).nodeName | default "") -}}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "coco-trustee.names.snp-kds-store.pv" . }}
+  labels:
+    {{- include "coco-trustee.labels" . | nindent 4 }}
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-storage
+  local:
+    path: {{ $kdsStorePath }}
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - {{ $nodeName }}
+{{- end }}

--- a/deployment/helm-chart/templates/snp-kds-store-pvc.yaml
+++ b/deployment/helm-chart/templates/snp-kds-store-pvc.yaml
@@ -1,0 +1,18 @@
+{{- $kdsStorePath := ((.Values.as.verifier | default dict).snp | default dict).kdsStoreHostPath | default "" -}}
+{{- if $kdsStorePath -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "coco-trustee.names.snp-kds-store.pvc" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "coco-trustee.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-storage
+  resources:
+    requests:
+      storage: 1Gi
+  volumeName: {{ include "coco-trustee.names.snp-kds-store.pv" . }}
+{{- end }}

--- a/deployment/helm-chart/values.yaml
+++ b/deployment/helm-chart/values.yaml
@@ -227,11 +227,14 @@ as:
       # the chart creates a `local`-type PersistentVolume + PersistentVolumeClaim and mounts
       # the directory at `/run/confidential-containers/ibmse/` on the AS Pod.
       # -- Absolute path on the target node to the directory containing IBM SE attestation
-      # materials (`rsa/`, `certs/`, `crls/`, `hkds/`, `hdr/hdr.bin`). When non-empty,
-      # the chart creates a `local`-type PV + PVC. Requires `as.verifier.se.nodeName`.
+      # materials (`rsa/`, `certs/`, `crls/`, `hkds/`, `hdr/hdr.bin`). When non-empty, the
+      # chart creates a `local`-type PersistentVolume + PersistentVolumeClaim and mounts the
+      # directory at `/run/confidential-containers/ibmse/` on the AS Pod. Requires
+      # `as.verifier.se.nodeName`.
       credsDir: ""
       # -- Kubernetes node name where the IBM SE materials directory (`as.verifier.se.credsDir`)
-      # resides. Required when `as.verifier.se.credsDir` is set; used in the PV `nodeAffinity`.
+      # resides. Required when `as.verifier.se.credsDir` is set; used in the PersistentVolume
+      # `nodeAffinity`.
       nodeName: ""
   service:
     # -- AS Service type (`ClusterIP` or `LoadBalancer`).

--- a/deployment/helm-chart/values.yaml
+++ b/deployment/helm-chart/values.yaml
@@ -222,6 +222,26 @@ as:
       collateral_service: "https://api.trustedservices.intel.com/sgx/certification/v4/"
       # -- DCAP TCB update type (for example `early`).
       tcb_update_type: "early"
+    snp:
+      # -- Absolute path on the target node to the directory containing the AMD SNP
+      # offline VCEK certificate store (must contain a `vcek/` subdirectory). When
+      # non-empty, the chart creates a `local`-type PV + PVC and mounts it at
+      # `/opt/confidential-containers/attestation-service/kds-store` on the AS Pod,
+      # which is where an `OfflineStore` entry in `as.verifier.snp.vcekSources` reads
+      # from. Requires `as.verifier.snp.nodeName`. See
+      # [the offline certificate cache guide](../../attestation-service/docs/amd-offline-certificate-cache.md)
+      # for the directory layout.
+      kdsStoreHostPath: ""
+      # -- Kubernetes node name where the kds-store directory (`as.verifier.snp.kdsStoreHostPath`)
+      # resides. Required when `as.verifier.snp.kdsStoreHostPath` is set; used in the PV `nodeAffinity`.
+      nodeName: ""
+      # -- VCEK certificate sources for the SNP verifier, tried in the order given.
+      # When empty (the default), no `snp_verifier` block is emitted and the AS uses
+      # its built-in default (KDS). `KDS` fetches from AMD's Key Distribution Service
+      # and requires outbound connectivity. To configure an `OfflineStore` source,
+      # `as.verifier.snp.nodeName` and `as.verifier.snp.kdsStoreHostPath` must be
+      # provided as well, so the certificate store gets mounted into the AS Pod.
+      vcekSources: []
     se:
       # -- IBM Secure Execution (s390x) attestation materials. When `credsDir` is non-empty
       # the chart creates a `local`-type PersistentVolume + PersistentVolumeClaim and mounts


### PR DESCRIPTION
Includes changes to add Helm chart support for configuring an offline AMD VCEK certificate store, enabling SNP attestation in air-gapped environments without connectivity to AMD's KDS.

Changes

  - Helm chart: New as.verifier.snp values (kdsStoreHostPath, nodeName, vcekSources) with PV/PVC templates to mount host certificates into the AS pod
  - CI: Added SNP leg to nightly e2e workflow with kind-config for host path mounting
  - Docs: Added Helm instructions to amd-offline-certificate-cache.md

Testing :   Verified on SNP host - attestation successful using offline VCEK store.

Github Issue -  [#1512](https://github.com/confidential-containers/trustee/issues/1512)