### PR TITLE
kbs: rename RCAR policy-selector to attestation-policy-selector

### DIFF
--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -155,7 +155,7 @@ Concrete attestation service can be set via `type` field. Supported attestation 
 Due to different `type` field, properties are different.
 
 `timeout` and `policy_id_map` apply to every type. The latter is a table mapping
-each policy-selector a client may select to one or more policy IDs:
+each attestation-policy-selector a client may select to one or more policy IDs:
 
 ```toml
 [attestation_service.policy_id_map]
@@ -173,7 +173,7 @@ When `type` is set to `coco_as_builtin`, the following properties can be set.
 | Property                   | Type                        | Description                                              | Default                                                                                                       |
 |----------------------------|-----------------------------|----------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
 | `timeout`                  | Integer                     | The maximum time (in minutes) of the attestation session | 5                                                                                                             |
-| `policy_id_map`            | Map of String array         | AS policies selectable by a client, keyed by policy-selector. See [RCAR `Request`][ps]| `{}`                                                          |
+| `policy_id_map`            | Map of String array         | AS policies selectable by a client, keyed by attestation-policy-selector. See [RCAR `Request`][ps]| `{}`                                                          |
 | `rvps_config`              | [RVPSConfiguration][2]      | RVPS configuration                                       | See [RVPSConfiguration][2]                                                                                    |
 | `attestation_token_broker` | [AttestationTokenBroker][1] | Attestation result token configuration.                  | See [AttestationTokenBroker][1]                                                                               |
 | `verifier_config`          | Object                      | Optional verifier specific configuration (for example TPM)| See [Verifier Configuration][vcfg]                                                                            |
@@ -246,7 +246,7 @@ The following properties can be set.
 | Property    | Type    | Description                                                                                                                   | Default                  |
 |-------------|---------|-------------------------------------------------------------------------------------------------------------------------------|--------------------------|
 | `timeout`   | Integer | The maximum time (in minutes) between RCAR handshake's `auth` and `attest` requests                                           | 5                        |
-| `policy_id_map` | Map of String array | AS policies selectable by a client, keyed by policy-selector. See [RCAR `Request`][ps]                    | `{}`                     |
+| `policy_id_map` | Map of String array | AS policies selectable by a client, keyed by attestation-policy-selector. See [RCAR `Request`][ps]                    | `{}`                     |
 | `as_addr`   | String  | The URL of the remote CoCoAS                                                                                                  | `http://127.0.0.1:50004` |
 | `pool_size` | Integer | The connections between KBS and CoCoAS are maintained in a conenction pool. This property determines the max size of the pool | `100`                    |
 
@@ -264,7 +264,7 @@ The following properties can be set.
 | `api_key`                | String       | Intel Trust Authority API key.                                                                         | Yes      | -       |
 | `certs_file`             | String       | URL to an Intel Trust Authority portal or path to JWKS file used for token verification.               | Yes      | -       |
 | `policy_ids`             | String array | Quoted and comma-separated list of policy IDs defined in ITA portal.                                   | No       | `[]`    |
-| `policy_id_map`          | Map of String array | Policies selectable by a client, keyed by policy-selector. A selected policy-selector replaces `policy_ids`. See [RCAR `Request`][ps] | No       | `{}`    |
+| `policy_id_map`          | Map of String array | Policies selectable by a client, keyed by attestation-policy-selector. A selected attestation-policy-selector replaces `policy_ids`. See [RCAR `Request`][ps] | No       | `{}`    |
 | `allow_unmatched_policy` | Boolean      | Whether policy matching is required. If no `policy_ids` are specified, policy matching is not checked. | No       | false   |
 
 Detailed [documentation](https://docs.trustauthority.intel.com).

--- a/kbs/docs/kbs_attestation_protocol.md
+++ b/kbs/docs/kbs_attestation_protocol.md
@@ -117,26 +117,26 @@ transfer some specific information. For example, some attestations follow the
 Diffie–Hellman key exchange protocol to first build a secure channel and
 transfer secret messages (Such as AMD SEV(-ES) pre-attestation).
 
-`extra-params` may also carry a `policy-selector`, which selects the Attestation
+`extra-params` may also carry a `attestation-policy-selector`, which selects the Attestation
 Service policies that evaluate this session's evidence:
 
 ```json
-"extra-params": { "policy-selector": "alice" }
+"extra-params": { "attestation-policy-selector": "alice" }
 ```
 
-KBS maps each `policy-selector` to one or more attestation policies, so the
+KBS maps each `attestation-policy-selector` to one or more attestation policies, so the
 accepted values are specific to a deployment and must be known to the KBC in
-advance. An unmapped `policy-selector` is rejected, and omitting the field
+advance. An unmapped `attestation-policy-selector` is rejected, and omitting the field
 selects a default policy.
 Note that not all backend attestation services support multiple policies, e.g.
 CoCo AS now only support one policy, while ITA supports multiple.
 
-Selecting a `policy-selector` does not by itself entitle the KBC to anything,
+Selecting a `attestation-policy-selector` does not by itself entitle the KBC to anything,
 since KBS still decides what each appraisal may release. It does change what the
 resulting token means, though, so a relying party should not treat every token
 alike. The [Attestation Results Token](#attestation-results-token) names the
-policy that was actually applied, which is the policy the `policy-selector`
-resolved to rather than the `policy-selector` itself, so a resource policy can
+policy that was actually applied, which is the policy the `attestation-policy-selector`
+resolved to rather than the `attestation-policy-selector` itself, so a resource policy can
 require a particular appraisal before releasing a resource.
 
 ## `Challenge`

--- a/kbs/src/attestation/backend.rs
+++ b/kbs/src/attestation/backend.rs
@@ -26,7 +26,7 @@ use crate::prometheus::{
 use super::{
     config::{AttestationConfig, AttestationServiceConfig},
     session::SessionStatus,
-    Error, Result, POLICY_SELECTOR_JSON_KEY,
+    Error, Result, ATTESTATION_POLICY_SELECTOR_JSON_KEY,
 };
 
 const KBS_SESSION_STORAGE_NAMESPACE: &str = "kbs_protocol_session";
@@ -94,7 +94,7 @@ pub trait Attest: Send + Sync {
     /// Verify Attestation Evidence
     /// Return Attestation Results Token
     ///
-    /// `policy_ids` are the policies resolved from the policy-selector
+    /// `policy_ids` are the policies resolved from the attestation-policy-selector
     /// selected by the client, or `None` to apply the default of this
     /// Attestation Service.
     async fn verify(
@@ -130,30 +130,30 @@ pub trait Attest: Send + Sync {
     }
 }
 
-/// Resolve the policy-selector that a client optionally selected in an RCAR
+/// Resolve the attestation-policy-selector that a client optionally selected in an RCAR
 /// `Request` into the Attestation Service policies to evaluate its evidence
 /// with.
 ///
-/// Selecting no policy-selector leaves the Attestation Service default in
-/// place. An unknown policy-selector is rejected instead of silently falling
+/// Selecting no attestation-policy-selector leaves the Attestation Service default in
+/// place. An unknown attestation-policy-selector is rejected instead of silently falling
 /// back, so a client can only reach policies that an administrator declared.
 fn resolve_policy_ids(
     policy_id_map: &HashMap<String, Vec<String>>,
     extra_params: &serde_json::Value,
 ) -> anyhow::Result<Option<Vec<String>>> {
-    let Some(policy_selector) = extra_params.get(POLICY_SELECTOR_JSON_KEY) else {
+    let Some(policy_selector) = extra_params.get(ATTESTATION_POLICY_SELECTOR_JSON_KEY) else {
         return Ok(None);
     };
 
     let policy_selector = policy_selector
         .as_str()
-        .context("policy-selector is not a string")?;
+        .context("attestation-policy-selector is not a string")?;
 
     policy_id_map
         .get(policy_selector)
         .cloned()
         .map(Some)
-        .context("policy-selector is not configured")
+        .context("attestation-policy-selector is not configured")
 }
 
 /// Attestation Service
@@ -168,7 +168,7 @@ pub struct AttestationService {
     /// Maximum session expiration time.
     timeout: i64,
 
-    /// Policies a client is allowed to select, keyed by policy-selector
+    /// Policies a client is allowed to select, keyed by attestation-policy-selector
     policy_id_map: HashMap<String, Vec<String>>,
 }
 
@@ -185,13 +185,13 @@ impl AttestationService {
         storage_backend_config: &StorageBackendConfig,
         storage_provider: Arc<dyn StorageProvider>,
     ) -> Result<Self> {
-        // A policy-selector without any policy would leave the evidence
+        // A attestation-policy-selector without any policy would leave the evidence
         // unevaluated, which some Attestation Services accept silently.
         for (policy_selector, policy_ids) in &config.policy_id_map {
             if policy_ids.is_empty() {
                 return Err(Error::AttestationServiceInitialization {
                     source: anyhow!(
-                        "no attestation policy is mapped to policy-selector {policy_selector}"
+                        "no attestation policy is mapped to attestation-policy-selector {policy_selector}"
                     ),
                 });
             }
@@ -559,18 +559,18 @@ mod tests {
     }
 
     #[rstest::rstest]
-    // No policy-selector selected: the Attestation Service default applies.
+    // No attestation-policy-selector selected: the Attestation Service default applies.
     #[case(json!({}), Some(None))]
     #[case(json!(""), Some(None))]
     #[case(json!({"selected-hash-algorithm": "sha384"}), Some(None))]
-    // A declared policy-selector resolves to every policy it is mapped to.
-    #[case(json!({"policy-selector": "alice"}), Some(Some(vec!["alice-strict"])))]
-    #[case(json!({"policy-selector": "bob"}), Some(Some(vec!["bob-cpu", "bob-gpu"])))]
+    // A declared attestation-policy-selector resolves to every policy it is mapped to.
+    #[case(json!({"attestation-policy-selector": "alice"}), Some(Some(vec!["alice-strict"])))]
+    #[case(json!({"attestation-policy-selector": "bob"}), Some(Some(vec!["bob-cpu", "bob-gpu"])))]
     // Anything else is rejected rather than downgraded to the default.
-    #[case(json!({"policy-selector": "alice-strict"}), None)]
-    #[case(json!({"policy-selector": "../escape"}), None)]
-    #[case(json!({"policy-selector": ""}), None)]
-    #[case(json!({"policy-selector": 1}), None)]
+    #[case(json!({"attestation-policy-selector": "alice-strict"}), None)]
+    #[case(json!({"attestation-policy-selector": "../escape"}), None)]
+    #[case(json!({"attestation-policy-selector": ""}), None)]
+    #[case(json!({"attestation-policy-selector": 1}), None)]
     fn test_resolve_policy_ids(
         #[case] extra_params: serde_json::Value,
         #[case] expected: Option<Option<Vec<&str>>>,
@@ -595,7 +595,11 @@ mod tests {
         assert!(resolve_policy_ids(&policy_id_map, &json!({}))
             .unwrap()
             .is_none());
-        assert!(resolve_policy_ids(&policy_id_map, &json!({"policy-selector": "alice"})).is_err());
+        assert!(resolve_policy_ids(
+            &policy_id_map,
+            &json!({"attestation-policy-selector": "alice"})
+        )
+        .is_err());
     }
 
     #[tokio::test]

--- a/kbs/src/attestation/coco/mod.rs
+++ b/kbs/src/attestation/coco/mod.rs
@@ -5,5 +5,5 @@ pub mod grpc;
 pub mod builtin;
 
 /// Attestation Service policy applied when a client does not select a
-/// policy-selector.
+/// attestation-policy-selector.
 pub const DEFAULT_POLICY_ID: &str = "default";

--- a/kbs/src/attestation/config.rs
+++ b/kbs/src/attestation/config.rs
@@ -16,12 +16,12 @@ pub struct AttestationConfig {
     #[serde(default = "default_timeout")]
     pub timeout: i64,
 
-    /// Maps a policy-selector, which a client may select in the RCAR
+    /// Maps an attestation-policy-selector, which a client may select in the RCAR
     /// `Request`, to the Attestation Service policies that evaluate its
     /// evidence.
     ///
     /// Empty by default, which leaves clients unable to influence policy
-    /// selection. Only policy-selectors declared here are reachable.
+    /// selection. Only attestation-policy-selectors declared here are reachable.
     #[serde(default)]
     pub policy_id_map: HashMap<String, Vec<String>>,
 }

--- a/kbs/src/attestation/intel_trust_authority/mod.rs
+++ b/kbs/src/attestation/intel_trust_authority/mod.rs
@@ -298,7 +298,7 @@ impl Attest for IntelTrustAuthority {
         policy_ids: Option<&[String]>,
     ) -> anyhow::Result<String> {
         // Fall back to the configured policies when the client selected no
-        // policy-selector.
+        // attestation-policy-selector.
         let policy_ids = policy_ids
             .map(<[String]>::to_vec)
             .unwrap_or_else(|| self.config.policy_ids.clone());

--- a/kbs/src/attestation/mod.rs
+++ b/kbs/src/attestation/mod.rs
@@ -27,7 +27,7 @@ pub const SELECTED_HASH_ALGORITHM_JSON_KEY: &str = "selected-hash-algorithm";
 
 /// JSON key with which a client selects attestation policies in the extra
 /// parameters of an RCAR `Request`
-pub const POLICY_SELECTOR_JSON_KEY: &str = "policy-selector";
+pub const ATTESTATION_POLICY_SELECTOR_JSON_KEY: &str = "attestation-policy-selector";
 
 /// Generate extra parameters for TEE hash algorithm negotiation.
 ///


### PR DESCRIPTION
Align the extra-params field name with guest-components. see https://github.com/confidential-containers/guest-components/pull/1604