### PR TITLE
verifier: add hardware_type claim to parsed evidence

### DIFF
--- a/attestation-service/src/ear_token/broker.rs
+++ b/attestation-service/src/ear_token/broker.rs
@@ -436,10 +436,13 @@ fn generate_ec_keys() -> Result<(EcKey<Private>, Vec<u8>, Vec<u8>)> {
 ///    This means that the full init_data and report_data will be
 ///    available in the token.
 ///
-/// 2) Move all claims from input_claims except the ones mentioned
-///    in the previous step into their own Object under the tee name.
+/// 2) If the verifier produced a `hardware_type` claim, hoist it to the
+///    annotated-evidence top level alongside init_data and report_data.
 ///
-/// 3) Convert the claims from serde_json Values to RawValues from the
+/// 3) Move all claims from input_claims except the ones mentioned
+///    in the previous steps into their own Object under the tee name.
+///
+/// 4) Convert the claims from serde_json Values to RawValues from the
 ///    EAR crate.
 ///
 pub fn transform_claims(
@@ -489,6 +492,18 @@ pub fn transform_claims(
                 serde_json::from_str(&serde_json::to_string(&runtime_data_claims)?)?;
 
             output_claims.insert("runtime_data_claims".to_string(), transformed_claims);
+        }
+
+        if let Some(hardware_type) = claims_map.remove("hardware_type") {
+            output_claims.insert(
+                "hardware_type".to_string(),
+                RawValue::String(
+                    hardware_type
+                        .as_str()
+                        .context("hardware_type claim must be a string")?
+                        .to_string(),
+                ),
+            );
         }
     }
 
@@ -691,7 +706,8 @@ mod tests {
                 }
             },
             "report_data": "7c71fe2c86eff65a7cf8dbc22b3275689fd0464a267baced1bf94fc1324656aeb755da3d44d098c0c87382f3a5f85b45c8a28fee1d3bdb38342bf96671501429",
-            "init_data": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            "init_data": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "hardware_type": "intel-tdx"
         });
 
         let init_data_claims = Value::String("".to_string());
@@ -736,6 +752,7 @@ mod tests {
             },
             "report_data": "7c71fe2c86eff65a7cf8dbc22b3275689fd0464a267baced1bf94fc1324656aeb755da3d44d098c0c87382f3a5f85b45c8a28fee1d3bdb38342bf96671501429",
             "init_data": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "hardware_type": "intel-tdx",
             "runtime_data_claims": "",
             "init_data_claims": ""
         });

--- a/deps/verifier/src/az_snp_vtpm/mod.rs
+++ b/deps/verifier/src/az_snp_vtpm/mod.rs
@@ -362,6 +362,8 @@ pub(crate) fn parse_tee_evidence_az(report: &AttestationReport) -> TeeEvidencePa
         "measurement": format!("{}", STANDARD.encode(report.measurement)),
         "report_data": format!("{}", STANDARD.encode(report.report_data)),
         "init_data": format!("{}", STANDARD.encode(report.host_data)),
+
+        "hardware_type": crate::hardware_type::types::AZURE_SNP_VTPM,
     });
 
     claims_map as TeeEvidenceParsedClaim

--- a/deps/verifier/src/az_tdx_vtpm/mod.rs
+++ b/deps/verifier/src/az_tdx_vtpm/mod.rs
@@ -100,6 +100,7 @@ impl Verifier for AzTdxVtpm {
         let mut claim = generate_parsed_claim(&td_quote, None, &platform_info)?;
         extend_claim(&mut claim, &tpm_quote)?;
         extend_using_custom_claims(&mut claim, custom_claims)?;
+        crate::hardware_type::insert(&mut claim, crate::hardware_type::types::AZURE_TDX_VTPM);
 
         Ok(vec![(claim, "cpu".to_string())])
     }

--- a/deps/verifier/src/cca/mod.rs
+++ b/deps/verifier/src/cca/mod.rs
@@ -229,7 +229,8 @@ fn b642hex(b64: &String) -> Result<String> {
 }
 
 fn cca_generate_parsed_claim(tcb: EvidenceClaimsSet) -> Result<TeeEvidenceParsedClaim> {
-    let v = serde_json::to_value(tcb).context("serializing CCA evidence claims into JSON")?;
+    let mut v = serde_json::to_value(tcb).context("serializing CCA evidence claims into JSON")?;
+    crate::hardware_type::insert(&mut v, crate::hardware_type::types::ARM_CCA);
     Ok(v as TeeEvidenceParsedClaim)
 }
 

--- a/deps/verifier/src/csv/mod.rs
+++ b/deps/verifier/src/csv/mod.rs
@@ -177,6 +177,7 @@ impl Verifier for CsvVerifier {
                     "sig_algo": hex::encode(report.tee_info().sig_algo().to_le_bytes()),
                     "anonce": hex::encode(anonce.to_le_bytes()),
                     "serial_number": String::from_utf8(serial_number)?.trim_end_matches('\0'),
+                    "hardware_type": crate::hardware_type::types::HYGON_CSV,
                 });
                 Ok(vec![(claims, "cpu".to_string())])
             }
@@ -216,6 +217,7 @@ impl Verifier for CsvVerifier {
                     "rtmr4": hex::encode(attestation_report_v2.tee_info.rtmr4),
                     "reserved1": hex::encode(attestation_report_v2.tee_info.reserved1),
                     "serial_number": String::from_utf8(serial_number)?.trim_end_matches('\0'),
+                    "hardware_type": crate::hardware_type::types::HYGON_CSV,
                 });
                 if let Some(el) = cc_eventlog {
                     let ccel_data = base64::engine::general_purpose::STANDARD.decode(el)?;

--- a/deps/verifier/src/hardware_type.rs
+++ b/deps/verifier/src/hardware_type.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 by Alibaba.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Normalized `hardware_type` claim for verifier parsed evidence.
+//!
+//! Prefer `"hardware_type": types::...` in local `json!` builders.
+//! Use [`insert`] when claims come from serde or other helpers.
+
+use serde_json::Value;
+
+/// Claim key for the normalized hardware platform identifier.
+pub const CLAIM: &str = "hardware_type";
+
+pub mod types {
+    pub const INTEL_SGX: &str = "intel-sgx";
+    pub const INTEL_TDX: &str = "intel-tdx";
+    pub const AMD_SNP: &str = "amd-snp";
+    pub const AZURE_SNP_VTPM: &str = "azure-snp-vtpm";
+    pub const AZURE_TDX_VTPM: &str = "azure-tdx-vtpm";
+    pub const ARM_CCA: &str = "arm-cca";
+    pub const HYGON_CSV: &str = "hygon-csv";
+    pub const HYGON_DCU: &str = "hygon-dcu";
+    pub const IBM_SE: &str = "ibm-se";
+    pub const TPM: &str = "tpm";
+    pub const NVIDIA_HOPPER: &str = "nvidia-hopper";
+    pub const NVIDIA_BLACKWELL: &str = "nvidia-blackwell";
+    pub const NVIDIA_LS10: &str = "nvidia-ls10";
+    pub const NVIDIA_PPCIE: &str = "nvidia-ppcie";
+    pub const NVIDIA_DPU: &str = "nvidia-dpu";
+    pub const SAMPLE: &str = "sample";
+    pub const SAMPLE_DEVICE: &str = "sample-device";
+}
+
+/// Insert `hardware_type` into claims assembled outside a local `json!` builder.
+pub fn insert(claims: &mut Value, hardware_type: &str) {
+    if let Some(obj) = claims.as_object_mut() {
+        obj.insert(
+            CLAIM.to_string(),
+            Value::String(hardware_type.to_string()),
+        );
+    }
+}

--- a/deps/verifier/src/hygon_dcu/mod.rs
+++ b/deps/verifier/src/hygon_dcu/mod.rs
@@ -68,6 +68,7 @@ impl Verifier for HygonDcuVerifier {
                         "sig_algo": format!("{:x}", report.body.sig_algo),
                     },
                     "report_data": hex::encode(report.body.user_data),
+                    "hardware_type": crate::hardware_type::types::HYGON_DCU,
                 });
                 (value, HYGON_DCU_TEE_CLASS.to_string())
             })

--- a/deps/verifier/src/lib.rs
+++ b/deps/verifier/src/lib.rs
@@ -8,6 +8,8 @@ use key_value_storage::StorageProvider;
 use serde::Deserialize;
 use tracing::debug;
 
+pub mod hardware_type;
+
 pub mod sample;
 pub mod sample_device;
 

--- a/deps/verifier/src/nvidia/mod.rs
+++ b/deps/verifier/src/nvidia/mod.rs
@@ -98,6 +98,16 @@ enum Architecture {
     LS10,
 }
 
+impl Architecture {
+    fn hardware_type(&self) -> &'static str {
+        match self {
+            Architecture::Hopper => crate::hardware_type::types::NVIDIA_HOPPER,
+            Architecture::Blackwell => crate::hardware_type::types::NVIDIA_BLACKWELL,
+            Architecture::LS10 => crate::hardware_type::types::NVIDIA_LS10,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 struct NvDeviceReportAndCert {
     arch: Architecture,
@@ -216,7 +226,11 @@ fn validate_ppcie(
         bail!("Topology must contain 4 switches");
     }
 
-    let claims = json!({"switch_count":4, "gpu_count":8 });
+    let claims = json!({
+        "switch_count": 4,
+        "gpu_count": 8,
+        "hardware_type": crate::hardware_type::types::NVIDIA_PPCIE,
+    });
 
     Ok(claims)
 }
@@ -299,7 +313,7 @@ impl Nvidia {
         let response = NrasResponse::from_str(&res.text().await?)?;
         response.validate(jwks)?;
 
-        let claims = response.claims()?;
+        let mut claims = response.claims()?;
 
         // Check that the nonce matches the expected report data.
         // Consider moving this logic into the NrasResponse struct.
@@ -314,6 +328,8 @@ impl Nvidia {
         if !nonce_ok {
             bail!("Report Data Mismatch");
         }
+
+        crate::hardware_type::insert(&mut claims, device.arch.hardware_type());
 
         Ok((claims, tee_class.to_string()))
     }
@@ -352,8 +368,9 @@ impl Nvidia {
         // Build the device claims
         let device_claims =
             NvDeviceReportAndCertClaim::new(&device.arch, device.uuid.as_str(), &report);
-        let value = serde_json::to_value(device_claims)
+        let mut value = serde_json::to_value(device_claims)
             .context("serializing NVIDIA evidence claims into JSON")?;
+        crate::hardware_type::insert(&mut value, device.arch.hardware_type());
 
         Ok((value as TeeEvidenceParsedClaim, "gpu".to_string()))
     }

--- a/deps/verifier/src/nvidia_dpu/mod.rs
+++ b/deps/verifier/src/nvidia_dpu/mod.rs
@@ -152,6 +152,7 @@ impl crate::Verifier for NvidiaDpuVerifier {
         if let ReportData::Value(expected) = expected_report_data {
             claims["session_nonce"] = serde_json::Value::String(hex::encode(expected));
         }
+        crate::hardware_type::insert(&mut claims, crate::hardware_type::types::NVIDIA_DPU);
 
         info!("NVIDIA DPU verifier: evidence verified successfully");
         Ok(vec![(claims, TEE_CLASS_NVIDIA_DPU.to_string())])

--- a/deps/verifier/src/sample/mod.rs
+++ b/deps/verifier/src/sample/mod.rs
@@ -93,6 +93,7 @@ fn parse_tee_evidence(quote: &SampleTeeEvidence) -> Result<TeeEvidenceParsedClai
         // The sample platform is in a sense only for debugging.
         // This claim will always be set to false and is only for testing.
         "debug": false,
+        "hardware_type": crate::hardware_type::types::SAMPLE,
     });
 
     Ok(claims_map as TeeEvidenceParsedClaim)

--- a/deps/verifier/src/sample_device/mod.rs
+++ b/deps/verifier/src/sample_device/mod.rs
@@ -70,6 +70,7 @@ fn parse_tee_evidence(quote: &SampleDeviceEvidence) -> Result<TeeEvidenceParsedC
     let claims_map = json!({
         "svn": quote.svn,
         "report_data": quote.report_data,
+        "hardware_type": crate::hardware_type::types::SAMPLE_DEVICE,
     });
 
     Ok(claims_map as TeeEvidenceParsedClaim)

--- a/deps/verifier/src/se/mod.rs
+++ b/deps/verifier/src/se/mod.rs
@@ -33,7 +33,8 @@ impl Verifier for SeVerifier {
         if let InitDataHash::Value(_) = expected_init_data_hash {
             warn!("IBM SE verifier does not support verify init data hash, will ignore the input `init_data_hash`.");
         }
-        let claims = se_verifier.evaluate(evidence, expected_report_data)?;
+        let mut claims = se_verifier.evaluate(evidence, expected_report_data)?;
+        crate::hardware_type::insert(&mut claims, crate::hardware_type::types::IBM_SE);
         Ok(vec![(claims, "cpu".to_string())])
     }
 

--- a/deps/verifier/src/sgx/mod.rs
+++ b/deps/verifier/src/sgx/mod.rs
@@ -118,6 +118,7 @@ async fn verify_evidence(
 
     let mut claim = claims::generate_parsed_claims(&quote, &platform_info)?;
     extend_using_custom_claims(&mut claim, custom_claims)?;
+    crate::hardware_type::insert(&mut claim, crate::hardware_type::types::INTEL_SGX);
 
     Ok(claim)
 }

--- a/deps/verifier/src/snp/mod.rs
+++ b/deps/verifier/src/snp/mod.rs
@@ -658,6 +658,8 @@ pub(crate) fn parse_tee_evidence(report: &AttestationReport) -> TeeEvidenceParse
 
         // platform identity
         "chip_id": hex::encode(report.chip_id),
+
+        "hardware_type": crate::hardware_type::types::AMD_SNP,
     });
 
     claims_map as TeeEvidenceParsedClaim

--- a/deps/verifier/src/tdx/mod.rs
+++ b/deps/verifier/src/tdx/mod.rs
@@ -165,6 +165,7 @@ async fn verify_evidence(
     // Return Evidence parsed claim
     let mut claim = generate_parsed_claim(&quote, ccel_option, &platform_info)?;
     extend_using_custom_claims(&mut claim, custom_claims)?;
+    crate::hardware_type::insert(&mut claim, crate::hardware_type::types::INTEL_TDX);
 
     Ok(claim)
 }

--- a/deps/verifier/src/tpm/mod.rs
+++ b/deps/verifier/src/tpm/mod.rs
@@ -242,6 +242,7 @@ pub fn parse_tee_evidence(quote: &VtpmQuote, ak_public: &str) -> TeeEvidencePars
         "init_data": hex::encode(pcrs[INITDATA_PCR]),
         "report_data": hex::encode(quote.nonce().unwrap_or_default()),
         "ak_public": ak_public,
+        "hardware_type": crate::hardware_type::types::TPM,
     });
     claims_map as TeeEvidenceParsedClaim
 }


### PR DESCRIPTION
Add a normalized hardware_type claim in each verifier so policy engines can identify the attested platform without inferring it from Tee enum values or EAR submodule labels. Hoist the claim to annotated-evidence top level in the AS EAR broker alongside init_data and report_data.