### PR TITLE
rvps: add ListReferenceValues RPC and rvps-tool list command

### DIFF
--- a/attestation-service/src/bin/grpc/mod.rs
+++ b/attestation-service/src/bin/grpc/mod.rs
@@ -35,8 +35,8 @@ use crate::rvps_api::{
     reference_value_provider_service_server::{
         ReferenceValueProviderService, ReferenceValueProviderServiceServer,
     },
-    ReferenceValueQueryRequest, ReferenceValueQueryResponse, ReferenceValueRegisterRequest,
-    ReferenceValueRegisterResponse,
+    ReferenceValueListRequest, ReferenceValueListResponse, ReferenceValueQueryRequest,
+    ReferenceValueQueryResponse, ReferenceValueRegisterRequest, ReferenceValueRegisterResponse,
 };
 
 fn to_kbs_tee(tee: &str) -> anyhow::Result<Tee> {
@@ -329,6 +329,27 @@ impl ReferenceValueProviderService for Arc<RwLock<AttestationServer>> {
         info!("RegisterReferenceValue succeeded.");
         let res = ReferenceValueRegisterResponse {};
         Ok(Response::new(res))
+    }
+
+    #[instrument(skip_all, fields(request_id = tracing::field::Empty))]
+    async fn list_reference_values(
+        &self,
+        _request: Request<ReferenceValueListRequest>,
+    ) -> Result<Response<ReferenceValueListResponse>, Status> {
+        let request_id = Uuid::new_v4().to_string();
+        Span::current().record("request_id", tracing::field::display(&request_id));
+        info!("ListReferenceValues API called.");
+        let reference_value_ids = self
+            .read()
+            .await
+            .attestation_service
+            .list_reference_values()
+            .await
+            .map_err(|e| Status::aborted(format!("List reference values: {e}")))?;
+        info!("ListReferenceValues succeeded.");
+        Ok(Response::new(ReferenceValueListResponse {
+            reference_value_ids,
+        }))
     }
 }
 

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -299,6 +299,16 @@ impl AttestationService {
             .context("query reference values")
     }
 
+    /// List all registered reference value IDs
+    pub async fn list_reference_values(&self) -> Result<Vec<String>> {
+        self.rvps
+            .lock()
+            .await
+            .list_reference_values()
+            .await
+            .context("list reference values")
+    }
+
     pub async fn generate_supplemental_challenge(
         &self,
         tee: Tee,

--- a/attestation-service/src/rvps/builtin.rs
+++ b/attestation-service/src/rvps/builtin.rs
@@ -43,4 +43,9 @@ impl RvpsApi for BuiltinRvps {
 
         Ok(reference_value)
     }
+
+    async fn list_reference_values(&self) -> Result<Vec<String>> {
+        let ids = self.rvps.list_reference_values().await?;
+        Ok(ids)
+    }
 }

--- a/attestation-service/src/rvps/grpc.rs
+++ b/attestation-service/src/rvps/grpc.rs
@@ -8,7 +8,7 @@ use tracing::{debug, info};
 
 use self::rvps_api::{
     reference_value_provider_service_client::ReferenceValueProviderServiceClient,
-    ReferenceValueQueryRequest, ReferenceValueRegisterRequest,
+    ReferenceValueListRequest, ReferenceValueQueryRequest, ReferenceValueRegisterRequest,
 };
 
 use super::{Result, RvpsApi};
@@ -114,6 +114,17 @@ impl RvpsApi for Agent {
             }
             None => Ok(None),
         }
+    }
+
+    async fn list_reference_values(&self) -> Result<Vec<String>> {
+        let req = tonic::Request::new(ReferenceValueListRequest {});
+        let mut client = self.pool.get().await?;
+        let ids = client
+            .list_reference_values(req)
+            .await?
+            .into_inner()
+            .reference_value_ids;
+        Ok(ids)
     }
 }
 

--- a/attestation-service/src/rvps/mod.rs
+++ b/attestation-service/src/rvps/mod.rs
@@ -53,6 +53,9 @@ pub trait RvpsApi {
 
     /// Get the reference value by the given id.
     async fn query_reference_value(&self, reference_value_id: &str) -> Result<Option<Value>>;
+
+    /// List all registered reference value IDs.
+    async fn list_reference_values(&self) -> Result<Vec<String>>;
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq)]

--- a/protos/reference.proto
+++ b/protos/reference.proto
@@ -16,7 +16,14 @@ message ReferenceValueRegisterRequest {
 
 message ReferenceValueRegisterResponse {}
 
+message ReferenceValueListRequest {}
+
+message ReferenceValueListResponse {
+    repeated string reference_value_ids = 1;
+}
+
 service ReferenceValueProviderService {
     rpc QueryReferenceValue(ReferenceValueQueryRequest) returns (ReferenceValueQueryResponse) {};
     rpc RegisterReferenceValue(ReferenceValueRegisterRequest) returns (ReferenceValueRegisterResponse) {};
+    rpc ListReferenceValues(ReferenceValueListRequest) returns (ReferenceValueListResponse) {};
 }

--- a/rvps/src/bin/rvps-tool.rs
+++ b/rvps/src/bin/rvps-tool.rs
@@ -31,6 +31,16 @@ async fn query(addr: String, reference_value_id: String) -> Result<()> {
     Ok(())
 }
 
+async fn list(addr: String) -> Result<()> {
+    let ids = client::list(addr).await?;
+    if ids.is_empty() {
+        info!("No reference values registered.");
+    } else {
+        info!("Registered reference value IDs:\n{}", ids.join("\n"));
+    }
+    Ok(())
+}
+
 /// RVPS command-line arguments.
 #[derive(Parser)]
 #[command(name = "rvps-tool")]
@@ -42,6 +52,9 @@ enum Cli {
 
     /// Query reference values
     Query(QueryArgs),
+
+    /// List of all registered reference values
+    List(ListArgs),
 }
 
 #[derive(Args)]
@@ -68,6 +81,14 @@ struct QueryArgs {
     reference_value_id: String,
 }
 
+#[derive(Args)]
+#[command(author, version, about, long_about = None)]
+struct ListArgs {
+    /// The address of target RVPS
+    #[arg(short, long, default_value = DEFAULT_ADDR)]
+    addr: String,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let env_filter = match std::env::var_os("RUST_LOG") {
@@ -90,5 +111,6 @@ async fn main() -> Result<()> {
     match cli {
         Cli::Register(para) => register(&para.addr, &para.path).await,
         Cli::Query(para) => query(para.addr, para.reference_value_id).await,
+        Cli::List(para) => list(para.addr).await,
     }
 }

--- a/rvps/src/client/mod.rs
+++ b/rvps/src/client/mod.rs
@@ -8,7 +8,7 @@ use anyhow::*;
 
 use crate::rvps_api::reference::{
     reference_value_provider_service_client::ReferenceValueProviderServiceClient,
-    ReferenceValueQueryRequest, ReferenceValueRegisterRequest,
+    ReferenceValueListRequest, ReferenceValueQueryRequest, ReferenceValueRegisterRequest,
 };
 
 pub async fn register(address: String, message: String) -> Result<()> {
@@ -31,4 +31,15 @@ pub async fn query(address: String, reference_value_id: String) -> Result<Option
         .reference_value_results;
 
     Ok(rvs)
+}
+
+pub async fn list(address: String) -> Result<Vec<String>> {
+    let mut client = ReferenceValueProviderServiceClient::connect(address).await?;
+    let req = tonic::Request::new(ReferenceValueListRequest {});
+    let ids = client
+        .list_reference_values(req)
+        .await?
+        .into_inner()
+        .reference_value_ids;
+    Ok(ids)
 }

--- a/rvps/src/lib.rs
+++ b/rvps/src/lib.rs
@@ -120,4 +120,8 @@ impl Rvps {
 
         Ok(Some(reference_value.value()))
     }
+
+    pub async fn list_reference_values(&self) -> Result<Vec<String>> {
+        Ok(self.storage.list().await?)
+    }
 }

--- a/rvps/src/rvps_api/reference.rs
+++ b/rvps/src/rvps_api/reference.rs
@@ -16,6 +16,13 @@ pub struct ReferenceValueRegisterRequest {
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ReferenceValueRegisterResponse {}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ReferenceValueListRequest {}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ReferenceValueListResponse {
+    #[prost(string, repeated, tag = "1")]
+    pub reference_value_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
 /// Generated client implementations.
 pub mod reference_value_provider_service_client {
     #![allow(
@@ -146,6 +153,25 @@ pub mod reference_value_provider_service_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn list_reference_values(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ReferenceValueListRequest>,
+        ) -> std::result::Result<tonic::Response<super::ReferenceValueListResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/reference.ReferenceValueProviderService/ListReferenceValues",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "reference.ReferenceValueProviderService",
+                "ListReferenceValues",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -174,6 +200,10 @@ pub mod reference_value_provider_service_server {
             tonic::Response<super::ReferenceValueRegisterResponse>,
             tonic::Status,
         >;
+        async fn list_reference_values(
+            &self,
+            request: tonic::Request<super::ReferenceValueListRequest>,
+        ) -> std::result::Result<tonic::Response<super::ReferenceValueListResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ReferenceValueProviderServiceServer<T> {
@@ -323,6 +353,51 @@ pub mod reference_value_provider_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = RegisterReferenceValueSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/reference.ReferenceValueProviderService/ListReferenceValues" => {
+                    #[allow(non_camel_case_types)]
+                    struct ListReferenceValuesSvc<T: ReferenceValueProviderService>(pub Arc<T>);
+                    impl<T: ReferenceValueProviderService>
+                        tonic::server::UnaryService<super::ReferenceValueListRequest>
+                        for ListReferenceValuesSvc<T>
+                    {
+                        type Response = super::ReferenceValueListResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ReferenceValueListRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ReferenceValueProviderService>::list_reference_values(
+                                    &inner, request,
+                                )
+                                .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = ListReferenceValuesSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/rvps/src/server/mod.rs
+++ b/rvps/src/server/mod.rs
@@ -13,8 +13,8 @@ use crate::rvps_api::reference::reference_value_provider_service_server::{
     ReferenceValueProviderService, ReferenceValueProviderServiceServer,
 };
 use crate::rvps_api::reference::{
-    ReferenceValueQueryRequest, ReferenceValueQueryResponse, ReferenceValueRegisterRequest,
-    ReferenceValueRegisterResponse,
+    ReferenceValueListRequest, ReferenceValueListResponse, ReferenceValueQueryRequest,
+    ReferenceValueQueryResponse, ReferenceValueRegisterRequest, ReferenceValueRegisterResponse,
 };
 
 pub struct RvpsServer {
@@ -73,6 +73,22 @@ impl ReferenceValueProviderService for RvpsServer {
 
         let res = ReferenceValueRegisterResponse {};
         Ok(Response::new(res))
+    }
+
+    async fn list_reference_values(
+        &self,
+        _request: Request<ReferenceValueListRequest>,
+    ) -> Result<Response<ReferenceValueListResponse>, Status> {
+        let reference_value_ids = self
+            .rvps
+            .read()
+            .await
+            .list_reference_values()
+            .await
+            .map_err(|e| Status::aborted(format!("List reference values: {e}")))?;
+        Ok(Response::new(ReferenceValueListResponse {
+            reference_value_ids,
+        }))
     }
 }
 


### PR DESCRIPTION
- RVPS previously only supported registering a provenance and querying a single reference value by ID; there was no way to see what's currently registered without already knowing the exact IDs.

- Adds a new ListReferenceValues gRPC RPC, backed by the existing KeyValueStorage::list() the storage backen already provides (the same mechanism policy-engine's list_policies uses), and wires it through to a new 'rvps-tool list' subcommand.

- rvps/src/rvps_api/reference.rs is regenerated from protos/reference.proto via the rebuild-grpc-protos feature; the checked-in file still builds correctly without that feature enabled for normal contributors.

- Manually verified end-to-end: started a real rvps instance, registered two reference values via rvps-tool register, then confirmed rvps-tool list correctly returns both registered IDs.