### PR TITLE
fix(nvidia remote verifier): NRAS response length correction

### DIFF
--- a/deps/verifier/src/nvidia/nras_response.rs
+++ b/deps/verifier/src/nvidia/nras_response.rs
@@ -38,7 +38,7 @@ impl FromStr for NrasResponse {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let response: NrasResponseInternal = serde_json::from_str(s)?;
 
-        if response.1.len() != 2 {
+        if response.0.len() != 2 {
             bail!("Unexpected Payload Format");
         };
         let jwt = response.0[1].clone();


### PR DESCRIPTION
The _first_ field of NRAS response consists of two elements: string "JWT" and base64 of actual JWT. But due to the typo the code was checking the length of the _second_ field. Because of that all valid NRAS responses were failing with "Unexpected Payload Format" error. This PR fixes that, so NRAS responses are properly processed by nvidia verifier in remote mode.