### PR TITLE
ci: ignore linaro page

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -4,3 +4,4 @@ https://www.openpolicyagent.org
 https://confidentialcontainers.org/docs/attestation/installation/docker/
 https://www.ascii-code.com
 https://www.ibm.com/docs
+http://veraison.test.linaro.org


### PR DESCRIPTION
See error https://github.com/confidential-containers/trustee/actions/runs/32323758256/job/96290802539?pr=1569

message
```
  ### Errors in ./deps/verifier/test_data/cca/conf/README.md

  * [ERROR] <http://veraison.test.linaro.org/> (at 42:30) | SSL certificate expired. Site needs to renew certificate
```