### PR TITLE
kbs: add resource listing to the resource plugin

### DIFF
--- a/kbs/src/plugins/implementations/resource/backend.rs
+++ b/kbs/src/plugins/implementations/resource/backend.rs
@@ -39,6 +39,11 @@ pub trait StorageBackend: Send + Sync {
 
     /// Delete secret resource from repository
     async fn delete_secret_resource(&self, resource_desc: ResourceDesc) -> Result<()>;
+
+    /// List all resource paths ("repository/type/tag") stored in this backend, across every repository.
+    async fn list_secret_resources(&self) -> Result<Vec<String>> {
+        bail!("list_secret_resources is not supported for this backend")
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -185,6 +190,10 @@ impl ResourceStorage {
             .with_label_values(&[&format!("{}", resource_desc)])
             .inc();
         self.backend.read_secret_resource(resource_desc).await
+    }
+
+    pub(crate) async fn list_secret_resources(&self) -> Result<Vec<String>> {
+        self.backend.list_secret_resources().await
     }
 }
 

--- a/kbs/src/plugins/implementations/resource/kv_storage.rs
+++ b/kbs/src/plugins/implementations/resource/kv_storage.rs
@@ -51,6 +51,9 @@ impl StorageBackend for KvStorage {
 
         Ok(())
     }
+    async fn list_secret_resources(&self) -> Result<Vec<String>> {
+        Ok(self.storage.list().await?)
+    }
 }
 
 impl KvStorage {

--- a/kbs/src/plugins/implementations/resource/mod.rs
+++ b/kbs/src/plugins/implementations/resource/mod.rs
@@ -43,6 +43,10 @@ impl ClientPlugin for ResourceStorage {
                 self.set_secret_resource(resource_description, body).await?;
                 Ok(vec![])
             }
+            "GET" if path.is_empty() => {
+                let resources = self.list_secret_resources().await?;
+                Ok(serde_json::to_vec(&resources)?)
+            }
             "GET" => {
                 let resource_description = ResourceDesc::try_from(&resource_desc[..])?;
                 let resource = self.get_secret_resource(resource_description).await?;
@@ -62,13 +66,15 @@ impl ClientPlugin for ResourceStorage {
         &self,
         _body: &[u8],
         _query: &HashMap<String, String>,
-        _path: &[&str],
+        path: &[&str],
         method: &Method,
     ) -> Result<bool> {
         if method.as_str() == "POST" || method.as_str() == "DELETE" {
             return Ok(true);
         }
-
+        if method.as_str() == "GET" && path.is_empty() {
+            return Ok(true);
+        }
         Ok(false)
     }
 
@@ -76,10 +82,10 @@ impl ClientPlugin for ResourceStorage {
         &self,
         _body: &[u8],
         _query: &HashMap<String, String>,
-        _path: &[&str],
+        path: &[&str],
         method: &Method,
     ) -> Result<bool> {
-        if method.as_str() == "GET" {
+        if method.as_str() == "GET" && !path.is_empty() {
             return Ok(true);
         }
 


### PR DESCRIPTION
GET /kbs/v0/resource (no repository/type/tag) now lists all stored resource paths instead of failing to parse an empty path as a ResourceDesc.

Adds list_secret_resources to the StorageBackend trait with a default implementation that reports the operation as unsupported, and a concrete implementation for KvStorage backed by the existing KeyValueStorage::list(). The four KMS-based backends (AWS, GCP, Aliyun, Vault) are left unimplemented for now rather than guessed at, since I have no way to verify against real cloud accounts.

Listing requires admin authentication (validate_auth returns true for GET with an empty path), unlike retrieving a single resource, which is authorized separately via attestation - listing exposes which resources exist, which is a different trust boundary than releasing one specific resource's contents to an attested guest. The response is not JWE-encrypted, since it isn't attested-guest secret material.

Manually verified end-to-end against a running kbs + grpc-as: empty list, registering a resource, listing again to see it, and confirming an unauthenticated request to the same endpoint is rejected with 401.