### PR TITLE
verifier: snp: expose reported TCB FMC in TEE evidence

### DIFF
--- a/attestation-service/docs/tcb_claims.md
+++ b/attestation-service/docs/tcb_claims.md
@@ -255,6 +255,7 @@ not covered by TBS nor report_data_signature, thus not integrity-protected.
 - `snp.reported_tcb_microcode`: Reported microcode version
 - `snp.reported_tcb_snp`: Reported SVN of SNP Firmware
 - `snp.reported_tcb_tee`: Reported SVN of ASP OS
+- `snp.reported_tcb_fmc`: Reported SVN of FMC firmware (Turin and newer processors only, null for Milan/Genoa)
 
 The claims map only includes the reported TCB version.
 An SEV-SNP Attestation Report contains four sets of TCB version information.

--- a/deps/verifier/src/snp/mod.rs
+++ b/deps/verifier/src/snp/mod.rs
@@ -646,6 +646,7 @@ pub(crate) fn parse_tee_evidence(report: &AttestationReport) -> TeeEvidenceParse
         "reported_tcb_tee": report.reported_tcb.tee,
         "reported_tcb_snp": report.reported_tcb.snp,
         "reported_tcb_microcode": report.reported_tcb.microcode,
+        "reported_tcb_fmc": report.reported_tcb.fmc,
 
         // platform info
         "platform_tsme_enabled": report.plat_info.tsme_enabled(),


### PR DESCRIPTION
Turin and newer processors expose a new field in the reported TCB. Expose it in the parsed TEE evidence so that policies can use it.