### PR TITLE
policies: make allow all policy more permissive

### DIFF
--- a/kbs/sample_policies/allow_all.rego
+++ b/kbs/sample_policies/allow_all.rego
@@ -1,10 +1,3 @@
 package policy
 
-default allow = false
-
-plugin = data.plugin
-
-allow if {
-	plugin == "resource"
-}
-
+default allow = true


### PR DESCRIPTION
Make the allow-all policy truly allow all requests. Previously this policy allowed all resource requests but did not permit any plugin requests.

It seems more clear to have this truly allow everything.

Arguably, we could introduce a second allow-all policy to differentiate these two cases, but let's keep it simple.

Fixes: #1575