### PR TITLE
rvps: add DeleteReferenceValue RPC and rvps-tool delete command

### DIFF
--- a/attestation-service/src/bin/grpc/mod.rs
+++ b/attestation-service/src/bin/grpc/mod.rs
@@ -35,8 +35,9 @@ use crate::rvps_api::{
     reference_value_provider_service_server::{
         ReferenceValueProviderService, ReferenceValueProviderServiceServer,
     },
-    ReferenceValueListRequest, ReferenceValueListResponse, ReferenceValueQueryRequest,
-    ReferenceValueQueryResponse, ReferenceValueRegisterRequest, ReferenceValueRegisterResponse,
+    ReferenceValueDeleteRequest, ReferenceValueDeleteResponse, ReferenceValueListRequest,
+    ReferenceValueListResponse, ReferenceValueQueryRequest, ReferenceValueQueryResponse,
+    ReferenceValueRegisterRequest, ReferenceValueRegisterResponse,
 };
 
 fn to_kbs_tee(tee: &str) -> anyhow::Result<Tee> {
@@ -350,6 +351,25 @@ impl ReferenceValueProviderService for Arc<RwLock<AttestationServer>> {
         Ok(Response::new(ReferenceValueListResponse {
             reference_value_ids,
         }))
+    }
+
+    #[instrument(skip_all, fields(request_id = tracing::field::Empty))]
+    async fn delete_reference_value(
+        &self,
+        request: Request<ReferenceValueDeleteRequest>,
+    ) -> Result<Response<ReferenceValueDeleteResponse>, Status> {
+        let request_id = Uuid::new_v4().to_string();
+        Span::current().record("request_id", tracing::field::display(&request_id));
+        info!("DeleteReferenceValue API called.");
+        let deleted = self
+            .read()
+            .await
+            .attestation_service
+            .delete_reference_value(&request.into_inner().reference_value_id)
+            .await
+            .map_err(|e| Status::aborted(format!("Delete reference value: {e}")))?;
+        info!("DeleteReferenceValue succeeded.");
+        Ok(Response::new(ReferenceValueDeleteResponse { deleted }))
     }
 }
 

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -309,6 +309,16 @@ impl AttestationService {
             .context("list reference values")
     }
 
+    /// Delete a reference value by id
+    pub async fn delete_reference_value(&self, reference_value_id: &str) -> Result<bool> {
+        self.rvps
+            .lock()
+            .await
+            .delete_reference_value(reference_value_id)
+            .await
+            .context("delete reference value")
+    }
+
     pub async fn generate_supplemental_challenge(
         &self,
         tee: Tee,

--- a/attestation-service/src/rvps/builtin.rs
+++ b/attestation-service/src/rvps/builtin.rs
@@ -48,4 +48,9 @@ impl RvpsApi for BuiltinRvps {
         let ids = self.rvps.list_reference_values().await?;
         Ok(ids)
     }
+
+    async fn delete_reference_value(&self, reference_value_id: &str) -> Result<bool> {
+        let deleted = self.rvps.delete_reference_value(reference_value_id).await?;
+        Ok(deleted)
+    }
 }

--- a/attestation-service/src/rvps/grpc.rs
+++ b/attestation-service/src/rvps/grpc.rs
@@ -8,7 +8,8 @@ use tracing::{debug, info};
 
 use self::rvps_api::{
     reference_value_provider_service_client::ReferenceValueProviderServiceClient,
-    ReferenceValueListRequest, ReferenceValueQueryRequest, ReferenceValueRegisterRequest,
+    ReferenceValueDeleteRequest, ReferenceValueListRequest, ReferenceValueQueryRequest,
+    ReferenceValueRegisterRequest,
 };
 
 use super::{Result, RvpsApi};
@@ -125,6 +126,19 @@ impl RvpsApi for Agent {
             .into_inner()
             .reference_value_ids;
         Ok(ids)
+    }
+
+    async fn delete_reference_value(&self, reference_value_id: &str) -> Result<bool> {
+        let req = tonic::Request::new(ReferenceValueDeleteRequest {
+            reference_value_id: reference_value_id.to_string(),
+        });
+        let mut client = self.pool.get().await?;
+        let deleted = client
+            .delete_reference_value(req)
+            .await?
+            .into_inner()
+            .deleted;
+        Ok(deleted)
     }
 }
 

--- a/attestation-service/src/rvps/mod.rs
+++ b/attestation-service/src/rvps/mod.rs
@@ -56,6 +56,10 @@ pub trait RvpsApi {
 
     /// List all registered reference value IDs.
     async fn list_reference_values(&self) -> Result<Vec<String>>;
+
+    /// Delete a reference value by id. Returns true if it existed and was deleted,
+    /// false if there was nothing to delete.
+    async fn delete_reference_value(&self, reference_value_id: &str) -> Result<bool>;
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq)]

--- a/protos/reference.proto
+++ b/protos/reference.proto
@@ -22,8 +22,17 @@ message ReferenceValueListResponse {
     repeated string reference_value_ids = 1;
 }
 
+message ReferenceValueDeleteRequest {
+    string reference_value_id = 1;
+}
+
+message ReferenceValueDeleteResponse {
+    bool deleted = 1;
+}
+
 service ReferenceValueProviderService {
     rpc QueryReferenceValue(ReferenceValueQueryRequest) returns (ReferenceValueQueryResponse) {};
     rpc RegisterReferenceValue(ReferenceValueRegisterRequest) returns (ReferenceValueRegisterResponse) {};
     rpc ListReferenceValues(ReferenceValueListRequest) returns (ReferenceValueListResponse) {};
+    rpc DeleteReferenceValue(ReferenceValueDeleteRequest) returns (ReferenceValueDeleteResponse) {};
 }

--- a/rvps/src/bin/rvps-tool.rs
+++ b/rvps/src/bin/rvps-tool.rs
@@ -41,6 +41,16 @@ async fn list(addr: String) -> Result<()> {
     Ok(())
 }
 
+async fn delete(addr: String, reference_value_id: String) -> Result<()> {
+    let deleted = client::delete(addr, reference_value_id.clone()).await?;
+    if deleted {
+        info!("Deleted reference value '{reference_value_id}'.");
+    } else {
+        info!("No reference value found for id '{reference_value_id}'.");
+    }
+    Ok(())
+}
+
 /// RVPS command-line arguments.
 #[derive(Parser)]
 #[command(name = "rvps-tool")]
@@ -55,6 +65,9 @@ enum Cli {
 
     /// List of all registered reference values
     List(ListArgs),
+
+    /// Delete a reference value
+    Delete(DeleteArgs),
 }
 
 #[derive(Args)]
@@ -89,6 +102,17 @@ struct ListArgs {
     addr: String,
 }
 
+#[derive(Args)]
+#[command(author, version, about, long_about = None)]
+struct DeleteArgs {
+    /// The address of target RVPS
+    #[arg(short, long, default_value = DEFAULT_ADDR)]
+    addr: String,
+    /// The id of the reference value to delete
+    #[arg(short, long)]
+    reference_value_id: String,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let env_filter = match std::env::var_os("RUST_LOG") {
@@ -112,5 +136,6 @@ async fn main() -> Result<()> {
         Cli::Register(para) => register(&para.addr, &para.path).await,
         Cli::Query(para) => query(para.addr, para.reference_value_id).await,
         Cli::List(para) => list(para.addr).await,
+        Cli::Delete(para) => delete(para.addr, para.reference_value_id).await,
     }
 }

--- a/rvps/src/client/mod.rs
+++ b/rvps/src/client/mod.rs
@@ -8,7 +8,8 @@ use anyhow::*;
 
 use crate::rvps_api::reference::{
     reference_value_provider_service_client::ReferenceValueProviderServiceClient,
-    ReferenceValueListRequest, ReferenceValueQueryRequest, ReferenceValueRegisterRequest,
+    ReferenceValueDeleteRequest, ReferenceValueListRequest, ReferenceValueQueryRequest,
+    ReferenceValueRegisterRequest,
 };
 
 pub async fn register(address: String, message: String) -> Result<()> {
@@ -42,4 +43,15 @@ pub async fn list(address: String) -> Result<Vec<String>> {
         .into_inner()
         .reference_value_ids;
     Ok(ids)
+}
+
+pub async fn delete(address: String, reference_value_id: String) -> Result<bool> {
+    let mut client = ReferenceValueProviderServiceClient::connect(address).await?;
+    let req = tonic::Request::new(ReferenceValueDeleteRequest { reference_value_id });
+    let deleted = client
+        .delete_reference_value(req)
+        .await?
+        .into_inner()
+        .deleted;
+    Ok(deleted)
 }

--- a/rvps/src/lib.rs
+++ b/rvps/src/lib.rs
@@ -124,4 +124,9 @@ impl Rvps {
     pub async fn list_reference_values(&self) -> Result<Vec<String>> {
         Ok(self.storage.list().await?)
     }
+
+    pub async fn delete_reference_value(&self, reference_value_id: &str) -> Result<bool> {
+        let deleted = self.storage.delete(reference_value_id).await?;
+        Ok(deleted.is_some())
+    }
 }

--- a/rvps/src/rvps_api/reference.rs
+++ b/rvps/src/rvps_api/reference.rs
@@ -23,6 +23,16 @@ pub struct ReferenceValueListResponse {
     #[prost(string, repeated, tag = "1")]
     pub reference_value_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ReferenceValueDeleteRequest {
+    #[prost(string, tag = "1")]
+    pub reference_value_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ReferenceValueDeleteResponse {
+    #[prost(bool, tag = "1")]
+    pub deleted: bool,
+}
 /// Generated client implementations.
 pub mod reference_value_provider_service_client {
     #![allow(
@@ -172,6 +182,25 @@ pub mod reference_value_provider_service_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn delete_reference_value(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ReferenceValueDeleteRequest>,
+        ) -> std::result::Result<tonic::Response<super::ReferenceValueDeleteResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/reference.ReferenceValueProviderService/DeleteReferenceValue",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "reference.ReferenceValueProviderService",
+                "DeleteReferenceValue",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -204,6 +233,10 @@ pub mod reference_value_provider_service_server {
             &self,
             request: tonic::Request<super::ReferenceValueListRequest>,
         ) -> std::result::Result<tonic::Response<super::ReferenceValueListResponse>, tonic::Status>;
+        async fn delete_reference_value(
+            &self,
+            request: tonic::Request<super::ReferenceValueDeleteRequest>,
+        ) -> std::result::Result<tonic::Response<super::ReferenceValueDeleteResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ReferenceValueProviderServiceServer<T> {
@@ -398,6 +431,51 @@ pub mod reference_value_provider_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = ListReferenceValuesSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/reference.ReferenceValueProviderService/DeleteReferenceValue" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteReferenceValueSvc<T: ReferenceValueProviderService>(pub Arc<T>);
+                    impl<T: ReferenceValueProviderService>
+                        tonic::server::UnaryService<super::ReferenceValueDeleteRequest>
+                        for DeleteReferenceValueSvc<T>
+                    {
+                        type Response = super::ReferenceValueDeleteResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ReferenceValueDeleteRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ReferenceValueProviderService>::delete_reference_value(
+                                    &inner, request,
+                                )
+                                .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = DeleteReferenceValueSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/rvps/src/server/mod.rs
+++ b/rvps/src/server/mod.rs
@@ -13,8 +13,9 @@ use crate::rvps_api::reference::reference_value_provider_service_server::{
     ReferenceValueProviderService, ReferenceValueProviderServiceServer,
 };
 use crate::rvps_api::reference::{
-    ReferenceValueListRequest, ReferenceValueListResponse, ReferenceValueQueryRequest,
-    ReferenceValueQueryResponse, ReferenceValueRegisterRequest, ReferenceValueRegisterResponse,
+    ReferenceValueDeleteRequest, ReferenceValueDeleteResponse, ReferenceValueListRequest,
+    ReferenceValueListResponse, ReferenceValueQueryRequest, ReferenceValueQueryResponse,
+    ReferenceValueRegisterRequest, ReferenceValueRegisterResponse,
 };
 
 pub struct RvpsServer {
@@ -89,6 +90,20 @@ impl ReferenceValueProviderService for RvpsServer {
         Ok(Response::new(ReferenceValueListResponse {
             reference_value_ids,
         }))
+    }
+
+    async fn delete_reference_value(
+        &self,
+        request: Request<ReferenceValueDeleteRequest>,
+    ) -> Result<Response<ReferenceValueDeleteResponse>, Status> {
+        let deleted = self
+            .rvps
+            .write()
+            .await
+            .delete_reference_value(&request.into_inner().reference_value_id)
+            .await
+            .map_err(|e| Status::aborted(format!("Delete reference value: {e}")))?;
+        Ok(Response::new(ReferenceValueDeleteResponse { deleted }))
     }
 }
 


### PR DESCRIPTION
RVPS supported registering and querying reference values, and (as of a previous PR) listing them, but had no way to remove one. A stale or mistakenly registered reference value could only be overwritten via register, never actually deleted.

Adds a DeleteReferenceValue gRPC RPC, backed by the existing KeyValueStorage::delete() the storage backend already provides (same mechanism KBS's resource plugin already uses for delete), and wires it through to a new 'rvps-tool delete' subcommand. Returns whether something was actually deleted, distinguishing 'deleted' from 'nothing to delete' rather than treating both as success uniformly.

attestation-service also implements ReferenceValueProviderService for its built-in and remote-gRPC RVPS modes; updated RvpsApi and both implementors (builtin, grpc) so this doesn't break AS's build, having learned that lesson from the ListReferenceValues PR.

Manually verified end-to-end: registered a reference value, listed it, deleted it, confirmed it no longer appears in the list, and confirmed deleting a nonexistent key reports 'not found' rather than erroring.