### PR TITLE
feat(verifier): version TEE evidence with an explicit version field

### DIFF
--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
 use tracing::{debug, info};
-use verifier::{InitDataHash, ReportData, TeeEvidenceParsedClaim};
+use verifier::{check_evidence_version, InitDataHash, ReportData, TeeEvidenceParsedClaim};
 
 use crate::ear_token::EarAttestationTokenBroker;
 
@@ -33,7 +33,7 @@ fn serialize_canon_json<T: Serialize>(value: T) -> Result<Vec<u8>> {
     Ok(serde_json_canonicalizer::to_vec(&value)?)
 }
 
-pub type TeeEvidence = serde_json::Value;
+pub use verifier::TeeEvidence;
 pub type TeeClass = String;
 
 /// Tee Claims are the output of the verifier plus some metadata
@@ -243,6 +243,14 @@ impl AttestationService {
                 Some(data) => InitDataHash::Value(data),
                 None => InitDataHash::NotProvided,
             };
+
+            // Generic version guard: reject evidence whose version exceeds what
+            // this verifier supports, before handing it to the TEE-specific code.
+            check_evidence_version(
+                verifier.as_ref(),
+                &verification_request.evidence,
+                &verification_request.tee,
+            )?;
 
             let claims = verifier
                 .evaluate(verification_request.evidence, &report_data, &init_data_hash)

--- a/deps/verifier/src/az_snp_vtpm/mod.rs
+++ b/deps/verifier/src/az_snp_vtpm/mod.rs
@@ -192,6 +192,10 @@ pub(crate) fn verify_user_data(hcl_report: &HclReport, report_data: &[u8]) -> Re
 
 #[async_trait]
 impl Verifier for AzSnpVtpm {
+    /// The max supported evidence version
+    fn max_supported_version(&self) -> u8 {
+        2
+    }
     /// The following verification steps are performed:
     /// 1. TPM Quote has been signed by AK included in the HCL variable data
     /// 2. Attestation report_data matches TPM Quote nonce
@@ -212,7 +216,7 @@ impl Verifier for AzSnpVtpm {
             bail!("unexpected empty report data");
         };
 
-        let evidence = serde_json::from_value::<Evidence>(evidence)
+        let evidence = serde_json::from_value::<Evidence>(evidence.data)
             .context("Failed to deserialize Azure vTPM SEV-SNP evidence")?;
 
         let hcl_report = HclReport::new(evidence.hcl_report().into())?;

--- a/deps/verifier/src/az_tdx_vtpm/mod.rs
+++ b/deps/verifier/src/az_tdx_vtpm/mod.rs
@@ -38,6 +38,11 @@ impl AzTdxVtpm {
 
 #[async_trait]
 impl Verifier for AzTdxVtpm {
+    /// The max supported evidence version
+    fn max_supported_version(&self) -> u8 {
+        2
+    }
+
     /// The following verification steps are performed:
     /// 1. TPM Quote has been signed by AK included in the HCL variable data
     /// 2. Attestation nonce matches TPM Quote nonce
@@ -57,7 +62,7 @@ impl Verifier for AzTdxVtpm {
             bail!("unexpected empty report data");
         };
 
-        let evidence = serde_json::from_value::<Evidence>(evidence)
+        let evidence = serde_json::from_value::<Evidence>(evidence.data)
             .context("Failed to deserialize Azure vTPM TDX evidence")?;
 
         let hcl_report = HclReport::new(evidence.hcl_report().into())?;

--- a/deps/verifier/src/cca/mod.rs
+++ b/deps/verifier/src/cca/mod.rs
@@ -89,7 +89,7 @@ impl Verifier for CCA {
 
         let expected_report_data = regularize_data(expected_report_data, 64, "REPORT_DATA", "CCA");
 
-        let evidence = serde_json::from_value::<CcaEvidence>(evidence)
+        let evidence = serde_json::from_value::<CcaEvidence>(evidence.data)
             .context("Deserialize CCA Evidence failed.")?;
 
         let ear: Ear = match config.cca_verifier {

--- a/deps/verifier/src/csv/mod.rs
+++ b/deps/verifier/src/csv/mod.rs
@@ -99,7 +99,7 @@ impl Verifier for CsvVerifier {
             cert_chain,
             serial_number,
             cc_eventlog,
-        } = serde_json::from_value(evidence).context("Deserialize Quote failed.")?;
+        } = serde_json::from_value(evidence.data).context("Deserialize Quote failed.")?;
 
         let report = AttestationReport::try_from(&report_wrapper)?;
         let chip_id = std::str::from_utf8(&serial_number)?.trim_end_matches('\0');

--- a/deps/verifier/src/hygon_dcu/mod.rs
+++ b/deps/verifier/src/hygon_dcu/mod.rs
@@ -34,7 +34,7 @@ impl Verifier for HygonDcuVerifier {
         expected_report_data: &ReportData,
         expected_init_data_hash: &InitDataHash,
     ) -> Result<Vec<(TeeEvidenceParsedClaim, TeeClass)>> {
-        let tee_evidence = serde_json::from_value::<DcuEvidence>(evidence)?;
+        let tee_evidence = serde_json::from_value::<DcuEvidence>(evidence.data)?;
 
         let expected_report_data = match expected_report_data {
             ReportData::Value(expected_report_data) => {

--- a/deps/verifier/src/lib.rs
+++ b/deps/verifier/src/lib.rs
@@ -214,8 +214,117 @@ pub async fn to_verifier(
 }
 
 pub type TeeEvidenceParsedClaim = serde_json::Value;
-pub type TeeEvidence = serde_json::Value;
 pub type TeeClass = String;
+
+/// Evidence as produced by an attester: an explicit format version alongside
+/// the opaque, TEE-specific payload.
+///
+/// # Wire contract
+///
+/// Evidence is a single JSON object. Its format version is carried by an
+/// optional top-level `version` field; everything else is the TEE-specific
+/// payload:
+///
+/// ```json
+/// { "version": 1, "tpm_quote": { /* ... */ } }   // explicit version 1
+/// { "attestation_report": { /* ... */ } }        // legacy, implicit version 0
+/// ```
+///
+/// The `version` must be a top-level field named exactly `version` and must
+/// be representable as a `u8`. If `version` is not provided, it defaults to `0`
+/// (legacy).
+///
+/// [`data`](Self::data) holds the whole payload verbatim (including the
+/// `version` field, if any). TEE verifiers deserialize [`data`](Self::data) into their
+/// own concrete evidence type.
+///
+/// Which versions are *supported* is a separate concern that belongs to the
+/// [`Verifier`] (see [`Verifier::max_supported_version`]).
+#[derive(Clone, Debug, PartialEq)]
+pub struct TeeEvidence {
+    /// The evidence format version, read from the top-level `version` field at
+    /// parse time. Legacy evidence without an explicit version is `0`.
+    pub version: u8,
+    /// The raw TEE-specific evidence payload, verbatim.
+    pub data: serde_json::Value,
+}
+
+/// Read a top-level `version` value as a `u8`. Returns `Ok(None)` when absent,
+/// `Err` when present but not representable as a `u8`.
+fn parse_version_field(value: &serde_json::Value) -> Result<Option<u8>> {
+    let Some(v) = value.get("version") else {
+        return Ok(None);
+    };
+
+    let Some(version) = v.as_u64().and_then(|n| u8::try_from(n).ok()) else {
+        bail!("invalid evidence version: {v}");
+    };
+
+    Ok(Some(version))
+}
+
+impl From<serde_json::Value> for TeeEvidence {
+    fn from(value: serde_json::Value) -> Self {
+        let version = parse_version_field(&value).unwrap_or(None).unwrap_or(0);
+        TeeEvidence {
+            version,
+            data: value,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TeeEvidence {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Read the payload as an opaque value once, then validate the version
+        // contract up front. This happens before any TEE-specific variant
+        // matching, so a malformed version yields a clear error rather than an
+        // opaque "failed to deserialize" later on.
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let version = parse_version_field(&value)
+            .map_err(<D::Error as serde::de::Error>::custom)?
+            .unwrap_or(0);
+        // Qualified: `use anyhow::*` shadows `Ok` with `anyhow::Ok`.
+        std::result::Result::Ok(TeeEvidence {
+            version,
+            data: value,
+        })
+    }
+}
+
+impl serde::Serialize for TeeEvidence {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // The payload is the wire form: it already carries `version`, so emitting
+        // it verbatim round-trips back to the same evidence.
+        self.data.serialize(serializer)
+    }
+}
+
+/// Reject evidence whose version exceeds what `verifier` supports, with a
+/// uniform, user-facing error message.
+///
+/// This is the generic version guard: it belongs to the dispatch layer, not to
+/// any individual TEE, and should be called before [`Verifier::evaluate`].
+pub fn check_evidence_version(
+    verifier: &dyn Verifier,
+    evidence: &TeeEvidence,
+    tee: &Tee,
+) -> Result<()> {
+    let max = verifier.max_supported_version();
+    let version = evidence.version;
+    if version > max {
+        bail!(
+            "Unsupported {tee:?} evidence version {version}. This verifier \
+             supports evidence versions 0-{max}",
+        );
+    }
+    Ok(())
+}
 
 /// Insert a verified eventlog as a `uefi_event_logs` claim -- a no-op if
 /// `ccel` is `None`.
@@ -265,6 +374,16 @@ impl ToHex for ReportData<'_> {
 
 #[async_trait]
 pub trait Verifier {
+    /// The highest evidence format version this verifier understands.
+    ///
+    /// Support for evidence versions is a property of the verifier, not of the
+    /// evidence itself. The default is `0` (legacy evidence only); a verifier
+    /// opts in to newer formats by overriding this and handling the additional
+    /// versions in [`evaluate`](Verifier::evaluate).
+    fn max_supported_version(&self) -> u8 {
+        0
+    }
+
     /// Verify the hardware signature.
     ///
     ///
@@ -328,5 +447,118 @@ pub fn regularize_data(data: &[u8], len: usize, data_name: &str, arch: &str) -> 
             debug!("The input {data_name} of {arch} is longer than {len} bytes, will be truncated to {len} bytes.");
             data[..len].to_vec()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use serde_json::json;
+
+    #[test]
+    fn evidence_without_version_is_legacy_zero() {
+        let ev: TeeEvidence = serde_json::from_value(json!({ "foo": "bar" })).unwrap();
+        assert_eq!(ev.version, 0);
+        // The payload is preserved verbatim.
+        assert_eq!(ev.data, json!({ "foo": "bar" }));
+    }
+
+    #[test]
+    fn evidence_reads_top_level_version() {
+        let ev: TeeEvidence =
+            serde_json::from_value(json!({ "version": 2, "foo": "bar" })).unwrap();
+        assert_eq!(ev.version, 2);
+        // The version field stays inside the payload handed to the verifier.
+        assert_eq!(ev.data, json!({ "version": 2, "foo": "bar" }));
+    }
+
+    #[test]
+    fn non_u8_version_is_a_deserialization_error() {
+        // A version that is not a u8 (e.g. a date string) must fail clearly
+        // rather than being silently ignored.
+        let err = serde_json::from_value::<TeeEvidence>(json!({ "version": "2026-05-24" }))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("invalid evidence version"), "got: {err}");
+    }
+
+    #[test]
+    fn version_only_applies_to_top_level() {
+        // A nested `version` must not be mistaken for the evidence version.
+        let ev: TeeEvidence = serde_json::from_value(json!({ "inner": { "version": 3 } })).unwrap();
+        assert_eq!(ev.version, 0);
+    }
+
+    #[test]
+    fn from_value_reads_version_leniently() {
+        let ev: TeeEvidence = json!({ "version": 1 }).into();
+        assert_eq!(ev.version, 1);
+        // A non-u8 version via the infallible `From` path reads as legacy.
+        let ev: TeeEvidence = json!({ "version": "nope" }).into();
+        assert_eq!(ev.version, 0);
+    }
+
+    #[test]
+    fn evidence_serializes_back_to_its_payload() {
+        // Serialization emits the payload verbatim, so it round-trips.
+        let data = json!({ "version": 1, "foo": "bar" });
+        let ev = TeeEvidence::from(data.clone());
+        assert_eq!(serde_json::to_value(&ev).unwrap(), data);
+
+        // Legacy (unversioned) evidence round-trips too.
+        let legacy = json!({ "foo": "bar" });
+        let ev = TeeEvidence::from(legacy.clone());
+        assert_eq!(serde_json::to_value(&ev).unwrap(), legacy);
+    }
+
+    // Minimal verifier used to exercise the generic version guard.
+    struct DummyVerifier {
+        max: u8,
+    }
+
+    #[async_trait]
+    impl Verifier for DummyVerifier {
+        fn max_supported_version(&self) -> u8 {
+            self.max
+        }
+
+        async fn evaluate(
+            &self,
+            _evidence: TeeEvidence,
+            _expected_report_data: &ReportData,
+            _expected_init_data_hash: &InitDataHash,
+        ) -> Result<Vec<(TeeEvidenceParsedClaim, TeeClass)>> {
+            Ok(vec![])
+        }
+    }
+
+    #[test]
+    fn check_version_accepts_supported_and_legacy() {
+        let verifier = DummyVerifier { max: 1 };
+        for v in [json!({}), json!({ "version": 1 })] {
+            let ev = TeeEvidence::from(v);
+            assert!(check_evidence_version(&verifier, &ev, &Tee::Snp).is_ok());
+        }
+    }
+
+    #[test]
+    fn check_version_rejects_too_new_with_clear_error() {
+        let verifier = DummyVerifier { max: 1 };
+        let ev = TeeEvidence::from(json!({ "version": 99 }));
+        let err = check_evidence_version(&verifier, &ev, &Tee::Snp)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Unsupported"), "got: {err}");
+        assert!(err.contains("version 99"), "got: {err}");
+        assert!(err.contains("versions 0-1"), "got: {err}");
+    }
+
+    #[test]
+    fn default_verifier_supports_only_legacy() {
+        let verifier = DummyVerifier { max: 0 };
+        assert_eq!(verifier.max_supported_version(), 0);
+        let ev = TeeEvidence::from(json!({ "version": 1 }));
+        assert!(check_evidence_version(&verifier, &ev, &Tee::Snp).is_err());
     }
 }

--- a/deps/verifier/src/nvidia/mod.rs
+++ b/deps/verifier/src/nvidia/mod.rs
@@ -368,7 +368,7 @@ impl Verifier for Nvidia {
         expected_report_data: &ReportData,
         _expected_init_data_hash: &InitDataHash,
     ) -> Result<Vec<(TeeEvidenceParsedClaim, TeeClass)>> {
-        let devices: NvDeviceEvidence = serde_json::from_value(evidence)
+        let devices: NvDeviceEvidence = serde_json::from_value(evidence.data)
             .context("Failed to deserialize the NVIDIA device evidence")?;
         let mut all_devices_claims: Vec<(TeeEvidenceParsedClaim, String)> = Vec::new();
 
@@ -518,7 +518,7 @@ mod tests {
         });
         let verifier = Nvidia::new(verifier_config).await.unwrap();
         let claims = verifier
-            .evaluate(evidence, &report_data, &init_data)
+            .evaluate(evidence.into(), &report_data, &init_data)
             .await
             .unwrap();
 

--- a/deps/verifier/src/nvidia_dpu/mod.rs
+++ b/deps/verifier/src/nvidia_dpu/mod.rs
@@ -104,7 +104,7 @@ impl crate::Verifier for NvidiaDpuVerifier {
 
         // (1) Parse the DPU evidence from the attester JSON.
         let dpu_evidence: DpuEvidence =
-            serde_json::from_value(evidence).context("Failed to parse NVIDIA DPU evidence")?;
+            serde_json::from_value(evidence.data).context("Failed to parse NVIDIA DPU evidence")?;
 
         // (2) Assert exactly one device and get it.
         anyhow::ensure!(

--- a/deps/verifier/src/sample/mod.rs
+++ b/deps/verifier/src/sample/mod.rs
@@ -26,7 +26,7 @@ impl Verifier for Sample {
         expected_report_data: &ReportData,
         expected_init_data_hash: &InitDataHash,
     ) -> Result<Vec<(TeeEvidenceParsedClaim, TeeClass)>> {
-        let tee_evidence = serde_json::from_value::<SampleTeeEvidence>(evidence)
+        let tee_evidence = serde_json::from_value::<SampleTeeEvidence>(evidence.data)
             .context("Deserialize Quote failed.")?;
 
         verify_tee_evidence(expected_report_data, expected_init_data_hash, &tee_evidence)

--- a/deps/verifier/src/sample_device/mod.rs
+++ b/deps/verifier/src/sample_device/mod.rs
@@ -31,7 +31,7 @@ impl Verifier for SampleDeviceVerifier {
         expected_report_data: &ReportData,
         expected_init_data_hash: &InitDataHash,
     ) -> Result<Vec<(TeeEvidenceParsedClaim, TeeClass)>> {
-        let tee_evidence = serde_json::from_value::<SampleDeviceEvidence>(evidence)
+        let tee_evidence = serde_json::from_value::<SampleDeviceEvidence>(evidence.data)
             .context("Deserialize Quote failed.")?;
 
         verify_tee_evidence(expected_report_data, expected_init_data_hash, &tee_evidence)

--- a/deps/verifier/src/se/ibmse.rs
+++ b/deps/verifier/src/se/ibmse.rs
@@ -220,7 +220,7 @@ impl SeVerifierImpl {
 
         // evidence is serialized SeAttestationResponse String bytes
         let se_response: SeAttestationResponse =
-            serde_json::from_value(evidence).map_err(SeError::DeserializeEvidence)?;
+            serde_json::from_value(evidence.data).map_err(SeError::DeserializeEvidence)?;
 
         let meas_key = self
             .decrypt(&se_response.encr_measurement_key)
@@ -473,7 +473,7 @@ mod tests {
         let evidence = serde_json::to_value(&response).expect("Failed to serialize");
         let expected_report_data = ReportData::Value(&report_data);
 
-        let result = verifier.evaluate(evidence, &expected_report_data);
+        let result = verifier.evaluate(evidence.into(), &expected_report_data);
 
         // Should fail at measurement verification (we don't have valid measurement),
         // but NOT at user_data validation
@@ -521,7 +521,7 @@ mod tests {
         let evidence = serde_json::to_value(&response).expect("Failed to serialize");
         let expected_report_data = ReportData::Value(&report_data);
 
-        let result = verifier.evaluate(evidence, &expected_report_data);
+        let result = verifier.evaluate(evidence.into(), &expected_report_data);
 
         assert!(result.is_err(), "Should fail with mismatched user_data");
         let err = result.unwrap_err();
@@ -566,7 +566,7 @@ mod tests {
         let evidence = serde_json::to_value(&response).expect("Failed to serialize");
         let expected_report_data = ReportData::NotProvided;
 
-        let result = verifier.evaluate(evidence, &expected_report_data);
+        let result = verifier.evaluate(evidence.into(), &expected_report_data);
 
         // Should fail at measurement verification, but NOT at user_data validation
         assert!(result.is_err(), "Should fail at measurement verification");

--- a/deps/verifier/src/sgx/mod.rs
+++ b/deps/verifier/src/sgx/mod.rs
@@ -50,8 +50,8 @@ impl Verifier for SgxVerifier {
         expected_report_data: &ReportData,
         expected_init_data_hash: &InitDataHash,
     ) -> Result<Vec<(TeeEvidenceParsedClaim, TeeClass)>> {
-        let tee_evidence =
-            serde_json::from_value::<SgxEvidence>(evidence).context("Deserialize Quote failed.")?;
+        let tee_evidence = serde_json::from_value::<SgxEvidence>(evidence.data)
+            .context("Deserialize Quote failed.")?;
 
         debug!("evidence: {}", serde_json::to_string(&tee_evidence)?);
 

--- a/deps/verifier/src/snp/mod.rs
+++ b/deps/verifier/src/snp/mod.rs
@@ -382,7 +382,7 @@ impl Verifier for Snp {
         let SnpEvidence {
             attestation_report: report,
             cert_chain,
-        } = serde_json::from_value(evidence).context("Deserialize SNP Evidence failed")?;
+        } = serde_json::from_value(evidence.data).context("Deserialize SNP Evidence failed")?;
 
         // See Trustee Issue#589 https://github.com/confidential-containers/trustee/issues/589
         // Version 3 minimum is needed to tell processor type in report

--- a/deps/verifier/src/tdx/mod.rs
+++ b/deps/verifier/src/tdx/mod.rs
@@ -51,7 +51,7 @@ impl Verifier for Tdx {
         expected_report_data: &ReportData,
         expected_init_data_hash: &InitDataHash,
     ) -> Result<Vec<(TeeEvidenceParsedClaim, TeeClass)>> {
-        let tdx_evidence = serde_json::from_value::<TdxEvidence>(evidence)
+        let tdx_evidence = serde_json::from_value::<TdxEvidence>(evidence.data)
             .context("Deserialize TDX Evidence failed.")?;
 
         let pcs = self.config.pcs()?;

--- a/deps/verifier/src/tpm/mod.rs
+++ b/deps/verifier/src/tpm/mod.rs
@@ -204,7 +204,7 @@ impl Verifier for TpmVerifier {
         expected_report_data: &ReportData,
         expected_init_data_hash: &InitDataHash,
     ) -> Result<Vec<(TeeEvidenceParsedClaim, TeeClass)>> {
-        let guest_ev = serde_json::from_value::<Evidence>(evidence)
+        let guest_ev = serde_json::from_value::<Evidence>(evidence.data)
             .context("Failed to deserialize TPM Evidence")?;
 
         let quote = guest_ev

--- a/kbs/src/attestation/coco/builtin.rs
+++ b/kbs/src/attestation/coco/builtin.rs
@@ -87,7 +87,7 @@ impl Attest for BuiltInCoCoAs {
             };
 
             let mut request = VerificationRequest {
-                evidence: evidence.tee_evidence,
+                evidence: evidence.tee_evidence.into(),
                 tee: evidence.tee,
                 runtime_data: Some(RuntimeData::Structured(evidence.runtime_data)),
                 runtime_data_hash_algorithm,


### PR DESCRIPTION
## What

Give TEE evidence an explicit format version. `TeeEvidence` changes from a
bare `serde_json::Value` to:

```rust
pub struct TeeEvidence {
    pub version: u8,             // top-level `version` field, 0 = legacy
    pub data: serde_json::Value, // TEE-specific payload, verbatim
}
```

Why

Today a changed evidence format just fails to deserialize with a cryptic
error. An explicit version lets the verifier reject evidence it's too old to
understand with a clear message, and gives attesters/verifiers a stable
contract to evolve against.

How

- Version is read from an optional top-level version field: absent → 0
  (legacy), present but not a u8 → hard error. The payload is passed to the
  TEE verifier untouched.
- Version support lives on the verifier: Verifier::max_supported_version()
  (default 0) plus a generic check_evidence_version() guard run before
  evaluate(). az_snp_vtpm / az_tdx_vtpm opt in to version 2.

Fully backward compatible — existing unversioned evidence is treated as
version 0; no attester changes required.

Refs: #1412
